### PR TITLE
Set defaultOpen to false

### DIFF
--- a/src/components/ChangeHistory.astro
+++ b/src/components/ChangeHistory.astro
@@ -25,7 +25,7 @@ if (previous.length <= 1) {
       <div>
         {
           previous.map((v, idx) => (
-            <ChangeList version={v} gvk={gvk} defaultOpen={idx === 0} />
+            <ChangeList version={v} gvk={gvk} defaultOpen={false} />
           ))
         }
       </div>


### PR DESCRIPTION
Making a change to set defaultOpen to false so all of the changelogs are collapsed by default

This will resolve https://github.com/aptakube/kubespec.dev/issues/5