### PR TITLE
Fix loading wrong example

### DIFF
--- a/src/lib/kube/metadata.ts
+++ b/src/lib/kube/metadata.ts
@@ -29,7 +29,7 @@ export async function readMetadata(
   const apiVersion = gvk.group ? `${gvk.group}/${gvk.version}` : gvk.version;
   const baseDir = `./content/metadata/${project.slug}/${apiVersion}/${gvk.kind.toLowerCase()}`;
   const examples = Object.entries(All_EXAMPLES)
-    .filter(([path]) => path.includes(baseDir))
+    .filter(([path]) => path.includes(baseDir + '/'))
     .map(([, value]) => value);
 
   const path = `${baseDir}/${gvk.kind.toLowerCase()}.json`;


### PR DESCRIPTION
Happened when a particular kind is a substring of another, such as PersistentVolume and PersistentVolumeClaim or Role and RoleBinding.

Ensured the matched string should end with a '/' to avoid this. Fixes #16 

@goenning Let me know if you prefer we match more strictly, but this seemed in the spirit of the existing code :).

Also, is there a test that we can have that could catch things like this?

