### PR TITLE
Add Karpenter CRDs

### DIFF
--- a/content/metadata/karpenter/karpenter.k8s.aws/v1/ec2nodeclass/1-ec2nodeclass.md
+++ b/content/metadata/karpenter/karpenter.k8s.aws/v1/ec2nodeclass/1-ec2nodeclass.md
@@ -1,0 +1,44 @@
+---
+title: An EC2NodeClass using a pinned version of the Amazon Linux 2023 AMI
+description: This EC2NodeClass will configure cluster node EC2 instances to use a specific AL2023 AMI version and associate them with tagged "cluster-private" subnet and "cluster-worker" security group.
+---
+
+```yaml
+apiVersion: karpenter.k8s.aws/v1
+kind: EC2NodeClass
+metadata:
+  name: private
+spec:
+  metadataOptions:
+    # Set the hop limit to 2 to allow containers to contact the Instance Metadata
+    # Service (IMDS) https://github.com/kubernetes-sigs/karpenter/issues/1769
+    httpPutResponseHopLimit: 2
+  blockDeviceMappings:
+    # Use encrypted, gp3, 50Gi root volumes
+    - deviceName: /dev/xvda
+      ebs:
+        volumeSize: 50Gi
+        volumeType: gp3
+        encrypted: true
+  # Required: Use an specific Amazon Linux 2023 AMI release compatible with the instance type
+  # https://github.com/awslabs/amazon-eks-ami/releases
+  amiFamily: AL2023
+  amiSelectorTerms:
+    - alias: al2023@v20250317
+  # IAM role name to use as the node role
+  role: KarpenterNode
+  # Don't associate a public IP address with the node, even if the subnet defaults to doing so
+  associatePublicIPAddress: false
+  subnetSelectorTerms:
+    # Required: Launch nodes in subnets with the following tags
+    - tags:
+        karpenter.sh/discovery: cluster-private
+        karpenter.sh/discovery/private: "true"
+  securityGroupSelectorTerms:
+    # Required: Launch nodes in security groups with the following tags
+    - tags:
+        karpenter.sh/discovery: cluster-worke
+  tags:
+    # Propagate AWS tags to the EC2 instances launched using this class
+    karpenter.sh/discovery: cluster-private
+```

--- a/content/metadata/karpenter/karpenter.k8s.aws/v1/ec2nodeclass/ec2nodeclass.json
+++ b/content/metadata/karpenter/karpenter.k8s.aws/v1/ec2nodeclass/ec2nodeclass.json
@@ -1,0 +1,8 @@
+{
+  "links": [
+    {
+      "name": "Karpenter Official Docs: EC2NodeClass",
+      "href": "https://karpenter.sh/docs/concepts/nodeclasses/"
+    }
+  ]
+}

--- a/content/metadata/karpenter/karpenter.sh/v1/nodeclaim/1-nodeclaim.md
+++ b/content/metadata/karpenter/karpenter.sh/v1/nodeclaim/1-nodeclaim.md
@@ -1,0 +1,162 @@
+---
+title: A NodeClaim created by Karpenter
+description: This NodeClaim represents a m5a.large AWS EC2 instance serving as a cluster node provisioned by the Karpenter controller in a NodePool named "default" using a EC2NodeClass named "private."
+---
+
+```yaml
+apiVersion: karpenter.sh/v1
+kind: NodeClaim
+metadata:
+  annotations:
+    compatibility.karpenter.k8s.aws/cluster-name-tagged: "true"
+    karpenter.k8s.aws/ec2nodeclass-hash: "17027975244315209952"
+    karpenter.k8s.aws/ec2nodeclass-hash-version: v4
+    karpenter.k8s.aws/tagged: "true"
+    karpenter.sh/nodepool-hash: "7192598826009892108"
+    karpenter.sh/nodepool-hash-version: v3
+  creationTimestamp: "2025-03-31T15:59:25Z"
+  finalizers:
+    - karpenter.sh/termination
+  generateName: default-
+  generation: 1
+  labels:
+    karpenter.k8s.aws/ec2nodeclass: private
+    karpenter.k8s.aws/instance-category: m
+    karpenter.k8s.aws/instance-cpu: "2"
+    karpenter.k8s.aws/instance-cpu-manufacturer: amd
+    karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz: "2500"
+    karpenter.k8s.aws/instance-ebs-bandwidth: "2880"
+    karpenter.k8s.aws/instance-encryption-in-transit-supported: "false"
+    karpenter.k8s.aws/instance-family: m5a
+    karpenter.k8s.aws/instance-generation: "5"
+    karpenter.k8s.aws/instance-hypervisor: nitro
+    karpenter.k8s.aws/instance-memory: "8192"
+    karpenter.k8s.aws/instance-network-bandwidth: "750"
+    karpenter.k8s.aws/instance-size: large
+    karpenter.sh/capacity-type: on-demand
+    karpenter.sh/nodepool: default
+    kubernetes.io/arch: amd64
+    kubernetes.io/os: linux
+    node.kubernetes.io/instance-type: m5a.large
+    topology.k8s.aws/zone-id: use1-az2
+    topology.kubernetes.io/region: us-east-1
+    topology.kubernetes.io/zone: us-east-1b
+  name: default-qmhg4
+  ownerReferences:
+    - apiVersion: karpenter.sh/v1
+      blockOwnerDeletion: true
+      kind: NodePool
+      name: default
+      uid: 1e1334cf-9696-406a-9a7f-e92780d6042b
+  resourceVersion: "688079106"
+  uid: e0d67077-3c60-4e1b-8c03-fe2a294485b5
+spec:
+  expireAfter: Never
+  nodeClassRef:
+    group: karpenter.k8s.aws
+    kind: EC2NodeClass
+    name: private
+  requirements:
+    - key: karpenter.sh/capacity-type
+      operator: In
+      values:
+        - on-demand
+    - key: topology.kubernetes.io/zone
+      operator: In
+      values:
+        - us-east-1b
+    - key: karpenter.k8s.aws/ec2nodeclass
+      operator: In
+      values:
+        - private
+    - key: node.kubernetes.io/instance-type
+      operator: In
+      values:
+        - c3.xlarge
+        - c4.xlarge
+        - c5.xlarge
+        - c5a.xlarge
+        - c5ad.xlarge
+        - c5d.xlarge
+        - c5n.large
+        - c5n.xlarge
+        - c6a.xlarge
+        - c6i.xlarge
+        - c6id.xlarge
+        - c6in.xlarge
+        - c7a.xlarge
+        - c7i-flex.xlarge
+        - c7i.xlarge
+        - m3.large
+        - m4.large
+        - m4.xlarge
+        - m5.large
+        - m5.xlarge
+        - m5a.large
+        - m5a.xlarge
+        - m5ad.large
+        - m5ad.xlarge
+        - m5d.large
+        - m5d.xlarge
+        - m5dn.large
+        - m5n.large
+        - m5zn.large
+        - m6a.large
+        - m6a.xlarge
+        - m6i.large
+        - m6i.xlarge
+        - m6id.large
+        - m6idn.large
+        - m6in.large
+        - m7a.large
+        - m7i-flex.large
+        - m7i-flex.xlarge
+        - m7i.large
+        - m7i.xlarge
+        - r3.large
+        - r4.large
+        - r5.large
+        - r5a.large
+        - r5a.xlarge
+        - r5ad.large
+        - r5b.large
+        - r5d.large
+        - r5dn.large
+        - r5n.large
+        - r6a.large
+        - r6a.xlarge
+        - r6i.large
+        - r6id.large
+        - r6idn.large
+        - r6in.large
+        - r7a.large
+        - r7i.large
+        - r7iz.large
+    - key: kubernetes.io/os
+      operator: In
+      values:
+        - linux
+    - key: karpenter.k8s.aws/instance-category
+      operator: In
+      values:
+        - c
+        - m
+        - r
+    - key: kubernetes.io/arch
+      operator: In
+      values:
+        - amd64
+    - key: karpenter.sh/nodepool
+      operator: In
+      values:
+        - default
+    - key: karpenter.k8s.aws/instance-generation
+      operator: Gt
+      values:
+        - "2"
+  resources:
+    requests:
+      cpu: 885m
+      memory: 4288Mi
+      pods: "13"
+```

--- a/content/metadata/karpenter/karpenter.sh/v1/nodeclaim/nodeclaim.json
+++ b/content/metadata/karpenter/karpenter.sh/v1/nodeclaim/nodeclaim.json
@@ -1,0 +1,12 @@
+{
+  "links": [
+    {
+      "name": "Karpenter Official Docs: NodeClaims",
+      "href": "https://karpenter.sh/docs/concepts/nodeclaims/"
+    },
+    {
+      "name": "Karpenter Official Docs: Instance Types",
+      "href": "https://karpenter.sh/docs/reference/instance-types/"
+    }
+  ]
+}

--- a/content/metadata/karpenter/karpenter.sh/v1/nodepool/1-nodepool-default.md
+++ b/content/metadata/karpenter/karpenter.sh/v1/nodepool/1-nodepool-default.md
@@ -1,0 +1,53 @@
+---
+title: A NodePool supporting typical cluster workloads
+description: This NodePool will select from standard EC2 instance types to right-size cluster nodes based on workload requests (e.g., cores, memory, CPU architecture).
+---
+
+```yaml
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: default
+spec:
+  # Constrain the maximum size of the node pool
+  limits:
+    cpu: 256
+    memory: 1024Gi
+  disruption:
+    # Allow Karpenter to consolidate nodes when they are empty or underutilized
+    consolidationPolicy: WhenEmptyOrUnderutilized
+    consolidateAfter: 5m
+    budgets:
+      # Allow voluntary disruptions to 5% of the nodes in the pool for any reason
+      - nodes: "5%"
+  template:
+    spec:
+      # Use the EC2NodeClass named "private" as the node template in this pool
+      nodeClassRef:
+        group: karpenter.k8s.aws
+        kind: EC2NodeClass
+        name: private
+      # Force node replacement after about a month
+      expireAfter: 720h
+      requirements:
+        # Select from standard instance families (compute, general, memory)
+        - key: karpenter.k8s.aws/instance-category
+          operator: In
+          values: ["c", "m", "r"]
+        # Only choose instances greater than this generation
+        - key: karpenter.k8s.aws/instance-generation
+          operator: Gt
+          values: ["2"]
+        # Only use on-demand instances in this pool
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["on-demand"]
+        - key: kubernetes.io/arch
+          operator: In
+          # Allow AMD64 and ARM64 (e.g., Graviton) proceseors
+          values: ["amd64", "arm64"]
+        # Only use Linux as the OS in this pool
+        - key: kubernetes.io/os
+          operator: In
+          values: ["linux"]
+```

--- a/content/metadata/karpenter/karpenter.sh/v1/nodepool/2-nodepool-gpu.md
+++ b/content/metadata/karpenter/karpenter.sh/v1/nodepool/2-nodepool-gpu.md
@@ -1,0 +1,51 @@
+---
+title: A NodePool supporting GPU workloads
+description: This NodePool will select from EC2 instances having NVIDIA GPUs and right-size cluster nodes based on workload requests (e.g., cores, memory, number of GPUs).
+---
+
+```yaml
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: gpu
+spec:
+  # Constrain the maximum size of the node pool
+  limits:
+    cpu: 256
+    memory: 1024Gi
+  disruption:
+    # Allow Karpenter to consolidate nodes when they are empty or underutilized
+    consolidationPolicy: WhenEmptyOrUnderutilized
+    consolidateAfter: 5m
+    budgets:
+      # Allow voluntary disruptions to 5% of the nodes in the pool for any reason
+      - nodes: "5%"
+  template:
+    spec:
+      # Use the EC2NodeClass named "private" as the node template in this pool
+      nodeClassRef:
+        group: karpenter.k8s.aws
+        kind: EC2NodeClass
+        name: private
+      # Never force replacement of nodes
+      expireAfter: Never
+      # Taint nodes so arbitrary workloads don't wind up provisioning expensive
+      # GPU instances.
+      taints:
+        - effect: NoSchedule
+          key: karpenter.sh/nodepool
+          value: "gpu"
+      requirements:
+        # Only use instances with NVIDIA GPUs
+        - key: karpenter.k8s.aws/instance-gpu-manufacturer
+          operator: In
+          values: ["nvidia"]
+        # Only use on-demand instances in this pool
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["on-demand"]
+        # Only use Linux as the OS in this pool
+        - key: kubernetes.io/os
+          operator: In
+          values: ["linux"]
+```

--- a/content/metadata/karpenter/karpenter.sh/v1/nodepool/nodepool.json
+++ b/content/metadata/karpenter/karpenter.sh/v1/nodepool/nodepool.json
@@ -1,0 +1,16 @@
+{
+  "links": [
+    {
+      "name": "Karpenter Official Docs: NodePools",
+      "href": "https://karpenter.sh/docs/concepts/nodepools/"
+    },
+    {
+      "name": "Karpenter Official Docs: Instance Types",
+      "href": "https://karpenter.sh/docs/reference/instance-types/"
+    },
+    {
+      "name": "Karpenter Blueprints for Amazon EKS: aws-samples/karpenter-blueprints",
+      "href": "https://github.com/aws-samples/karpenter-blueprints/tree/main"
+    }
+  ]
+}

--- a/content/projects/karpenter/v1.0.0/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/content/projects/karpenter/v1.0.0/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -1,0 +1,1346 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  name: ec2nodeclasses.karpenter.k8s.aws
+spec:
+  group: karpenter.k8s.aws
+  names:
+    categories:
+      - karpenter
+    kind: EC2NodeClass
+    listKind: EC2NodeClassList
+    plural: ec2nodeclasses
+    shortNames:
+      - ec2nc
+      - ec2ncs
+    singular: ec2nodeclass
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.role
+          name: Role
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: EC2NodeClass is the Schema for the EC2NodeClass API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                EC2NodeClassSpec is the top level specification for the AWS Karpenter Provider.
+                This will contain configuration necessary to launch instances in AWS.
+              properties:
+                amiFamily:
+                  description: |-
+                    AMIFamily dictates the UserData format and default BlockDeviceMappings used when generating launch templates.
+                    This field is optional when using an alias amiSelectorTerm, and the value will be inferred from the alias'
+                    family. When an alias is specified, this field may only be set to its corresponding family or 'Custom'. If no
+                    alias is specified, this field is required.
+                    NOTE: We ignore the AMIFamily for hashing here because we hash the AMIFamily dynamically by using the alias using
+                    the AMIFamily() helper function
+                  enum:
+                    - AL2
+                    - AL2023
+                    - Bottlerocket
+                    - Custom
+                    - Windows2019
+                    - Windows2022
+                  type: string
+                amiSelectorTerms:
+                  description: AMISelectorTerms is a list of or ami selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      AMISelectorTerm defines selection logic for an ami used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      alias:
+                        description: |-
+                          Alias specifies which EKS optimized AMI to select.
+                          Each alias consists of a family and an AMI version, specified as "family@version".
+                          Valid families include: al2, al2023, bottlerocket, windows2019, and windows2022.
+                          The version can either be pinned to a specific AMI release, with that AMIs version format (ex: "al2023@v20240625" or "bottlerocket@v1.10.0").
+                          The version can also be set to "latest" for any family. Setting the version to latest will result in drift when a new AMI is released. This is **not** recommended for production environments.
+                          Note: The Windows families do **not** support version pinning, and only latest may be used.
+                        maxLength: 30
+                        type: string
+                        x-kubernetes-validations:
+                          - message: '''alias'' is improperly formatted, must match the format ''family@version'''
+                            rule: self.matches('^[a-zA-Z0-9]+@.+$')
+                          - message: 'family is not supported, must be one of the following: ''al2'', ''al2023'', ''bottlerocket'', ''windows2019'', ''windows2022'''
+                            rule: self.split('@')[0] in ['al2','al2023','bottlerocket','windows2019','windows2022']
+                          - message: windows families may only specify version 'latest'
+                            rule: 'self.split(''@'')[0] in [''windows2019'',''windows2022''] ? self.split(''@'')[1] == ''latest'' : true'
+                      id:
+                        description: ID is the ami id in EC2
+                        pattern: ami-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the ami name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      owner:
+                        description: |-
+                          Owner is the owner for the ami.
+                          You can specify a combination of AWS account IDs, "self", "amazon", and "aws-marketplace"
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  minItems: 1
+                  type: array
+                  x-kubernetes-validations:
+                    - message: expected at least one, got none, ['tags', 'id', 'name', 'alias']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name) || has(x.alias))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.exists(x, has(x.id) && (has(x.alias) || has(x.tags) || has(x.name) || has(x.owner)))'
+                    - message: '''alias'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.exists(x, has(x.alias) && (has(x.id) || has(x.tags) || has(x.name) || has(x.owner)))'
+                    - message: '''alias'' is mutually exclusive, cannot be set with a combination of other amiSelectorTerms'
+                      rule: '!(self.exists(x, has(x.alias)) && self.size() != 1)'
+                associatePublicIPAddress:
+                  description: AssociatePublicIPAddress controls if public IP addresses are assigned to instances that are launched with the nodeclass.
+                  type: boolean
+                blockDeviceMappings:
+                  description: BlockDeviceMappings to be applied to provisioned nodes.
+                  items:
+                    properties:
+                      deviceName:
+                        description: The device name (for example, /dev/sdh or xvdh).
+                        type: string
+                      ebs:
+                        description: EBS contains parameters used to automatically set up EBS volumes when an instance is launched.
+                        properties:
+                          deleteOnTermination:
+                            description: DeleteOnTermination indicates whether the EBS volume is deleted on instance termination.
+                            type: boolean
+                          encrypted:
+                            description: |-
+                              Encrypted indicates whether the EBS volume is encrypted. Encrypted volumes can only
+                              be attached to instances that support Amazon EBS encryption. If you are creating
+                              a volume from a snapshot, you can't specify an encryption value.
+                            type: boolean
+                          iops:
+                            description: |-
+                              IOPS is the number of I/O operations per second (IOPS). For gp3, io1, and io2 volumes,
+                              this represents the number of IOPS that are provisioned for the volume. For
+                              gp2 volumes, this represents the baseline performance of the volume and the
+                              rate at which the volume accumulates I/O credits for bursting.
+
+
+                              The following are the supported values for each volume type:
+
+
+                                 * gp3: 3,000-16,000 IOPS
+
+
+                                 * io1: 100-64,000 IOPS
+
+
+                                 * io2: 100-64,000 IOPS
+
+
+                              For io1 and io2 volumes, we guarantee 64,000 IOPS only for Instances built
+                              on the Nitro System (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances).
+                              Other instance families guarantee performance up to 32,000 IOPS.
+
+
+                              This parameter is supported for io1, io2, and gp3 volumes only. This parameter
+                              is not supported for gp2, st1, sc1, or standard volumes.
+                            format: int64
+                            type: integer
+                          kmsKeyID:
+                            description: KMSKeyID (ARN) of the symmetric Key Management Service (KMS) CMK used for encryption.
+                            type: string
+                          snapshotID:
+                            description: SnapshotID is the ID of an EBS snapshot
+                            type: string
+                          throughput:
+                            description: |-
+                              Throughput to provision for a gp3 volume, with a maximum of 1,000 MiB/s.
+                              Valid Range: Minimum value of 125. Maximum value of 1000.
+                            format: int64
+                            type: integer
+                          volumeSize:
+                            description: |-
+                              VolumeSize in `Gi`, `G`, `Ti`, or `T`. You must specify either a snapshot ID or
+                              a volume size. The following are the supported volumes sizes for each volume
+                              type:
+
+
+                                 * gp2 and gp3: 1-16,384
+
+
+                                 * io1 and io2: 4-16,384
+
+
+                                 * st1 and sc1: 125-16,384
+
+
+                                 * standard: 1-1,024
+                            pattern: ^((?:[1-9][0-9]{0,3}|[1-4][0-9]{4}|[5][0-8][0-9]{3}|59000)Gi|(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|[6][0-3][0-9]{3}|64000)G|([1-9]||[1-5][0-7]|58)Ti|([1-9]||[1-5][0-9]|6[0-3]|64)T)$
+                            type: string
+                          volumeType:
+                            description: |-
+                              VolumeType of the block device.
+                              For more information, see Amazon EBS volume types (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html)
+                              in the Amazon Elastic Compute Cloud User Guide.
+                            enum:
+                              - standard
+                              - io1
+                              - io2
+                              - gp2
+                              - sc1
+                              - st1
+                              - gp3
+                            type: string
+                        type: object
+                        x-kubernetes-validations:
+                          - message: snapshotID or volumeSize must be defined
+                            rule: has(self.snapshotID) || has(self.volumeSize)
+                      rootVolume:
+                        description: |-
+                          RootVolume is a flag indicating if this device is mounted as kubelet root dir. You can
+                          configure at most one root volume in BlockDeviceMappings.
+                        type: boolean
+                    type: object
+                  maxItems: 50
+                  type: array
+                  x-kubernetes-validations:
+                    - message: must have only one blockDeviceMappings with rootVolume
+                      rule: self.filter(x, has(x.rootVolume)?x.rootVolume==true:false).size() <= 1
+                context:
+                  description: |-
+                    Context is a Reserved field in EC2 APIs
+                    https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet.html
+                  type: string
+                detailedMonitoring:
+                  description: DetailedMonitoring controls if detailed monitoring is enabled for instances that are launched
+                  type: boolean
+                instanceProfile:
+                  description: |-
+                    InstanceProfile is the AWS entity that instances use.
+                    This field is mutually exclusive from role.
+                    The instance profile should already have a role assigned to it that Karpenter
+                     has PassRole permission on for instance launch using this instanceProfile to succeed.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: instanceProfile cannot be empty
+                      rule: self != ''
+                instanceStorePolicy:
+                  description: InstanceStorePolicy specifies how to handle instance-store disks.
+                  enum:
+                    - RAID0
+                  type: string
+                kubelet:
+                  description: |-
+                    Kubelet defines args to be used when configuring kubelet on provisioned nodes.
+                    They are a subset of the upstream types, recognizing not all options may be supported.
+                    Wherever possible, the types and names should reflect the upstream kubelet types.
+                  properties:
+                    clusterDNS:
+                      description: |-
+                        clusterDNS is a list of IP addresses for the cluster DNS server.
+                        Note that not all providers may use all addresses.
+                      items:
+                        type: string
+                      type: array
+                    cpuCFSQuota:
+                      description: CPUCFSQuota enables CPU CFS quota enforcement for containers that specify CPU limits.
+                      type: boolean
+                    evictionHard:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionHard is the map of signal names to quantities that define hard eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionHard are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionMaxPodGracePeriod:
+                      description: |-
+                        EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in
+                        response to soft eviction thresholds being met.
+                      format: int32
+                      type: integer
+                    evictionSoft:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionSoft is the map of signal names to quantities that define soft eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoft are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionSoftGracePeriod:
+                      additionalProperties:
+                        type: string
+                      description: EvictionSoftGracePeriod is the map of signal names to quantities that define grace periods for each eviction signal
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoftGracePeriod are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    imageGCHighThresholdPercent:
+                      description: |-
+                        ImageGCHighThresholdPercent is the percent of disk usage after which image
+                        garbage collection is always run. The percent is calculated by dividing this
+                        field value by 100, so this field must be between 0 and 100, inclusive.
+                        When specified, the value must be greater than ImageGCLowThresholdPercent.
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    imageGCLowThresholdPercent:
+                      description: |-
+                        ImageGCLowThresholdPercent is the percent of disk usage before which image
+                        garbage collection is never run. Lowest disk usage to garbage collect to.
+                        The percent is calculated by dividing this field value by 100,
+                        so the field value must be between 0 and 100, inclusive.
+                        When specified, the value must be less than imageGCHighThresholdPercent
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    kubeReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: KubeReserved contains resources reserved for Kubernetes system components.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for kubeReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: kubeReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                    maxPods:
+                      description: |-
+                        MaxPods is an override for the maximum number of pods that can run on
+                        a worker node instance.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    podsPerCore:
+                      description: |-
+                        PodsPerCore is an override for the number of pods that can run on a worker node
+                        instance based on the number of cpu cores. This value cannot exceed MaxPods, so, if
+                        MaxPods is a lower value, that value will be used.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    systemReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: SystemReserved contains resources reserved for OS system daemons and kernel memory.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for systemReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: systemReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                  type: object
+                  x-kubernetes-validations:
+                    - message: imageGCHighThresholdPercent must be greater than imageGCLowThresholdPercent
+                      rule: 'has(self.imageGCHighThresholdPercent) && has(self.imageGCLowThresholdPercent) ?  self.imageGCHighThresholdPercent > self.imageGCLowThresholdPercent  : true'
+                    - message: evictionSoft OwnerKey does not have a matching evictionSoftGracePeriod
+                      rule: has(self.evictionSoft) ? self.evictionSoft.all(e, (e in self.evictionSoftGracePeriod)):true
+                    - message: evictionSoftGracePeriod OwnerKey does not have a matching evictionSoft
+                      rule: has(self.evictionSoftGracePeriod) ? self.evictionSoftGracePeriod.all(e, (e in self.evictionSoft)):true
+                metadataOptions:
+                  default:
+                    httpEndpoint: enabled
+                    httpProtocolIPv6: disabled
+                    httpPutResponseHopLimit: 1
+                    httpTokens: required
+                  description: |-
+                    MetadataOptions for the generated launch template of provisioned nodes.
+
+
+                    This specifies the exposure of the Instance Metadata Service to
+                    provisioned EC2 nodes. For more information,
+                    see Instance Metadata and User Data
+                    (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
+                    in the Amazon Elastic Compute Cloud User Guide.
+
+
+                    Refer to recommended, security best practices
+                    (https://aws.github.io/aws-eks-best-practices/security/docs/iam/#restrict-access-to-the-instance-profile-assigned-to-the-worker-node)
+                    for limiting exposure of Instance Metadata and User Data to pods.
+                    If omitted, defaults to httpEndpoint enabled, with httpProtocolIPv6
+                    disabled, with httpPutResponseLimit of 1, and with httpTokens
+                    required.
+                  properties:
+                    httpEndpoint:
+                      default: enabled
+                      description: |-
+                        HTTPEndpoint enables or disables the HTTP metadata endpoint on provisioned
+                        nodes. If metadata options is non-nil, but this parameter is not specified,
+                        the default state is "enabled".
+
+
+                        If you specify a value of "disabled", instance metadata will not be accessible
+                        on the node.
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpProtocolIPv6:
+                      default: disabled
+                      description: |-
+                        HTTPProtocolIPv6 enables or disables the IPv6 endpoint for the instance metadata
+                        service on provisioned nodes. If metadata options is non-nil, but this parameter
+                        is not specified, the default state is "disabled".
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpPutResponseHopLimit:
+                      default: 1
+                      description: |-
+                        HTTPPutResponseHopLimit is the desired HTTP PUT response hop limit for
+                        instance metadata requests. The larger the number, the further instance
+                        metadata requests can travel. Possible values are integers from 1 to 64.
+                        If metadata options is non-nil, but this parameter is not specified, the
+                        default value is 1.
+                      format: int64
+                      maximum: 64
+                      minimum: 1
+                      type: integer
+                    httpTokens:
+                      default: required
+                      description: |-
+                        HTTPTokens determines the state of token usage for instance metadata
+                        requests. If metadata options is non-nil, but this parameter is not
+                        specified, the default state is "required".
+
+
+                        If the state is optional, one can choose to retrieve instance metadata with
+                        or without a signed token header on the request. If one retrieves the IAM
+                        role credentials without a token, the version 1.0 role credentials are
+                        returned. If one retrieves the IAM role credentials using a valid signed
+                        token, the version 2.0 role credentials are returned.
+
+
+                        If the state is "required", one must send a signed token header with any
+                        instance metadata retrieval requests. In this state, retrieving the IAM
+                        role credentials always returns the version 2.0 credentials; the version
+                        1.0 credentials are not available.
+                      enum:
+                        - required
+                        - optional
+                      type: string
+                  type: object
+                role:
+                  description: |-
+                    Role is the AWS identity that nodes use. This field is immutable.
+                    This field is mutually exclusive from instanceProfile.
+                    Marking this field as immutable avoids concerns around terminating managed instance profiles from running instances.
+                    This field may be made mutable in the future, assuming the correct garbage collection and drift handling is implemented
+                    for the old instance profiles on an update.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: role cannot be empty
+                      rule: self != ''
+                    - message: immutable field changed
+                      rule: self == oldSelf
+                securityGroupSelectorTerms:
+                  description: SecurityGroupSelectorTerms is a list of or security group selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SecurityGroupSelectorTerm defines selection logic for a security group used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the security group id in EC2
+                        pattern: sg-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the security group name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: securityGroupSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id', 'name']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && (has(x.tags) || has(x.name)))'
+                    - message: '''name'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.name) && (has(x.tags) || has(x.id)))'
+                subnetSelectorTerms:
+                  description: SubnetSelectorTerms is a list of or subnet selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SubnetSelectorTerm defines selection logic for a subnet used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the subnet id in EC2
+                        pattern: subnet-[0-9a-z]+
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: subnetSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id']
+                      rule: self.all(x, has(x.tags) || has(x.id))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in subnetSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && has(x.tags))'
+                tags:
+                  additionalProperties:
+                    type: string
+                  description: Tags to be applied on ec2 resources like instances and launch templates.
+                  type: object
+                  x-kubernetes-validations:
+                    - message: empty tag keys aren't supported
+                      rule: self.all(k, k != '')
+                    - message: tag contains a restricted tag matching eks:eks-cluster-name
+                      rule: self.all(k, k !='eks:eks-cluster-name')
+                    - message: tag contains a restricted tag matching kubernetes.io/cluster/
+                      rule: self.all(k, !k.startsWith('kubernetes.io/cluster') )
+                    - message: tag contains a restricted tag matching karpenter.sh/nodepool
+                      rule: self.all(k, k != 'karpenter.sh/nodepool')
+                    - message: tag contains a restricted tag matching karpenter.sh/nodeclaim
+                      rule: self.all(k, k !='karpenter.sh/nodeclaim')
+                    - message: tag contains a restricted tag matching karpenter.k8s.aws/ec2nodeclass
+                      rule: self.all(k, k !='karpenter.k8s.aws/ec2nodeclass')
+                userData:
+                  description: |-
+                    UserData to be applied to the provisioned nodes.
+                    It must be in the appropriate format based on the AMIFamily in use. Karpenter will merge certain fields into
+                    this UserData to ensure nodes are being provisioned with the correct configuration.
+                  type: string
+              required:
+                - amiSelectorTerms
+                - securityGroupSelectorTerms
+                - subnetSelectorTerms
+              type: object
+              x-kubernetes-validations:
+                - message: must specify exactly one of ['role', 'instanceProfile']
+                  rule: (has(self.role) && !has(self.instanceProfile)) || (!has(self.role) && has(self.instanceProfile))
+                - message: changing from 'instanceProfile' to 'role' is not supported. You must delete and recreate this node class if you want to change this.
+                  rule: (has(oldSelf.role) && has(self.role)) || (has(oldSelf.instanceProfile) && has(self.instanceProfile))
+                - message: if set, amiFamily must be 'AL2' or 'Custom' when using an AL2 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''al2'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''AL2'') : true)'
+                - message: if set, amiFamily must be 'AL2023' or 'Custom' when using an AL2023 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''al2023'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''AL2023'') : true)'
+                - message: if set, amiFamily must be 'Bottlerocket' or 'Custom' when using a Bottlerocket alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''bottlerocket'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Bottlerocket'') : true)'
+                - message: if set, amiFamily must be 'Windows2019' or 'Custom' when using a Windows2019 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''windows2019'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Windows2019'') : true)'
+                - message: if set, amiFamily must be 'Windows2022' or 'Custom' when using a Windows2022 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''windows2022'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Windows2022'') : true)'
+                - message: must specify amiFamily if amiSelectorTerms does not contain an alias
+                  rule: 'self.amiSelectorTerms.exists(x, has(x.alias)) ? true : has(self.amiFamily)'
+            status:
+              description: EC2NodeClassStatus contains the resolved state of the EC2NodeClass
+              properties:
+                amis:
+                  description: |-
+                    AMI contains the current AMI values that are available to the
+                    cluster under the AMI selectors.
+                  items:
+                    description: AMI contains resolved AMI selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the AMI
+                        type: string
+                      name:
+                        description: Name of the AMI
+                        type: string
+                      requirements:
+                        description: Requirements of the AMI to be utilized on an instance type
+                        items:
+                          description: |-
+                            A node selector requirement is a selector that contains values, a key, and an operator
+                            that relates the key and values.
+                          properties:
+                            key:
+                              description: The label key that the selector applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                Represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                              type: string
+                            values:
+                              description: |-
+                                An array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. If the operator is Gt or Lt, the values
+                                array must have a single element, which will be interpreted as an integer.
+                                This array is replaced during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                            - key
+                            - operator
+                          type: object
+                        type: array
+                    required:
+                      - id
+                      - requirements
+                    type: object
+                  type: array
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: |-
+                          type of condition in CamelCase or in foo.example.com/CamelCase.
+                          ---
+                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                          useful (see .node.status.conditions), the ability to deconflict is important.
+                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                instanceProfile:
+                  description: InstanceProfile contains the resolved instance profile for the role
+                  type: string
+                securityGroups:
+                  description: |-
+                    SecurityGroups contains the current Security Groups values that are available to the
+                    cluster under the SecurityGroups selectors.
+                  items:
+                    description: SecurityGroup contains resolved SecurityGroup selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the security group
+                        type: string
+                      name:
+                        description: Name of the security group
+                        type: string
+                    required:
+                      - id
+                    type: object
+                  type: array
+                subnets:
+                  description: |-
+                    Subnets contains the current Subnet values that are available to the
+                    cluster under the subnet selectors.
+                  items:
+                    description: Subnet contains resolved Subnet selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the subnet
+                        type: string
+                      zone:
+                        description: The associated availability zone
+                        type: string
+                      zoneID:
+                        description: The associated availability zone ID
+                        type: string
+                    required:
+                      - id
+                      - zone
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: EC2NodeClass is the Schema for the EC2NodeClass API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                EC2NodeClassSpec is the top level specification for the AWS Karpenter Provider.
+                This will contain configuration necessary to launch instances in AWS.
+              properties:
+                amiFamily:
+                  description: AMIFamily is the AMI family that instances use.
+                  enum:
+                    - AL2
+                    - AL2023
+                    - Bottlerocket
+                    - Ubuntu
+                    - Custom
+                    - Windows2019
+                    - Windows2022
+                  type: string
+                amiSelectorTerms:
+                  description: AMISelectorTerms is a list of or ami selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      AMISelectorTerm defines selection logic for an ami used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the ami id in EC2
+                        pattern: ami-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the ami name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      owner:
+                        description: |-
+                          Owner is the owner for the ami.
+                          You can specify a combination of AWS account IDs, "self", "amazon", and "aws-marketplace"
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: expected at least one, got none, ['tags', 'id', 'name']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && (has(x.tags) || has(x.name) || has(x.owner)))'
+                associatePublicIPAddress:
+                  description: AssociatePublicIPAddress controls if public IP addresses are assigned to instances that are launched with the nodeclass.
+                  type: boolean
+                blockDeviceMappings:
+                  description: BlockDeviceMappings to be applied to provisioned nodes.
+                  items:
+                    properties:
+                      deviceName:
+                        description: The device name (for example, /dev/sdh or xvdh).
+                        type: string
+                      ebs:
+                        description: EBS contains parameters used to automatically set up EBS volumes when an instance is launched.
+                        properties:
+                          deleteOnTermination:
+                            description: DeleteOnTermination indicates whether the EBS volume is deleted on instance termination.
+                            type: boolean
+                          encrypted:
+                            description: |-
+                              Encrypted indicates whether the EBS volume is encrypted. Encrypted volumes can only
+                              be attached to instances that support Amazon EBS encryption. If you are creating
+                              a volume from a snapshot, you can't specify an encryption value.
+                            type: boolean
+                          iops:
+                            description: |-
+                              IOPS is the number of I/O operations per second (IOPS). For gp3, io1, and io2 volumes,
+                              this represents the number of IOPS that are provisioned for the volume. For
+                              gp2 volumes, this represents the baseline performance of the volume and the
+                              rate at which the volume accumulates I/O credits for bursting.
+
+
+                              The following are the supported values for each volume type:
+
+
+                                 * gp3: 3,000-16,000 IOPS
+
+
+                                 * io1: 100-64,000 IOPS
+
+
+                                 * io2: 100-64,000 IOPS
+
+
+                              For io1 and io2 volumes, we guarantee 64,000 IOPS only for Instances built
+                              on the Nitro System (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances).
+                              Other instance families guarantee performance up to 32,000 IOPS.
+
+
+                              This parameter is supported for io1, io2, and gp3 volumes only. This parameter
+                              is not supported for gp2, st1, sc1, or standard volumes.
+                            format: int64
+                            type: integer
+                          kmsKeyID:
+                            description: KMSKeyID (ARN) of the symmetric Key Management Service (KMS) CMK used for encryption.
+                            type: string
+                          snapshotID:
+                            description: SnapshotID is the ID of an EBS snapshot
+                            type: string
+                          throughput:
+                            description: |-
+                              Throughput to provision for a gp3 volume, with a maximum of 1,000 MiB/s.
+                              Valid Range: Minimum value of 125. Maximum value of 1000.
+                            format: int64
+                            type: integer
+                          volumeSize:
+                            description: |-
+                              VolumeSize in `Gi`, `G`, `Ti`, or `T`. You must specify either a snapshot ID or
+                              a volume size. The following are the supported volumes sizes for each volume
+                              type:
+
+
+                                 * gp2 and gp3: 1-16,384
+
+
+                                 * io1 and io2: 4-16,384
+
+
+                                 * st1 and sc1: 125-16,384
+
+
+                                 * standard: 1-1,024
+                            pattern: ^((?:[1-9][0-9]{0,3}|[1-4][0-9]{4}|[5][0-8][0-9]{3}|59000)Gi|(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|[6][0-3][0-9]{3}|64000)G|([1-9]||[1-5][0-7]|58)Ti|([1-9]||[1-5][0-9]|6[0-3]|64)T)$
+                            type: string
+                          volumeType:
+                            description: |-
+                              VolumeType of the block device.
+                              For more information, see Amazon EBS volume types (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html)
+                              in the Amazon Elastic Compute Cloud User Guide.
+                            enum:
+                              - standard
+                              - io1
+                              - io2
+                              - gp2
+                              - sc1
+                              - st1
+                              - gp3
+                            type: string
+                        type: object
+                        x-kubernetes-validations:
+                          - message: snapshotID or volumeSize must be defined
+                            rule: has(self.snapshotID) || has(self.volumeSize)
+                      rootVolume:
+                        description: |-
+                          RootVolume is a flag indicating if this device is mounted as kubelet root dir. You can
+                          configure at most one root volume in BlockDeviceMappings.
+                        type: boolean
+                    type: object
+                  maxItems: 50
+                  type: array
+                  x-kubernetes-validations:
+                    - message: must have only one blockDeviceMappings with rootVolume
+                      rule: self.filter(x, has(x.rootVolume)?x.rootVolume==true:false).size() <= 1
+                context:
+                  description: |-
+                    Context is a Reserved field in EC2 APIs
+                    https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet.html
+                  type: string
+                detailedMonitoring:
+                  description: DetailedMonitoring controls if detailed monitoring is enabled for instances that are launched
+                  type: boolean
+                instanceProfile:
+                  description: |-
+                    InstanceProfile is the AWS entity that instances use.
+                    This field is mutually exclusive from role.
+                    The instance profile should already have a role assigned to it that Karpenter
+                     has PassRole permission on for instance launch using this instanceProfile to succeed.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: instanceProfile cannot be empty
+                      rule: self != ''
+                instanceStorePolicy:
+                  description: InstanceStorePolicy specifies how to handle instance-store disks.
+                  enum:
+                    - RAID0
+                  type: string
+                metadataOptions:
+                  default:
+                    httpEndpoint: enabled
+                    httpProtocolIPv6: disabled
+                    httpPutResponseHopLimit: 1
+                    httpTokens: required
+                  description: |-
+                    MetadataOptions for the generated launch template of provisioned nodes.
+
+
+                    This specifies the exposure of the Instance Metadata Service to
+                    provisioned EC2 nodes. For more information,
+                    see Instance Metadata and User Data
+                    (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
+                    in the Amazon Elastic Compute Cloud User Guide.
+
+
+                    Refer to recommended, security best practices
+                    (https://aws.github.io/aws-eks-best-practices/security/docs/iam/#restrict-access-to-the-instance-profile-assigned-to-the-worker-node)
+                    for limiting exposure of Instance Metadata and User Data to pods.
+                    If omitted, defaults to httpEndpoint enabled, with httpProtocolIPv6
+                    disabled, with httpPutResponseLimit of 1, and with httpTokens
+                    required.
+                  properties:
+                    httpEndpoint:
+                      default: enabled
+                      description: |-
+                        HTTPEndpoint enables or disables the HTTP metadata endpoint on provisioned
+                        nodes. If metadata options is non-nil, but this parameter is not specified,
+                        the default state is "enabled".
+
+
+                        If you specify a value of "disabled", instance metadata will not be accessible
+                        on the node.
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpProtocolIPv6:
+                      default: disabled
+                      description: |-
+                        HTTPProtocolIPv6 enables or disables the IPv6 endpoint for the instance metadata
+                        service on provisioned nodes. If metadata options is non-nil, but this parameter
+                        is not specified, the default state is "disabled".
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpPutResponseHopLimit:
+                      default: 2
+                      description: |-
+                        HTTPPutResponseHopLimit is the desired HTTP PUT response hop limit for
+                        instance metadata requests. The larger the number, the further instance
+                        metadata requests can travel. Possible values are integers from 1 to 64.
+                        If metadata options is non-nil, but this parameter is not specified, the
+                        default value is 2.
+                      format: int64
+                      maximum: 64
+                      minimum: 1
+                      type: integer
+                    httpTokens:
+                      default: required
+                      description: |-
+                        HTTPTokens determines the state of token usage for instance metadata
+                        requests. If metadata options is non-nil, but this parameter is not
+                        specified, the default state is "required".
+
+
+                        If the state is optional, one can choose to retrieve instance metadata with
+                        or without a signed token header on the request. If one retrieves the IAM
+                        role credentials without a token, the version 1.0 role credentials are
+                        returned. If one retrieves the IAM role credentials using a valid signed
+                        token, the version 2.0 role credentials are returned.
+
+
+                        If the state is "required", one must send a signed token header with any
+                        instance metadata retrieval requests. In this state, retrieving the IAM
+                        role credentials always returns the version 2.0 credentials; the version
+                        1.0 credentials are not available.
+                      enum:
+                        - required
+                        - optional
+                      type: string
+                  type: object
+                role:
+                  description: |-
+                    Role is the AWS identity that nodes use. This field is immutable.
+                    This field is mutually exclusive from instanceProfile.
+                    Marking this field as immutable avoids concerns around terminating managed instance profiles from running instances.
+                    This field may be made mutable in the future, assuming the correct garbage collection and drift handling is implemented
+                    for the old instance profiles on an update.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: role cannot be empty
+                      rule: self != ''
+                    - message: immutable field changed
+                      rule: self == oldSelf
+                securityGroupSelectorTerms:
+                  description: SecurityGroupSelectorTerms is a list of or security group selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SecurityGroupSelectorTerm defines selection logic for a security group used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the security group id in EC2
+                        pattern: sg-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the security group name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: securityGroupSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id', 'name']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && (has(x.tags) || has(x.name)))'
+                    - message: '''name'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.name) && (has(x.tags) || has(x.id)))'
+                subnetSelectorTerms:
+                  description: SubnetSelectorTerms is a list of or subnet selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SubnetSelectorTerm defines selection logic for a subnet used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the subnet id in EC2
+                        pattern: subnet-[0-9a-z]+
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: subnetSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id']
+                      rule: self.all(x, has(x.tags) || has(x.id))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in subnetSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && has(x.tags))'
+                tags:
+                  additionalProperties:
+                    type: string
+                  description: Tags to be applied on ec2 resources like instances and launch templates.
+                  type: object
+                  x-kubernetes-validations:
+                    - message: empty tag keys aren't supported
+                      rule: self.all(k, k != '')
+                    - message: tag contains a restricted tag matching kubernetes.io/cluster/
+                      rule: self.all(k, !k.startsWith('kubernetes.io/cluster') )
+                    - message: tag contains a restricted tag matching karpenter.sh/nodepool
+                      rule: self.all(k, k != 'karpenter.sh/nodepool')
+                    - message: tag contains a restricted tag matching karpenter.sh/managed-by
+                      rule: self.all(k, k !='karpenter.sh/managed-by')
+                    - message: tag contains a restricted tag matching karpenter.sh/nodeclaim
+                      rule: self.all(k, k !='karpenter.sh/nodeclaim')
+                    - message: tag contains a restricted tag matching karpenter.k8s.aws/ec2nodeclass
+                      rule: self.all(k, k !='karpenter.k8s.aws/ec2nodeclass')
+                userData:
+                  description: |-
+                    UserData to be applied to the provisioned nodes.
+                    It must be in the appropriate format based on the AMIFamily in use. Karpenter will merge certain fields into
+                    this UserData to ensure nodes are being provisioned with the correct configuration.
+                  type: string
+              required:
+                - amiFamily
+                - securityGroupSelectorTerms
+                - subnetSelectorTerms
+              type: object
+              x-kubernetes-validations:
+                - message: amiSelectorTerms is required when amiFamily == 'Custom'
+                  rule: 'self.amiFamily == ''Custom'' ? self.amiSelectorTerms.size() != 0 : true'
+                - message: must specify exactly one of ['role', 'instanceProfile']
+                  rule: (has(self.role) && !has(self.instanceProfile)) || (!has(self.role) && has(self.instanceProfile))
+                - message: changing from 'instanceProfile' to 'role' is not supported. You must delete and recreate this node class if you want to change this.
+                  rule: (has(oldSelf.role) && has(self.role)) || (has(oldSelf.instanceProfile) && has(self.instanceProfile))
+            status:
+              description: EC2NodeClassStatus contains the resolved state of the EC2NodeClass
+              properties:
+                amis:
+                  description: |-
+                    AMI contains the current AMI values that are available to the
+                    cluster under the AMI selectors.
+                  items:
+                    description: AMI contains resolved AMI selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the AMI
+                        type: string
+                      name:
+                        description: Name of the AMI
+                        type: string
+                      requirements:
+                        description: Requirements of the AMI to be utilized on an instance type
+                        items:
+                          description: |-
+                            A node selector requirement is a selector that contains values, a key, and an operator
+                            that relates the key and values.
+                          properties:
+                            key:
+                              description: The label key that the selector applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                Represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                              type: string
+                            values:
+                              description: |-
+                                An array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. If the operator is Gt or Lt, the values
+                                array must have a single element, which will be interpreted as an integer.
+                                This array is replaced during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                            - key
+                            - operator
+                          type: object
+                        type: array
+                    required:
+                      - id
+                      - requirements
+                    type: object
+                  type: array
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: |-
+                          type of condition in CamelCase or in foo.example.com/CamelCase.
+                          ---
+                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                          useful (see .node.status.conditions), the ability to deconflict is important.
+                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                instanceProfile:
+                  description: InstanceProfile contains the resolved instance profile for the role
+                  type: string
+                securityGroups:
+                  description: |-
+                    SecurityGroups contains the current Security Groups values that are available to the
+                    cluster under the SecurityGroups selectors.
+                  items:
+                    description: SecurityGroup contains resolved SecurityGroup selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the security group
+                        type: string
+                      name:
+                        description: Name of the security group
+                        type: string
+                    required:
+                      - id
+                    type: object
+                  type: array
+                subnets:
+                  description: |-
+                    Subnets contains the current Subnet values that are available to the
+                    cluster under the subnet selectors.
+                  items:
+                    description: Subnet contains resolved Subnet selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the subnet
+                        type: string
+                      zone:
+                        description: The associated availability zone
+                        type: string
+                      zoneID:
+                        description: The associated availability zone ID
+                        type: string
+                    required:
+                      - id
+                      - zone
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+        - v1
+      clientConfig:
+        service:
+          name: karpenter
+          namespace: kube-system
+          port: 8443

--- a/content/projects/karpenter/v1.0.0/karpenter.sh_nodeclaims.yaml
+++ b/content/projects/karpenter/v1.0.0/karpenter.sh_nodeclaims.yaml
@@ -1,0 +1,843 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  name: nodeclaims.karpenter.sh
+spec:
+  group: karpenter.sh
+  names:
+    categories:
+      - karpenter
+    kind: NodeClaim
+    listKind: NodeClaimList
+    plural: nodeclaims
+    singular: nodeclaim
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.labels.node\.kubernetes\.io/instance-type
+          name: Type
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/capacity-type
+          name: Capacity
+          type: string
+        - jsonPath: .metadata.labels.topology\.kubernetes\.io/zone
+          name: Zone
+          type: string
+        - jsonPath: .status.nodeName
+          name: Node
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .status.providerID
+          name: ID
+          priority: 1
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/nodepool
+          name: NodePool
+          priority: 1
+          type: string
+        - jsonPath: .spec.nodeClassRef.name
+          name: NodeClass
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: NodeClaim is the Schema for the NodeClaims API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: NodeClaimSpec describes the desired state of the NodeClaim
+              properties:
+                expireAfter:
+                  default: 720h
+                  description: |-
+                    ExpireAfter is the duration the controller will wait
+                    before terminating a node, measured from when the node is created. This
+                    is useful to implement features like eventually consistent node upgrade,
+                    memory leak protection, and disruption testing.
+                  pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                  type: string
+                nodeClassRef:
+                  description: NodeClassRef is a reference to an object that defines provider specific configuration
+                  properties:
+                    group:
+                      description: API version of the referent
+                      pattern: ^[^/]*$
+                      type: string
+                    kind:
+                      description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                      type: string
+                    name:
+                      description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                      type: string
+                  required:
+                    - group
+                    - kind
+                    - name
+                  type: object
+                requirements:
+                  description: Requirements are layered with GetLabels and applied to every node.
+                  items:
+                    description: |-
+                      A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                      and minValues that represent the requirement to have at least that many values.
+                    properties:
+                      key:
+                        description: The label key that the selector applies to.
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                        x-kubernetes-validations:
+                          - message: label domain "kubernetes.io" is restricted
+                            rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                          - message: label domain "k8s.io" is restricted
+                            rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                          - message: label domain "karpenter.sh" is restricted
+                            rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                          - message: label "kubernetes.io/hostname" is restricted
+                            rule: self != "kubernetes.io/hostname"
+                          - message: label domain "karpenter.k8s.aws" is restricted
+                            rule: self in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                      minValues:
+                        description: |-
+                          This field is ALPHA and can be dropped or replaced at any time
+                          MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                        maximum: 50
+                        minimum: 1
+                        type: integer
+                      operator:
+                        description: |-
+                          Represents a key's relationship to a set of values.
+                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                        type: string
+                        enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          - Gt
+                          - Lt
+                      values:
+                        description: |-
+                          An array of string values. If the operator is In or NotIn,
+                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                          the values array must be empty. If the operator is Gt or Lt, the values
+                          array must have a single element, which will be interpreted as an integer.
+                          This array is replaced during a strategic merge patch.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                        maxLength: 63
+                        pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                    required:
+                      - key
+                      - operator
+                    type: object
+                  maxItems: 100
+                  type: array
+                  x-kubernetes-validations:
+                    - message: requirements with operator 'In' must have a value defined
+                      rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                    - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                      rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                    - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                      rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                resources:
+                  description: Resources models the resource requirements for the NodeClaim to launch
+                  properties:
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: Requests describes the minimum required resources for the NodeClaim to launch
+                      type: object
+                  type: object
+                startupTaints:
+                  description: |-
+                    StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                    within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                    daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                    purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                taints:
+                  description: Taints will be applied to the NodeClaim's node.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                terminationGracePeriod:
+                  description: |-
+                    TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
+
+
+                    Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
+
+
+                    This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
+                    When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
+
+
+                    Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
+                    If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
+                    that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
+
+
+                    The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
+                    If left undefined, the controller will wait indefinitely for pods to be drained.
+                  pattern: ^([0-9]+(s|m|h))+$
+                  type: string
+              required:
+                - nodeClassRef
+                - requirements
+              type: object
+              x-kubernetes-validations:
+                - message: spec is immutable
+                  rule: self == oldSelf
+            status:
+              description: NodeClaimStatus defines the observed state of NodeClaim
+              properties:
+                allocatable:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Allocatable is the estimated allocatable capacity of the node
+                  type: object
+                capacity:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Capacity is the estimated full capacity of the node
+                  type: object
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        pattern: ^([A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?|)$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: |-
+                          type of condition in CamelCase or in foo.example.com/CamelCase.
+                          ---
+                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                          useful (see .node.status.conditions), the ability to deconflict is important.
+                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - status
+                      - type
+                    type: object
+                  type: array
+                imageID:
+                  description: ImageID is an identifier for the image that runs on the node
+                  type: string
+                lastPodEventTime:
+                  description: |-
+                    LastPodEventTime is updated with the last time a pod was scheduled
+                    or removed from the node. A pod going terminal or terminating
+                    is also considered as removed.
+                  format: date-time
+                  type: string
+                nodeName:
+                  description: NodeName is the name of the corresponding node object
+                  type: string
+                providerID:
+                  description: ProviderID of the corresponding node object
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.labels.node\.kubernetes\.io/instance-type
+          name: Type
+          type: string
+        - jsonPath: .metadata.labels.topology\.kubernetes\.io/zone
+          name: Zone
+          type: string
+        - jsonPath: .status.nodeName
+          name: Node
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .metadata.labels.karpenter\.sh/capacity-type
+          name: Capacity
+          priority: 1
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/nodepool
+          name: NodePool
+          priority: 1
+          type: string
+        - jsonPath: .spec.nodeClassRef.name
+          name: NodeClass
+          priority: 1
+          type: string
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: NodeClaim is the Schema for the NodeClaims API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: NodeClaimSpec describes the desired state of the NodeClaim
+              properties:
+                kubelet:
+                  description: |-
+                    Kubelet defines args to be used when configuring kubelet on provisioned nodes.
+                    They are a subset of the upstream types, recognizing not all options may be supported.
+                    Wherever possible, the types and names should reflect the upstream kubelet types.
+                  properties:
+                    clusterDNS:
+                      description: |-
+                        clusterDNS is a list of IP addresses for the cluster DNS server.
+                        Note that not all providers may use all addresses.
+                      items:
+                        type: string
+                      type: array
+                    cpuCFSQuota:
+                      description: CPUCFSQuota enables CPU CFS quota enforcement for containers that specify CPU limits.
+                      type: boolean
+                    evictionHard:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionHard is the map of signal names to quantities that define hard eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionHard are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionMaxPodGracePeriod:
+                      description: |-
+                        EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in
+                        response to soft eviction thresholds being met.
+                      format: int32
+                      type: integer
+                    evictionSoft:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionSoft is the map of signal names to quantities that define soft eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoft are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionSoftGracePeriod:
+                      additionalProperties:
+                        type: string
+                      description: EvictionSoftGracePeriod is the map of signal names to quantities that define grace periods for each eviction signal
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoftGracePeriod are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    imageGCHighThresholdPercent:
+                      description: |-
+                        ImageGCHighThresholdPercent is the percent of disk usage after which image
+                        garbage collection is always run. The percent is calculated by dividing this
+                        field value by 100, so this field must be between 0 and 100, inclusive.
+                        When specified, the value must be greater than ImageGCLowThresholdPercent.
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    imageGCLowThresholdPercent:
+                      description: |-
+                        ImageGCLowThresholdPercent is the percent of disk usage before which image
+                        garbage collection is never run. Lowest disk usage to garbage collect to.
+                        The percent is calculated by dividing this field value by 100,
+                        so the field value must be between 0 and 100, inclusive.
+                        When specified, the value must be less than imageGCHighThresholdPercent
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    kubeReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: KubeReserved contains resources reserved for Kubernetes system components.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for kubeReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: kubeReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                    maxPods:
+                      description: |-
+                        MaxPods is an override for the maximum number of pods that can run on
+                        a worker node instance.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    podsPerCore:
+                      description: |-
+                        PodsPerCore is an override for the number of pods that can run on a worker node
+                        instance based on the number of cpu cores. This value cannot exceed MaxPods, so, if
+                        MaxPods is a lower value, that value will be used.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    systemReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: SystemReserved contains resources reserved for OS system daemons and kernel memory.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for systemReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: systemReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                  type: object
+                  x-kubernetes-validations:
+                    - message: imageGCHighThresholdPercent must be greater than imageGCLowThresholdPercent
+                      rule: 'has(self.imageGCHighThresholdPercent) && has(self.imageGCLowThresholdPercent) ?  self.imageGCHighThresholdPercent > self.imageGCLowThresholdPercent  : true'
+                    - message: evictionSoft OwnerKey does not have a matching evictionSoftGracePeriod
+                      rule: has(self.evictionSoft) ? self.evictionSoft.all(e, (e in self.evictionSoftGracePeriod)):true
+                    - message: evictionSoftGracePeriod OwnerKey does not have a matching evictionSoft
+                      rule: has(self.evictionSoftGracePeriod) ? self.evictionSoftGracePeriod.all(e, (e in self.evictionSoft)):true
+                nodeClassRef:
+                  description: NodeClassRef is a reference to an object that defines provider specific configuration
+                  properties:
+                    apiVersion:
+                      description: API version of the referent
+                      type: string
+                    kind:
+                      description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                      type: string
+                    name:
+                      description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                      type: string
+                  required:
+                    - name
+                  type: object
+                requirements:
+                  description: Requirements are layered with GetLabels and applied to every node.
+                  items:
+                    description: |-
+                      A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                      and minValues that represent the requirement to have at least that many values.
+                    properties:
+                      key:
+                        description: The label key that the selector applies to.
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                        x-kubernetes-validations:
+                          - message: label domain "kubernetes.io" is restricted
+                            rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                          - message: label domain "k8s.io" is restricted
+                            rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                          - message: label domain "karpenter.sh" is restricted
+                            rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                          - message: label "kubernetes.io/hostname" is restricted
+                            rule: self != "kubernetes.io/hostname"
+                          - message: label domain "karpenter.k8s.aws" is restricted
+                            rule: self in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                      minValues:
+                        description: |-
+                          This field is ALPHA and can be dropped or replaced at any time
+                          MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                        maximum: 50
+                        minimum: 1
+                        type: integer
+                      operator:
+                        description: |-
+                          Represents a key's relationship to a set of values.
+                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                        type: string
+                        enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          - Gt
+                          - Lt
+                      values:
+                        description: |-
+                          An array of string values. If the operator is In or NotIn,
+                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                          the values array must be empty. If the operator is Gt or Lt, the values
+                          array must have a single element, which will be interpreted as an integer.
+                          This array is replaced during a strategic merge patch.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                        maxLength: 63
+                        pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                    required:
+                      - key
+                      - operator
+                    type: object
+                  maxItems: 100
+                  type: array
+                  x-kubernetes-validations:
+                    - message: requirements with operator 'In' must have a value defined
+                      rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                    - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                      rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                    - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                      rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                resources:
+                  description: Resources models the resource requirements for the NodeClaim to launch
+                  properties:
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: Requests describes the minimum required resources for the NodeClaim to launch
+                      type: object
+                  type: object
+                startupTaints:
+                  description: |-
+                    StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                    within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                    daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                    purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                taints:
+                  description: Taints will be applied to the NodeClaim's node.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+              required:
+                - nodeClassRef
+                - requirements
+              type: object
+            status:
+              description: NodeClaimStatus defines the observed state of NodeClaim
+              properties:
+                allocatable:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Allocatable is the estimated allocatable capacity of the node
+                  type: object
+                capacity:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Capacity is the estimated full capacity of the node
+                  type: object
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        pattern: ^([A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?|)$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: |-
+                          type of condition in CamelCase or in foo.example.com/CamelCase.
+                          ---
+                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                          useful (see .node.status.conditions), the ability to deconflict is important.
+                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - status
+                      - type
+                    type: object
+                  type: array
+                imageID:
+                  description: ImageID is an identifier for the image that runs on the node
+                  type: string
+                nodeName:
+                  description: NodeName is the name of the corresponding node object
+                  type: string
+                providerID:
+                  description: ProviderID of the corresponding node object
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+        - v1
+      clientConfig:
+        service:
+          name: karpenter
+          namespace: kube-system
+          port: 8443

--- a/content/projects/karpenter/v1.0.0/karpenter.sh_nodepools.yaml
+++ b/content/projects/karpenter/v1.0.0/karpenter.sh_nodepools.yaml
@@ -1,0 +1,1094 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  name: nodepools.karpenter.sh
+spec:
+  group: karpenter.sh
+  names:
+    categories:
+      - karpenter
+    kind: NodePool
+    listKind: NodePoolList
+    plural: nodepools
+    singular: nodepool
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.template.spec.nodeClassRef.name
+          name: NodeClass
+          type: string
+        - jsonPath: .status.resources.nodes
+          name: Nodes
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.weight
+          name: Weight
+          priority: 1
+          type: integer
+        - jsonPath: .status.resources.cpu
+          name: CPU
+          priority: 1
+          type: string
+        - jsonPath: .status.resources.memory
+          name: Memory
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: NodePool is the Schema for the NodePools API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                NodePoolSpec is the top level nodepool specification. Nodepools
+                launch nodes in response to pods that are unschedulable. A single nodepool
+                is capable of managing a diverse set of nodes. Node properties are determined
+                from a combination of nodepool and pod scheduling constraints.
+              properties:
+                disruption:
+                  description: Disruption contains the parameters that relate to Karpenter's disruption logic
+                  properties:
+                    budgets:
+                      default:
+                        - nodes: 10%
+                      description: |-
+                        Budgets is a list of Budgets.
+                        If there are multiple active budgets, Karpenter uses
+                        the most restrictive value. If left undefined,
+                        this will default to one budget with a value to 10%.
+                      items:
+                        description: |-
+                          Budget defines when Karpenter will restrict the
+                          number of Node Claims that can be terminating simultaneously.
+                        properties:
+                          duration:
+                            description: |-
+                              Duration determines how long a Budget is active since each Schedule hit.
+                              Only minutes and hours are accepted, as cron does not work in seconds.
+                              If omitted, the budget is always active.
+                              This is required if Schedule is set.
+                              This regex has an optional 0s at the end since the duration.String() always adds
+                              a 0s at the end.
+                            pattern: ^((([0-9]+(h|m))|([0-9]+h[0-9]+m))(0s)?)$
+                            type: string
+                          nodes:
+                            default: 10%
+                            description: |-
+                              Nodes dictates the maximum number of NodeClaims owned by this NodePool
+                              that can be terminating at once. This is calculated by counting nodes that
+                              have a deletion timestamp set, or are actively being deleted by Karpenter.
+                              This field is required when specifying a budget.
+                              This cannot be of type intstr.IntOrString since kubebuilder doesn't support pattern
+                              checking for int nodes for IntOrString nodes.
+                              Ref: https://github.com/kubernetes-sigs/controller-tools/blob/55efe4be40394a288216dab63156b0a64fb82929/pkg/crd/markers/validation.go#L379-L388
+                            pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
+                            type: string
+                          reasons:
+                            description: |-
+                              Reasons is a list of disruption methods that this budget applies to. If Reasons is not set, this budget applies to all methods.
+                              Otherwise, this will apply to each reason defined.
+                              allowed reasons are Underutilized, Empty, and Drifted.
+                            items:
+                              description: DisruptionReason defines valid reasons for disruption budgets.
+                              enum:
+                                - Underutilized
+                                - Empty
+                                - Drifted
+                              type: string
+                            type: array
+                          schedule:
+                            description: |-
+                              Schedule specifies when a budget begins being active, following
+                              the upstream cronjob syntax. If omitted, the budget is always active.
+                              Timezones are not supported.
+                              This field is required if Duration is set.
+                            pattern: ^(@(annually|yearly|monthly|weekly|daily|midnight|hourly))|((.+)\s(.+)\s(.+)\s(.+)\s(.+))$
+                            type: string
+                        required:
+                          - nodes
+                        type: object
+                      maxItems: 50
+                      type: array
+                      x-kubernetes-validations:
+                        - message: '''schedule'' must be set with ''duration'''
+                          rule: self.all(x, has(x.schedule) == has(x.duration))
+                    consolidateAfter:
+                      description: |-
+                        ConsolidateAfter is the duration the controller will wait
+                        before attempting to terminate nodes that are underutilized.
+                        Refer to ConsolidationPolicy for how underutilization is considered.
+                      pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                      type: string
+                    consolidationPolicy:
+                      default: WhenEmptyOrUnderutilized
+                      description: |-
+                        ConsolidationPolicy describes which nodes Karpenter can disrupt through its consolidation
+                        algorithm. This policy defaults to "WhenEmptyOrUnderutilized" if not specified
+                      enum:
+                        - WhenEmpty
+                        - WhenEmptyOrUnderutilized
+                      type: string
+                  required:
+                    - consolidateAfter
+                  type: object
+                limits:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Limits define a set of bounds for provisioning capacity.
+                  type: object
+                template:
+                  description: |-
+                    Template contains the template of possibilities for the provisioning logic to launch a NodeClaim with.
+                    NodeClaims launched from this NodePool will often be further constrained than the template specifies.
+                  properties:
+                    metadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Annotations is an unstructured key value map stored with a resource that may be
+                            set by external tools to store and retrieve arbitrary metadata. They are not
+                            queryable and should be preserved when modifying objects.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                            maxLength: 63
+                            pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                          description: |-
+                            Map of string keys and values that can be used to organize and categorize
+                            (scope and select) objects. May match selectors of replication controllers
+                            and services.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
+                          type: object
+                          maxProperties: 100
+                          x-kubernetes-validations:
+                            - message: label domain "kubernetes.io" is restricted
+                              rule: self.all(x, x in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region",  "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || x.find("^([^/]+)").endsWith("node.kubernetes.io") || x.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !x.find("^([^/]+)").endsWith("kubernetes.io"))
+                            - message: label domain "k8s.io" is restricted
+                              rule: self.all(x, x.find("^([^/]+)").endsWith("kops.k8s.io") || !x.find("^([^/]+)").endsWith("k8s.io"))
+                            - message: label domain "karpenter.sh" is restricted
+                              rule: self.all(x, x in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !x.find("^([^/]+)").endsWith("karpenter.sh"))
+                            - message: label "karpenter.sh/nodepool" is restricted
+                              rule: self.all(x, x != "karpenter.sh/nodepool")
+                            - message: label "kubernetes.io/hostname" is restricted
+                              rule: self.all(x, x != "kubernetes.io/hostname")
+                            - message: label domain "karpenter.k8s.aws" is restricted
+                              rule: self.all(x, x in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !x.find("^([^/]+)").endsWith("karpenter.k8s.aws"))
+                      type: object
+                    spec:
+                      description: |-
+                        NodeClaimTemplateSpec describes the desired state of the NodeClaim in the Nodepool
+                        NodeClaimTemplateSpec is used in the NodePool's NodeClaimTemplate, with the resource requests omitted since
+                        users are not able to set resource requests in the NodePool.
+                      properties:
+                        expireAfter:
+                          default: 720h
+                          description: |-
+                            ExpireAfter is the duration the controller will wait
+                            before terminating a node, measured from when the node is created. This
+                            is useful to implement features like eventually consistent node upgrade,
+                            memory leak protection, and disruption testing.
+                          pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                          type: string
+                        nodeClassRef:
+                          description: NodeClassRef is a reference to an object that defines provider specific configuration
+                          properties:
+                            group:
+                              description: API version of the referent
+                              pattern: ^[^/]*$
+                              type: string
+                            kind:
+                              description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                              type: string
+                            name:
+                              description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                          required:
+                            - group
+                            - kind
+                            - name
+                          type: object
+                        requirements:
+                          description: Requirements are layered with GetLabels and applied to every node.
+                          items:
+                            description: |-
+                              A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                              and minValues that represent the requirement to have at least that many values.
+                            properties:
+                              key:
+                                description: The label key that the selector applies to.
+                                type: string
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                                x-kubernetes-validations:
+                                  - message: label domain "kubernetes.io" is restricted
+                                    rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                                  - message: label domain "k8s.io" is restricted
+                                    rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                                  - message: label domain "karpenter.sh" is restricted
+                                    rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                                  - message: label "karpenter.sh/nodepool" is restricted
+                                    rule: self != "karpenter.sh/nodepool"
+                                  - message: label "kubernetes.io/hostname" is restricted
+                                    rule: self != "kubernetes.io/hostname"
+                                  - message: label domain "karpenter.k8s.aws" is restricted
+                                    rule: self in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                              minValues:
+                                description: |-
+                                  This field is ALPHA and can be dropped or replaced at any time
+                                  MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                                maximum: 50
+                                minimum: 1
+                                type: integer
+                              operator:
+                                description: |-
+                                  Represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                type: string
+                                enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  - Gt
+                                  - Lt
+                              values:
+                                description: |-
+                                  An array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                  array must have a single element, which will be interpreted as an integer.
+                                  This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          maxItems: 100
+                          type: array
+                          x-kubernetes-validations:
+                            - message: requirements with operator 'In' must have a value defined
+                              rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                            - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                              rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                            - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                              rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                        startupTaints:
+                          description: |-
+                            StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                            within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                            daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                            purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        taints:
+                          description: Taints will be applied to the NodeClaim's node.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        terminationGracePeriod:
+                          description: |-
+                            TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
+
+
+                            Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
+
+
+                            This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
+                            When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
+
+
+                            Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
+                            If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
+                            that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
+
+
+                            The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
+                            If left undefined, the controller will wait indefinitely for pods to be drained.
+                          pattern: ^([0-9]+(s|m|h))+$
+                          type: string
+                      required:
+                        - nodeClassRef
+                        - requirements
+                      type: object
+                  required:
+                    - spec
+                  type: object
+                weight:
+                  description: |-
+                    Weight is the priority given to the nodepool during scheduling. A higher
+                    numerical weight indicates that this nodepool will be ordered
+                    ahead of other nodepools with lower weights. A nodepool with no weight
+                    will be treated as if it is a nodepool with a weight of 0.
+                  format: int32
+                  maximum: 100
+                  minimum: 1
+                  type: integer
+              required:
+                - template
+              type: object
+            status:
+              description: NodePoolStatus defines the observed state of NodePool
+              properties:
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: |-
+                          type of condition in CamelCase or in foo.example.com/CamelCase.
+                          ---
+                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                          useful (see .node.status.conditions), the ability to deconflict is important.
+                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                resources:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Resources is the list of resources that have been provisioned.
+                  type: object
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .spec.template.spec.nodeClassRef.name
+          name: NodeClass
+          type: string
+        - jsonPath: .spec.weight
+          name: Weight
+          priority: 1
+          type: string
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: NodePool is the Schema for the NodePools API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                NodePoolSpec is the top level nodepool specification. Nodepools
+                launch nodes in response to pods that are unschedulable. A single nodepool
+                is capable of managing a diverse set of nodes. Node properties are determined
+                from a combination of nodepool and pod scheduling constraints.
+              properties:
+                disruption:
+                  default:
+                    consolidationPolicy: WhenUnderutilized
+                    expireAfter: 720h
+                  description: Disruption contains the parameters that relate to Karpenter's disruption logic
+                  properties:
+                    budgets:
+                      default:
+                        - nodes: 10%
+                      description: |-
+                        Budgets is a list of Budgets.
+                        If there are multiple active budgets, Karpenter uses
+                        the most restrictive value. If left undefined,
+                        this will default to one budget with a value to 10%.
+                      items:
+                        description: |-
+                          Budget defines when Karpenter will restrict the
+                          number of Node Claims that can be terminating simultaneously.
+                        properties:
+                          duration:
+                            description: |-
+                              Duration determines how long a Budget is active since each Schedule hit.
+                              Only minutes and hours are accepted, as cron does not work in seconds.
+                              If omitted, the budget is always active.
+                              This is required if Schedule is set.
+                              This regex has an optional 0s at the end since the duration.String() always adds
+                              a 0s at the end.
+                            pattern: ^((([0-9]+(h|m))|([0-9]+h[0-9]+m))(0s)?)$
+                            type: string
+                          nodes:
+                            default: 10%
+                            description: |-
+                              Nodes dictates the maximum number of NodeClaims owned by this NodePool
+                              that can be terminating at once. This is calculated by counting nodes that
+                              have a deletion timestamp set, or are actively being deleted by Karpenter.
+                              This field is required when specifying a budget.
+                              This cannot be of type intstr.IntOrString since kubebuilder doesn't support pattern
+                              checking for int nodes for IntOrString nodes.
+                              Ref: https://github.com/kubernetes-sigs/controller-tools/blob/55efe4be40394a288216dab63156b0a64fb82929/pkg/crd/markers/validation.go#L379-L388
+                            pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
+                            type: string
+                          schedule:
+                            description: |-
+                              Schedule specifies when a budget begins being active, following
+                              the upstream cronjob syntax. If omitted, the budget is always active.
+                              Timezones are not supported.
+                              This field is required if Duration is set.
+                            pattern: ^(@(annually|yearly|monthly|weekly|daily|midnight|hourly))|((.+)\s(.+)\s(.+)\s(.+)\s(.+))$
+                            type: string
+                        required:
+                          - nodes
+                        type: object
+                      maxItems: 50
+                      type: array
+                      x-kubernetes-validations:
+                        - message: '''schedule'' must be set with ''duration'''
+                          rule: self.all(x, has(x.schedule) == has(x.duration))
+                    consolidateAfter:
+                      description: |-
+                        ConsolidateAfter is the duration the controller will wait
+                        before attempting to terminate nodes that are underutilized.
+                        Refer to ConsolidationPolicy for how underutilization is considered.
+                      pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                      type: string
+                    consolidationPolicy:
+                      default: WhenUnderutilized
+                      description: |-
+                        ConsolidationPolicy describes which nodes Karpenter can disrupt through its consolidation
+                        algorithm. This policy defaults to "WhenUnderutilized" if not specified
+                      enum:
+                        - WhenEmpty
+                        - WhenUnderutilized
+                      type: string
+                    expireAfter:
+                      default: 720h
+                      description: |-
+                        ExpireAfter is the duration the controller will wait
+                        before terminating a node, measured from when the node is created. This
+                        is useful to implement features like eventually consistent node upgrade,
+                        memory leak protection, and disruption testing.
+                      pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                      type: string
+                  type: object
+                  x-kubernetes-validations:
+                    - message: consolidateAfter cannot be combined with consolidationPolicy=WhenUnderutilized
+                      rule: 'has(self.consolidateAfter) ? self.consolidationPolicy != ''WhenUnderutilized'' || self.consolidateAfter == ''Never'' : true'
+                    - message: consolidateAfter must be specified with consolidationPolicy=WhenEmpty
+                      rule: 'self.consolidationPolicy == ''WhenEmpty'' ? has(self.consolidateAfter) : true'
+                limits:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Limits define a set of bounds for provisioning capacity.
+                  type: object
+                template:
+                  description: |-
+                    Template contains the template of possibilities for the provisioning logic to launch a NodeClaim with.
+                    NodeClaims launched from this NodePool will often be further constrained than the template specifies.
+                  properties:
+                    metadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Annotations is an unstructured key value map stored with a resource that may be
+                            set by external tools to store and retrieve arbitrary metadata. They are not
+                            queryable and should be preserved when modifying objects.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                            maxLength: 63
+                            pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                          description: |-
+                            Map of string keys and values that can be used to organize and categorize
+                            (scope and select) objects. May match selectors of replication controllers
+                            and services.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
+                          type: object
+                          maxProperties: 100
+                          x-kubernetes-validations:
+                            - message: label domain "kubernetes.io" is restricted
+                              rule: self.all(x, x in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region",  "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || x.find("^([^/]+)").endsWith("node.kubernetes.io") || x.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !x.find("^([^/]+)").endsWith("kubernetes.io"))
+                            - message: label domain "k8s.io" is restricted
+                              rule: self.all(x, x.find("^([^/]+)").endsWith("kops.k8s.io") || !x.find("^([^/]+)").endsWith("k8s.io"))
+                            - message: label domain "karpenter.sh" is restricted
+                              rule: self.all(x, x in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !x.find("^([^/]+)").endsWith("karpenter.sh"))
+                            - message: label "karpenter.sh/nodepool" is restricted
+                              rule: self.all(x, x != "karpenter.sh/nodepool")
+                            - message: label "kubernetes.io/hostname" is restricted
+                              rule: self.all(x, x != "kubernetes.io/hostname")
+                            - message: label domain "karpenter.k8s.aws" is restricted
+                              rule: self.all(x, x in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !x.find("^([^/]+)").endsWith("karpenter.k8s.aws"))
+                      type: object
+                    spec:
+                      description: NodeClaimSpec describes the desired state of the NodeClaim
+                      properties:
+                        kubelet:
+                          description: |-
+                            Kubelet defines args to be used when configuring kubelet on provisioned nodes.
+                            They are a subset of the upstream types, recognizing not all options may be supported.
+                            Wherever possible, the types and names should reflect the upstream kubelet types.
+                          properties:
+                            clusterDNS:
+                              description: |-
+                                clusterDNS is a list of IP addresses for the cluster DNS server.
+                                Note that not all providers may use all addresses.
+                              items:
+                                type: string
+                              type: array
+                            cpuCFSQuota:
+                              description: CPUCFSQuota enables CPU CFS quota enforcement for containers that specify CPU limits.
+                              type: boolean
+                            evictionHard:
+                              additionalProperties:
+                                type: string
+                                pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                              description: EvictionHard is the map of signal names to quantities that define hard eviction thresholds
+                              type: object
+                              x-kubernetes-validations:
+                                - message: valid keys for evictionHard are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                                  rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                            evictionMaxPodGracePeriod:
+                              description: |-
+                                EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in
+                                response to soft eviction thresholds being met.
+                              format: int32
+                              type: integer
+                            evictionSoft:
+                              additionalProperties:
+                                type: string
+                                pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                              description: EvictionSoft is the map of signal names to quantities that define soft eviction thresholds
+                              type: object
+                              x-kubernetes-validations:
+                                - message: valid keys for evictionSoft are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                                  rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                            evictionSoftGracePeriod:
+                              additionalProperties:
+                                type: string
+                              description: EvictionSoftGracePeriod is the map of signal names to quantities that define grace periods for each eviction signal
+                              type: object
+                              x-kubernetes-validations:
+                                - message: valid keys for evictionSoftGracePeriod are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                                  rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                            imageGCHighThresholdPercent:
+                              description: |-
+                                ImageGCHighThresholdPercent is the percent of disk usage after which image
+                                garbage collection is always run. The percent is calculated by dividing this
+                                field value by 100, so this field must be between 0 and 100, inclusive.
+                                When specified, the value must be greater than ImageGCLowThresholdPercent.
+                              format: int32
+                              maximum: 100
+                              minimum: 0
+                              type: integer
+                            imageGCLowThresholdPercent:
+                              description: |-
+                                ImageGCLowThresholdPercent is the percent of disk usage before which image
+                                garbage collection is never run. Lowest disk usage to garbage collect to.
+                                The percent is calculated by dividing this field value by 100,
+                                so the field value must be between 0 and 100, inclusive.
+                                When specified, the value must be less than imageGCHighThresholdPercent
+                              format: int32
+                              maximum: 100
+                              minimum: 0
+                              type: integer
+                            kubeReserved:
+                              additionalProperties:
+                                type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              description: KubeReserved contains resources reserved for Kubernetes system components.
+                              type: object
+                              x-kubernetes-validations:
+                                - message: valid keys for kubeReserved are ['cpu','memory','ephemeral-storage','pid']
+                                  rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                                - message: kubeReserved value cannot be a negative resource quantity
+                                  rule: self.all(x, !self[x].startsWith('-'))
+                            maxPods:
+                              description: |-
+                                MaxPods is an override for the maximum number of pods that can run on
+                                a worker node instance.
+                              format: int32
+                              minimum: 0
+                              type: integer
+                            podsPerCore:
+                              description: |-
+                                PodsPerCore is an override for the number of pods that can run on a worker node
+                                instance based on the number of cpu cores. This value cannot exceed MaxPods, so, if
+                                MaxPods is a lower value, that value will be used.
+                              format: int32
+                              minimum: 0
+                              type: integer
+                            systemReserved:
+                              additionalProperties:
+                                type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              description: SystemReserved contains resources reserved for OS system daemons and kernel memory.
+                              type: object
+                              x-kubernetes-validations:
+                                - message: valid keys for systemReserved are ['cpu','memory','ephemeral-storage','pid']
+                                  rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                                - message: systemReserved value cannot be a negative resource quantity
+                                  rule: self.all(x, !self[x].startsWith('-'))
+                          type: object
+                          x-kubernetes-validations:
+                            - message: imageGCHighThresholdPercent must be greater than imageGCLowThresholdPercent
+                              rule: 'has(self.imageGCHighThresholdPercent) && has(self.imageGCLowThresholdPercent) ?  self.imageGCHighThresholdPercent > self.imageGCLowThresholdPercent  : true'
+                            - message: evictionSoft OwnerKey does not have a matching evictionSoftGracePeriod
+                              rule: has(self.evictionSoft) ? self.evictionSoft.all(e, (e in self.evictionSoftGracePeriod)):true
+                            - message: evictionSoftGracePeriod OwnerKey does not have a matching evictionSoft
+                              rule: has(self.evictionSoftGracePeriod) ? self.evictionSoftGracePeriod.all(e, (e in self.evictionSoft)):true
+                        nodeClassRef:
+                          description: NodeClassRef is a reference to an object that defines provider specific configuration
+                          properties:
+                            apiVersion:
+                              description: API version of the referent
+                              type: string
+                            kind:
+                              description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                              type: string
+                            name:
+                              description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        requirements:
+                          description: Requirements are layered with GetLabels and applied to every node.
+                          items:
+                            description: |-
+                              A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                              and minValues that represent the requirement to have at least that many values.
+                            properties:
+                              key:
+                                description: The label key that the selector applies to.
+                                type: string
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                                x-kubernetes-validations:
+                                  - message: label domain "kubernetes.io" is restricted
+                                    rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                                  - message: label domain "k8s.io" is restricted
+                                    rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                                  - message: label domain "karpenter.sh" is restricted
+                                    rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                                  - message: label "karpenter.sh/nodepool" is restricted
+                                    rule: self != "karpenter.sh/nodepool"
+                                  - message: label "kubernetes.io/hostname" is restricted
+                                    rule: self != "kubernetes.io/hostname"
+                                  - message: label domain "karpenter.k8s.aws" is restricted
+                                    rule: self in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                              minValues:
+                                description: |-
+                                  This field is ALPHA and can be dropped or replaced at any time
+                                  MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                                maximum: 50
+                                minimum: 1
+                                type: integer
+                              operator:
+                                description: |-
+                                  Represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                type: string
+                                enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  - Gt
+                                  - Lt
+                              values:
+                                description: |-
+                                  An array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                  array must have a single element, which will be interpreted as an integer.
+                                  This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          maxItems: 100
+                          type: array
+                          x-kubernetes-validations:
+                            - message: requirements with operator 'In' must have a value defined
+                              rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                            - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                              rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                            - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                              rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                        resources:
+                          description: Resources models the resource requirements for the NodeClaim to launch
+                          properties:
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: Requests describes the minimum required resources for the NodeClaim to launch
+                              type: object
+                          type: object
+                          maxProperties: 0
+                        startupTaints:
+                          description: |-
+                            StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                            within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                            daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                            purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        taints:
+                          description: Taints will be applied to the NodeClaim's node.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                      required:
+                        - nodeClassRef
+                        - requirements
+                      type: object
+                  required:
+                    - spec
+                  type: object
+                weight:
+                  description: |-
+                    Weight is the priority given to the nodepool during scheduling. A higher
+                    numerical weight indicates that this nodepool will be ordered
+                    ahead of other nodepools with lower weights. A nodepool with no weight
+                    will be treated as if it is a nodepool with a weight of 0.
+                  format: int32
+                  maximum: 100
+                  minimum: 1
+                  type: integer
+              required:
+                - template
+              type: object
+            status:
+              description: NodePoolStatus defines the observed state of NodePool
+              properties:
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: |-
+                          type of condition in CamelCase or in foo.example.com/CamelCase.
+                          ---
+                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                          useful (see .node.status.conditions), the ability to deconflict is important.
+                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                resources:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Resources is the list of resources that have been provisioned.
+                  type: object
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+        - v1
+      clientConfig:
+        service:
+          name: karpenter
+          namespace: kube-system
+          port: 8443

--- a/content/projects/karpenter/v1.0.1/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/content/projects/karpenter/v1.0.1/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -1,0 +1,1346 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  name: ec2nodeclasses.karpenter.k8s.aws
+spec:
+  group: karpenter.k8s.aws
+  names:
+    categories:
+      - karpenter
+    kind: EC2NodeClass
+    listKind: EC2NodeClassList
+    plural: ec2nodeclasses
+    shortNames:
+      - ec2nc
+      - ec2ncs
+    singular: ec2nodeclass
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.role
+          name: Role
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: EC2NodeClass is the Schema for the EC2NodeClass API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                EC2NodeClassSpec is the top level specification for the AWS Karpenter Provider.
+                This will contain configuration necessary to launch instances in AWS.
+              properties:
+                amiFamily:
+                  description: |-
+                    AMIFamily dictates the UserData format and default BlockDeviceMappings used when generating launch templates.
+                    This field is optional when using an alias amiSelectorTerm, and the value will be inferred from the alias'
+                    family. When an alias is specified, this field may only be set to its corresponding family or 'Custom'. If no
+                    alias is specified, this field is required.
+                    NOTE: We ignore the AMIFamily for hashing here because we hash the AMIFamily dynamically by using the alias using
+                    the AMIFamily() helper function
+                  enum:
+                    - AL2
+                    - AL2023
+                    - Bottlerocket
+                    - Custom
+                    - Windows2019
+                    - Windows2022
+                  type: string
+                amiSelectorTerms:
+                  description: AMISelectorTerms is a list of or ami selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      AMISelectorTerm defines selection logic for an ami used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      alias:
+                        description: |-
+                          Alias specifies which EKS optimized AMI to select.
+                          Each alias consists of a family and an AMI version, specified as "family@version".
+                          Valid families include: al2, al2023, bottlerocket, windows2019, and windows2022.
+                          The version can either be pinned to a specific AMI release, with that AMIs version format (ex: "al2023@v20240625" or "bottlerocket@v1.10.0").
+                          The version can also be set to "latest" for any family. Setting the version to latest will result in drift when a new AMI is released. This is **not** recommended for production environments.
+                          Note: The Windows families do **not** support version pinning, and only latest may be used.
+                        maxLength: 30
+                        type: string
+                        x-kubernetes-validations:
+                          - message: '''alias'' is improperly formatted, must match the format ''family@version'''
+                            rule: self.matches('^[a-zA-Z0-9]+@.+$')
+                          - message: 'family is not supported, must be one of the following: ''al2'', ''al2023'', ''bottlerocket'', ''windows2019'', ''windows2022'''
+                            rule: self.split('@')[0] in ['al2','al2023','bottlerocket','windows2019','windows2022']
+                          - message: windows families may only specify version 'latest'
+                            rule: 'self.split(''@'')[0] in [''windows2019'',''windows2022''] ? self.split(''@'')[1] == ''latest'' : true'
+                      id:
+                        description: ID is the ami id in EC2
+                        pattern: ami-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the ami name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      owner:
+                        description: |-
+                          Owner is the owner for the ami.
+                          You can specify a combination of AWS account IDs, "self", "amazon", and "aws-marketplace"
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  minItems: 1
+                  type: array
+                  x-kubernetes-validations:
+                    - message: expected at least one, got none, ['tags', 'id', 'name', 'alias']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name) || has(x.alias))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.exists(x, has(x.id) && (has(x.alias) || has(x.tags) || has(x.name) || has(x.owner)))'
+                    - message: '''alias'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.exists(x, has(x.alias) && (has(x.id) || has(x.tags) || has(x.name) || has(x.owner)))'
+                    - message: '''alias'' is mutually exclusive, cannot be set with a combination of other amiSelectorTerms'
+                      rule: '!(self.exists(x, has(x.alias)) && self.size() != 1)'
+                associatePublicIPAddress:
+                  description: AssociatePublicIPAddress controls if public IP addresses are assigned to instances that are launched with the nodeclass.
+                  type: boolean
+                blockDeviceMappings:
+                  description: BlockDeviceMappings to be applied to provisioned nodes.
+                  items:
+                    properties:
+                      deviceName:
+                        description: The device name (for example, /dev/sdh or xvdh).
+                        type: string
+                      ebs:
+                        description: EBS contains parameters used to automatically set up EBS volumes when an instance is launched.
+                        properties:
+                          deleteOnTermination:
+                            description: DeleteOnTermination indicates whether the EBS volume is deleted on instance termination.
+                            type: boolean
+                          encrypted:
+                            description: |-
+                              Encrypted indicates whether the EBS volume is encrypted. Encrypted volumes can only
+                              be attached to instances that support Amazon EBS encryption. If you are creating
+                              a volume from a snapshot, you can't specify an encryption value.
+                            type: boolean
+                          iops:
+                            description: |-
+                              IOPS is the number of I/O operations per second (IOPS). For gp3, io1, and io2 volumes,
+                              this represents the number of IOPS that are provisioned for the volume. For
+                              gp2 volumes, this represents the baseline performance of the volume and the
+                              rate at which the volume accumulates I/O credits for bursting.
+
+
+                              The following are the supported values for each volume type:
+
+
+                                 * gp3: 3,000-16,000 IOPS
+
+
+                                 * io1: 100-64,000 IOPS
+
+
+                                 * io2: 100-64,000 IOPS
+
+
+                              For io1 and io2 volumes, we guarantee 64,000 IOPS only for Instances built
+                              on the Nitro System (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances).
+                              Other instance families guarantee performance up to 32,000 IOPS.
+
+
+                              This parameter is supported for io1, io2, and gp3 volumes only. This parameter
+                              is not supported for gp2, st1, sc1, or standard volumes.
+                            format: int64
+                            type: integer
+                          kmsKeyID:
+                            description: KMSKeyID (ARN) of the symmetric Key Management Service (KMS) CMK used for encryption.
+                            type: string
+                          snapshotID:
+                            description: SnapshotID is the ID of an EBS snapshot
+                            type: string
+                          throughput:
+                            description: |-
+                              Throughput to provision for a gp3 volume, with a maximum of 1,000 MiB/s.
+                              Valid Range: Minimum value of 125. Maximum value of 1000.
+                            format: int64
+                            type: integer
+                          volumeSize:
+                            description: |-
+                              VolumeSize in `Gi`, `G`, `Ti`, or `T`. You must specify either a snapshot ID or
+                              a volume size. The following are the supported volumes sizes for each volume
+                              type:
+
+
+                                 * gp2 and gp3: 1-16,384
+
+
+                                 * io1 and io2: 4-16,384
+
+
+                                 * st1 and sc1: 125-16,384
+
+
+                                 * standard: 1-1,024
+                            pattern: ^((?:[1-9][0-9]{0,3}|[1-4][0-9]{4}|[5][0-8][0-9]{3}|59000)Gi|(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|[6][0-3][0-9]{3}|64000)G|([1-9]||[1-5][0-7]|58)Ti|([1-9]||[1-5][0-9]|6[0-3]|64)T)$
+                            type: string
+                          volumeType:
+                            description: |-
+                              VolumeType of the block device.
+                              For more information, see Amazon EBS volume types (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html)
+                              in the Amazon Elastic Compute Cloud User Guide.
+                            enum:
+                              - standard
+                              - io1
+                              - io2
+                              - gp2
+                              - sc1
+                              - st1
+                              - gp3
+                            type: string
+                        type: object
+                        x-kubernetes-validations:
+                          - message: snapshotID or volumeSize must be defined
+                            rule: has(self.snapshotID) || has(self.volumeSize)
+                      rootVolume:
+                        description: |-
+                          RootVolume is a flag indicating if this device is mounted as kubelet root dir. You can
+                          configure at most one root volume in BlockDeviceMappings.
+                        type: boolean
+                    type: object
+                  maxItems: 50
+                  type: array
+                  x-kubernetes-validations:
+                    - message: must have only one blockDeviceMappings with rootVolume
+                      rule: self.filter(x, has(x.rootVolume)?x.rootVolume==true:false).size() <= 1
+                context:
+                  description: |-
+                    Context is a Reserved field in EC2 APIs
+                    https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet.html
+                  type: string
+                detailedMonitoring:
+                  description: DetailedMonitoring controls if detailed monitoring is enabled for instances that are launched
+                  type: boolean
+                instanceProfile:
+                  description: |-
+                    InstanceProfile is the AWS entity that instances use.
+                    This field is mutually exclusive from role.
+                    The instance profile should already have a role assigned to it that Karpenter
+                     has PassRole permission on for instance launch using this instanceProfile to succeed.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: instanceProfile cannot be empty
+                      rule: self != ''
+                instanceStorePolicy:
+                  description: InstanceStorePolicy specifies how to handle instance-store disks.
+                  enum:
+                    - RAID0
+                  type: string
+                kubelet:
+                  description: |-
+                    Kubelet defines args to be used when configuring kubelet on provisioned nodes.
+                    They are a subset of the upstream types, recognizing not all options may be supported.
+                    Wherever possible, the types and names should reflect the upstream kubelet types.
+                  properties:
+                    clusterDNS:
+                      description: |-
+                        clusterDNS is a list of IP addresses for the cluster DNS server.
+                        Note that not all providers may use all addresses.
+                      items:
+                        type: string
+                      type: array
+                    cpuCFSQuota:
+                      description: CPUCFSQuota enables CPU CFS quota enforcement for containers that specify CPU limits.
+                      type: boolean
+                    evictionHard:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionHard is the map of signal names to quantities that define hard eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionHard are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionMaxPodGracePeriod:
+                      description: |-
+                        EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in
+                        response to soft eviction thresholds being met.
+                      format: int32
+                      type: integer
+                    evictionSoft:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionSoft is the map of signal names to quantities that define soft eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoft are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionSoftGracePeriod:
+                      additionalProperties:
+                        type: string
+                      description: EvictionSoftGracePeriod is the map of signal names to quantities that define grace periods for each eviction signal
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoftGracePeriod are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    imageGCHighThresholdPercent:
+                      description: |-
+                        ImageGCHighThresholdPercent is the percent of disk usage after which image
+                        garbage collection is always run. The percent is calculated by dividing this
+                        field value by 100, so this field must be between 0 and 100, inclusive.
+                        When specified, the value must be greater than ImageGCLowThresholdPercent.
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    imageGCLowThresholdPercent:
+                      description: |-
+                        ImageGCLowThresholdPercent is the percent of disk usage before which image
+                        garbage collection is never run. Lowest disk usage to garbage collect to.
+                        The percent is calculated by dividing this field value by 100,
+                        so the field value must be between 0 and 100, inclusive.
+                        When specified, the value must be less than imageGCHighThresholdPercent
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    kubeReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: KubeReserved contains resources reserved for Kubernetes system components.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for kubeReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: kubeReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                    maxPods:
+                      description: |-
+                        MaxPods is an override for the maximum number of pods that can run on
+                        a worker node instance.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    podsPerCore:
+                      description: |-
+                        PodsPerCore is an override for the number of pods that can run on a worker node
+                        instance based on the number of cpu cores. This value cannot exceed MaxPods, so, if
+                        MaxPods is a lower value, that value will be used.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    systemReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: SystemReserved contains resources reserved for OS system daemons and kernel memory.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for systemReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: systemReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                  type: object
+                  x-kubernetes-validations:
+                    - message: imageGCHighThresholdPercent must be greater than imageGCLowThresholdPercent
+                      rule: 'has(self.imageGCHighThresholdPercent) && has(self.imageGCLowThresholdPercent) ?  self.imageGCHighThresholdPercent > self.imageGCLowThresholdPercent  : true'
+                    - message: evictionSoft OwnerKey does not have a matching evictionSoftGracePeriod
+                      rule: has(self.evictionSoft) ? self.evictionSoft.all(e, (e in self.evictionSoftGracePeriod)):true
+                    - message: evictionSoftGracePeriod OwnerKey does not have a matching evictionSoft
+                      rule: has(self.evictionSoftGracePeriod) ? self.evictionSoftGracePeriod.all(e, (e in self.evictionSoft)):true
+                metadataOptions:
+                  default:
+                    httpEndpoint: enabled
+                    httpProtocolIPv6: disabled
+                    httpPutResponseHopLimit: 1
+                    httpTokens: required
+                  description: |-
+                    MetadataOptions for the generated launch template of provisioned nodes.
+
+
+                    This specifies the exposure of the Instance Metadata Service to
+                    provisioned EC2 nodes. For more information,
+                    see Instance Metadata and User Data
+                    (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
+                    in the Amazon Elastic Compute Cloud User Guide.
+
+
+                    Refer to recommended, security best practices
+                    (https://aws.github.io/aws-eks-best-practices/security/docs/iam/#restrict-access-to-the-instance-profile-assigned-to-the-worker-node)
+                    for limiting exposure of Instance Metadata and User Data to pods.
+                    If omitted, defaults to httpEndpoint enabled, with httpProtocolIPv6
+                    disabled, with httpPutResponseLimit of 1, and with httpTokens
+                    required.
+                  properties:
+                    httpEndpoint:
+                      default: enabled
+                      description: |-
+                        HTTPEndpoint enables or disables the HTTP metadata endpoint on provisioned
+                        nodes. If metadata options is non-nil, but this parameter is not specified,
+                        the default state is "enabled".
+
+
+                        If you specify a value of "disabled", instance metadata will not be accessible
+                        on the node.
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpProtocolIPv6:
+                      default: disabled
+                      description: |-
+                        HTTPProtocolIPv6 enables or disables the IPv6 endpoint for the instance metadata
+                        service on provisioned nodes. If metadata options is non-nil, but this parameter
+                        is not specified, the default state is "disabled".
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpPutResponseHopLimit:
+                      default: 1
+                      description: |-
+                        HTTPPutResponseHopLimit is the desired HTTP PUT response hop limit for
+                        instance metadata requests. The larger the number, the further instance
+                        metadata requests can travel. Possible values are integers from 1 to 64.
+                        If metadata options is non-nil, but this parameter is not specified, the
+                        default value is 1.
+                      format: int64
+                      maximum: 64
+                      minimum: 1
+                      type: integer
+                    httpTokens:
+                      default: required
+                      description: |-
+                        HTTPTokens determines the state of token usage for instance metadata
+                        requests. If metadata options is non-nil, but this parameter is not
+                        specified, the default state is "required".
+
+
+                        If the state is optional, one can choose to retrieve instance metadata with
+                        or without a signed token header on the request. If one retrieves the IAM
+                        role credentials without a token, the version 1.0 role credentials are
+                        returned. If one retrieves the IAM role credentials using a valid signed
+                        token, the version 2.0 role credentials are returned.
+
+
+                        If the state is "required", one must send a signed token header with any
+                        instance metadata retrieval requests. In this state, retrieving the IAM
+                        role credentials always returns the version 2.0 credentials; the version
+                        1.0 credentials are not available.
+                      enum:
+                        - required
+                        - optional
+                      type: string
+                  type: object
+                role:
+                  description: |-
+                    Role is the AWS identity that nodes use. This field is immutable.
+                    This field is mutually exclusive from instanceProfile.
+                    Marking this field as immutable avoids concerns around terminating managed instance profiles from running instances.
+                    This field may be made mutable in the future, assuming the correct garbage collection and drift handling is implemented
+                    for the old instance profiles on an update.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: role cannot be empty
+                      rule: self != ''
+                    - message: immutable field changed
+                      rule: self == oldSelf
+                securityGroupSelectorTerms:
+                  description: SecurityGroupSelectorTerms is a list of or security group selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SecurityGroupSelectorTerm defines selection logic for a security group used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the security group id in EC2
+                        pattern: sg-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the security group name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: securityGroupSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id', 'name']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && (has(x.tags) || has(x.name)))'
+                    - message: '''name'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.name) && (has(x.tags) || has(x.id)))'
+                subnetSelectorTerms:
+                  description: SubnetSelectorTerms is a list of or subnet selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SubnetSelectorTerm defines selection logic for a subnet used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the subnet id in EC2
+                        pattern: subnet-[0-9a-z]+
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: subnetSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id']
+                      rule: self.all(x, has(x.tags) || has(x.id))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in subnetSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && has(x.tags))'
+                tags:
+                  additionalProperties:
+                    type: string
+                  description: Tags to be applied on ec2 resources like instances and launch templates.
+                  type: object
+                  x-kubernetes-validations:
+                    - message: empty tag keys aren't supported
+                      rule: self.all(k, k != '')
+                    - message: tag contains a restricted tag matching eks:eks-cluster-name
+                      rule: self.all(k, k !='eks:eks-cluster-name')
+                    - message: tag contains a restricted tag matching kubernetes.io/cluster/
+                      rule: self.all(k, !k.startsWith('kubernetes.io/cluster') )
+                    - message: tag contains a restricted tag matching karpenter.sh/nodepool
+                      rule: self.all(k, k != 'karpenter.sh/nodepool')
+                    - message: tag contains a restricted tag matching karpenter.sh/nodeclaim
+                      rule: self.all(k, k !='karpenter.sh/nodeclaim')
+                    - message: tag contains a restricted tag matching karpenter.k8s.aws/ec2nodeclass
+                      rule: self.all(k, k !='karpenter.k8s.aws/ec2nodeclass')
+                userData:
+                  description: |-
+                    UserData to be applied to the provisioned nodes.
+                    It must be in the appropriate format based on the AMIFamily in use. Karpenter will merge certain fields into
+                    this UserData to ensure nodes are being provisioned with the correct configuration.
+                  type: string
+              required:
+                - amiSelectorTerms
+                - securityGroupSelectorTerms
+                - subnetSelectorTerms
+              type: object
+              x-kubernetes-validations:
+                - message: must specify exactly one of ['role', 'instanceProfile']
+                  rule: (has(self.role) && !has(self.instanceProfile)) || (!has(self.role) && has(self.instanceProfile))
+                - message: changing from 'instanceProfile' to 'role' is not supported. You must delete and recreate this node class if you want to change this.
+                  rule: (has(oldSelf.role) && has(self.role)) || (has(oldSelf.instanceProfile) && has(self.instanceProfile))
+                - message: if set, amiFamily must be 'AL2' or 'Custom' when using an AL2 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''al2'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''AL2'') : true)'
+                - message: if set, amiFamily must be 'AL2023' or 'Custom' when using an AL2023 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''al2023'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''AL2023'') : true)'
+                - message: if set, amiFamily must be 'Bottlerocket' or 'Custom' when using a Bottlerocket alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''bottlerocket'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Bottlerocket'') : true)'
+                - message: if set, amiFamily must be 'Windows2019' or 'Custom' when using a Windows2019 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''windows2019'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Windows2019'') : true)'
+                - message: if set, amiFamily must be 'Windows2022' or 'Custom' when using a Windows2022 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''windows2022'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Windows2022'') : true)'
+                - message: must specify amiFamily if amiSelectorTerms does not contain an alias
+                  rule: 'self.amiSelectorTerms.exists(x, has(x.alias)) ? true : has(self.amiFamily)'
+            status:
+              description: EC2NodeClassStatus contains the resolved state of the EC2NodeClass
+              properties:
+                amis:
+                  description: |-
+                    AMI contains the current AMI values that are available to the
+                    cluster under the AMI selectors.
+                  items:
+                    description: AMI contains resolved AMI selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the AMI
+                        type: string
+                      name:
+                        description: Name of the AMI
+                        type: string
+                      requirements:
+                        description: Requirements of the AMI to be utilized on an instance type
+                        items:
+                          description: |-
+                            A node selector requirement is a selector that contains values, a key, and an operator
+                            that relates the key and values.
+                          properties:
+                            key:
+                              description: The label key that the selector applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                Represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                              type: string
+                            values:
+                              description: |-
+                                An array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. If the operator is Gt or Lt, the values
+                                array must have a single element, which will be interpreted as an integer.
+                                This array is replaced during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                            - key
+                            - operator
+                          type: object
+                        type: array
+                    required:
+                      - id
+                      - requirements
+                    type: object
+                  type: array
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: |-
+                          type of condition in CamelCase or in foo.example.com/CamelCase.
+                          ---
+                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                          useful (see .node.status.conditions), the ability to deconflict is important.
+                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                instanceProfile:
+                  description: InstanceProfile contains the resolved instance profile for the role
+                  type: string
+                securityGroups:
+                  description: |-
+                    SecurityGroups contains the current Security Groups values that are available to the
+                    cluster under the SecurityGroups selectors.
+                  items:
+                    description: SecurityGroup contains resolved SecurityGroup selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the security group
+                        type: string
+                      name:
+                        description: Name of the security group
+                        type: string
+                    required:
+                      - id
+                    type: object
+                  type: array
+                subnets:
+                  description: |-
+                    Subnets contains the current Subnet values that are available to the
+                    cluster under the subnet selectors.
+                  items:
+                    description: Subnet contains resolved Subnet selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the subnet
+                        type: string
+                      zone:
+                        description: The associated availability zone
+                        type: string
+                      zoneID:
+                        description: The associated availability zone ID
+                        type: string
+                    required:
+                      - id
+                      - zone
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: EC2NodeClass is the Schema for the EC2NodeClass API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                EC2NodeClassSpec is the top level specification for the AWS Karpenter Provider.
+                This will contain configuration necessary to launch instances in AWS.
+              properties:
+                amiFamily:
+                  description: AMIFamily is the AMI family that instances use.
+                  enum:
+                    - AL2
+                    - AL2023
+                    - Bottlerocket
+                    - Ubuntu
+                    - Custom
+                    - Windows2019
+                    - Windows2022
+                  type: string
+                amiSelectorTerms:
+                  description: AMISelectorTerms is a list of or ami selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      AMISelectorTerm defines selection logic for an ami used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the ami id in EC2
+                        pattern: ami-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the ami name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      owner:
+                        description: |-
+                          Owner is the owner for the ami.
+                          You can specify a combination of AWS account IDs, "self", "amazon", and "aws-marketplace"
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: expected at least one, got none, ['tags', 'id', 'name']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && (has(x.tags) || has(x.name) || has(x.owner)))'
+                associatePublicIPAddress:
+                  description: AssociatePublicIPAddress controls if public IP addresses are assigned to instances that are launched with the nodeclass.
+                  type: boolean
+                blockDeviceMappings:
+                  description: BlockDeviceMappings to be applied to provisioned nodes.
+                  items:
+                    properties:
+                      deviceName:
+                        description: The device name (for example, /dev/sdh or xvdh).
+                        type: string
+                      ebs:
+                        description: EBS contains parameters used to automatically set up EBS volumes when an instance is launched.
+                        properties:
+                          deleteOnTermination:
+                            description: DeleteOnTermination indicates whether the EBS volume is deleted on instance termination.
+                            type: boolean
+                          encrypted:
+                            description: |-
+                              Encrypted indicates whether the EBS volume is encrypted. Encrypted volumes can only
+                              be attached to instances that support Amazon EBS encryption. If you are creating
+                              a volume from a snapshot, you can't specify an encryption value.
+                            type: boolean
+                          iops:
+                            description: |-
+                              IOPS is the number of I/O operations per second (IOPS). For gp3, io1, and io2 volumes,
+                              this represents the number of IOPS that are provisioned for the volume. For
+                              gp2 volumes, this represents the baseline performance of the volume and the
+                              rate at which the volume accumulates I/O credits for bursting.
+
+
+                              The following are the supported values for each volume type:
+
+
+                                 * gp3: 3,000-16,000 IOPS
+
+
+                                 * io1: 100-64,000 IOPS
+
+
+                                 * io2: 100-64,000 IOPS
+
+
+                              For io1 and io2 volumes, we guarantee 64,000 IOPS only for Instances built
+                              on the Nitro System (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances).
+                              Other instance families guarantee performance up to 32,000 IOPS.
+
+
+                              This parameter is supported for io1, io2, and gp3 volumes only. This parameter
+                              is not supported for gp2, st1, sc1, or standard volumes.
+                            format: int64
+                            type: integer
+                          kmsKeyID:
+                            description: KMSKeyID (ARN) of the symmetric Key Management Service (KMS) CMK used for encryption.
+                            type: string
+                          snapshotID:
+                            description: SnapshotID is the ID of an EBS snapshot
+                            type: string
+                          throughput:
+                            description: |-
+                              Throughput to provision for a gp3 volume, with a maximum of 1,000 MiB/s.
+                              Valid Range: Minimum value of 125. Maximum value of 1000.
+                            format: int64
+                            type: integer
+                          volumeSize:
+                            description: |-
+                              VolumeSize in `Gi`, `G`, `Ti`, or `T`. You must specify either a snapshot ID or
+                              a volume size. The following are the supported volumes sizes for each volume
+                              type:
+
+
+                                 * gp2 and gp3: 1-16,384
+
+
+                                 * io1 and io2: 4-16,384
+
+
+                                 * st1 and sc1: 125-16,384
+
+
+                                 * standard: 1-1,024
+                            pattern: ^((?:[1-9][0-9]{0,3}|[1-4][0-9]{4}|[5][0-8][0-9]{3}|59000)Gi|(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|[6][0-3][0-9]{3}|64000)G|([1-9]||[1-5][0-7]|58)Ti|([1-9]||[1-5][0-9]|6[0-3]|64)T)$
+                            type: string
+                          volumeType:
+                            description: |-
+                              VolumeType of the block device.
+                              For more information, see Amazon EBS volume types (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html)
+                              in the Amazon Elastic Compute Cloud User Guide.
+                            enum:
+                              - standard
+                              - io1
+                              - io2
+                              - gp2
+                              - sc1
+                              - st1
+                              - gp3
+                            type: string
+                        type: object
+                        x-kubernetes-validations:
+                          - message: snapshotID or volumeSize must be defined
+                            rule: has(self.snapshotID) || has(self.volumeSize)
+                      rootVolume:
+                        description: |-
+                          RootVolume is a flag indicating if this device is mounted as kubelet root dir. You can
+                          configure at most one root volume in BlockDeviceMappings.
+                        type: boolean
+                    type: object
+                  maxItems: 50
+                  type: array
+                  x-kubernetes-validations:
+                    - message: must have only one blockDeviceMappings with rootVolume
+                      rule: self.filter(x, has(x.rootVolume)?x.rootVolume==true:false).size() <= 1
+                context:
+                  description: |-
+                    Context is a Reserved field in EC2 APIs
+                    https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet.html
+                  type: string
+                detailedMonitoring:
+                  description: DetailedMonitoring controls if detailed monitoring is enabled for instances that are launched
+                  type: boolean
+                instanceProfile:
+                  description: |-
+                    InstanceProfile is the AWS entity that instances use.
+                    This field is mutually exclusive from role.
+                    The instance profile should already have a role assigned to it that Karpenter
+                     has PassRole permission on for instance launch using this instanceProfile to succeed.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: instanceProfile cannot be empty
+                      rule: self != ''
+                instanceStorePolicy:
+                  description: InstanceStorePolicy specifies how to handle instance-store disks.
+                  enum:
+                    - RAID0
+                  type: string
+                metadataOptions:
+                  default:
+                    httpEndpoint: enabled
+                    httpProtocolIPv6: disabled
+                    httpPutResponseHopLimit: 1
+                    httpTokens: required
+                  description: |-
+                    MetadataOptions for the generated launch template of provisioned nodes.
+
+
+                    This specifies the exposure of the Instance Metadata Service to
+                    provisioned EC2 nodes. For more information,
+                    see Instance Metadata and User Data
+                    (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
+                    in the Amazon Elastic Compute Cloud User Guide.
+
+
+                    Refer to recommended, security best practices
+                    (https://aws.github.io/aws-eks-best-practices/security/docs/iam/#restrict-access-to-the-instance-profile-assigned-to-the-worker-node)
+                    for limiting exposure of Instance Metadata and User Data to pods.
+                    If omitted, defaults to httpEndpoint enabled, with httpProtocolIPv6
+                    disabled, with httpPutResponseLimit of 1, and with httpTokens
+                    required.
+                  properties:
+                    httpEndpoint:
+                      default: enabled
+                      description: |-
+                        HTTPEndpoint enables or disables the HTTP metadata endpoint on provisioned
+                        nodes. If metadata options is non-nil, but this parameter is not specified,
+                        the default state is "enabled".
+
+
+                        If you specify a value of "disabled", instance metadata will not be accessible
+                        on the node.
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpProtocolIPv6:
+                      default: disabled
+                      description: |-
+                        HTTPProtocolIPv6 enables or disables the IPv6 endpoint for the instance metadata
+                        service on provisioned nodes. If metadata options is non-nil, but this parameter
+                        is not specified, the default state is "disabled".
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpPutResponseHopLimit:
+                      default: 2
+                      description: |-
+                        HTTPPutResponseHopLimit is the desired HTTP PUT response hop limit for
+                        instance metadata requests. The larger the number, the further instance
+                        metadata requests can travel. Possible values are integers from 1 to 64.
+                        If metadata options is non-nil, but this parameter is not specified, the
+                        default value is 2.
+                      format: int64
+                      maximum: 64
+                      minimum: 1
+                      type: integer
+                    httpTokens:
+                      default: required
+                      description: |-
+                        HTTPTokens determines the state of token usage for instance metadata
+                        requests. If metadata options is non-nil, but this parameter is not
+                        specified, the default state is "required".
+
+
+                        If the state is optional, one can choose to retrieve instance metadata with
+                        or without a signed token header on the request. If one retrieves the IAM
+                        role credentials without a token, the version 1.0 role credentials are
+                        returned. If one retrieves the IAM role credentials using a valid signed
+                        token, the version 2.0 role credentials are returned.
+
+
+                        If the state is "required", one must send a signed token header with any
+                        instance metadata retrieval requests. In this state, retrieving the IAM
+                        role credentials always returns the version 2.0 credentials; the version
+                        1.0 credentials are not available.
+                      enum:
+                        - required
+                        - optional
+                      type: string
+                  type: object
+                role:
+                  description: |-
+                    Role is the AWS identity that nodes use. This field is immutable.
+                    This field is mutually exclusive from instanceProfile.
+                    Marking this field as immutable avoids concerns around terminating managed instance profiles from running instances.
+                    This field may be made mutable in the future, assuming the correct garbage collection and drift handling is implemented
+                    for the old instance profiles on an update.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: role cannot be empty
+                      rule: self != ''
+                    - message: immutable field changed
+                      rule: self == oldSelf
+                securityGroupSelectorTerms:
+                  description: SecurityGroupSelectorTerms is a list of or security group selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SecurityGroupSelectorTerm defines selection logic for a security group used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the security group id in EC2
+                        pattern: sg-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the security group name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: securityGroupSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id', 'name']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && (has(x.tags) || has(x.name)))'
+                    - message: '''name'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.name) && (has(x.tags) || has(x.id)))'
+                subnetSelectorTerms:
+                  description: SubnetSelectorTerms is a list of or subnet selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SubnetSelectorTerm defines selection logic for a subnet used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the subnet id in EC2
+                        pattern: subnet-[0-9a-z]+
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: subnetSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id']
+                      rule: self.all(x, has(x.tags) || has(x.id))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in subnetSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && has(x.tags))'
+                tags:
+                  additionalProperties:
+                    type: string
+                  description: Tags to be applied on ec2 resources like instances and launch templates.
+                  type: object
+                  x-kubernetes-validations:
+                    - message: empty tag keys aren't supported
+                      rule: self.all(k, k != '')
+                    - message: tag contains a restricted tag matching kubernetes.io/cluster/
+                      rule: self.all(k, !k.startsWith('kubernetes.io/cluster') )
+                    - message: tag contains a restricted tag matching karpenter.sh/nodepool
+                      rule: self.all(k, k != 'karpenter.sh/nodepool')
+                    - message: tag contains a restricted tag matching karpenter.sh/managed-by
+                      rule: self.all(k, k !='karpenter.sh/managed-by')
+                    - message: tag contains a restricted tag matching karpenter.sh/nodeclaim
+                      rule: self.all(k, k !='karpenter.sh/nodeclaim')
+                    - message: tag contains a restricted tag matching karpenter.k8s.aws/ec2nodeclass
+                      rule: self.all(k, k !='karpenter.k8s.aws/ec2nodeclass')
+                userData:
+                  description: |-
+                    UserData to be applied to the provisioned nodes.
+                    It must be in the appropriate format based on the AMIFamily in use. Karpenter will merge certain fields into
+                    this UserData to ensure nodes are being provisioned with the correct configuration.
+                  type: string
+              required:
+                - amiFamily
+                - securityGroupSelectorTerms
+                - subnetSelectorTerms
+              type: object
+              x-kubernetes-validations:
+                - message: amiSelectorTerms is required when amiFamily == 'Custom'
+                  rule: 'self.amiFamily == ''Custom'' ? self.amiSelectorTerms.size() != 0 : true'
+                - message: must specify exactly one of ['role', 'instanceProfile']
+                  rule: (has(self.role) && !has(self.instanceProfile)) || (!has(self.role) && has(self.instanceProfile))
+                - message: changing from 'instanceProfile' to 'role' is not supported. You must delete and recreate this node class if you want to change this.
+                  rule: (has(oldSelf.role) && has(self.role)) || (has(oldSelf.instanceProfile) && has(self.instanceProfile))
+            status:
+              description: EC2NodeClassStatus contains the resolved state of the EC2NodeClass
+              properties:
+                amis:
+                  description: |-
+                    AMI contains the current AMI values that are available to the
+                    cluster under the AMI selectors.
+                  items:
+                    description: AMI contains resolved AMI selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the AMI
+                        type: string
+                      name:
+                        description: Name of the AMI
+                        type: string
+                      requirements:
+                        description: Requirements of the AMI to be utilized on an instance type
+                        items:
+                          description: |-
+                            A node selector requirement is a selector that contains values, a key, and an operator
+                            that relates the key and values.
+                          properties:
+                            key:
+                              description: The label key that the selector applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                Represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                              type: string
+                            values:
+                              description: |-
+                                An array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. If the operator is Gt or Lt, the values
+                                array must have a single element, which will be interpreted as an integer.
+                                This array is replaced during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                            - key
+                            - operator
+                          type: object
+                        type: array
+                    required:
+                      - id
+                      - requirements
+                    type: object
+                  type: array
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: |-
+                          type of condition in CamelCase or in foo.example.com/CamelCase.
+                          ---
+                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                          useful (see .node.status.conditions), the ability to deconflict is important.
+                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                instanceProfile:
+                  description: InstanceProfile contains the resolved instance profile for the role
+                  type: string
+                securityGroups:
+                  description: |-
+                    SecurityGroups contains the current Security Groups values that are available to the
+                    cluster under the SecurityGroups selectors.
+                  items:
+                    description: SecurityGroup contains resolved SecurityGroup selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the security group
+                        type: string
+                      name:
+                        description: Name of the security group
+                        type: string
+                    required:
+                      - id
+                    type: object
+                  type: array
+                subnets:
+                  description: |-
+                    Subnets contains the current Subnet values that are available to the
+                    cluster under the subnet selectors.
+                  items:
+                    description: Subnet contains resolved Subnet selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the subnet
+                        type: string
+                      zone:
+                        description: The associated availability zone
+                        type: string
+                      zoneID:
+                        description: The associated availability zone ID
+                        type: string
+                    required:
+                      - id
+                      - zone
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+        - v1
+      clientConfig:
+        service:
+          name: karpenter
+          namespace: kube-system
+          port: 8443

--- a/content/projects/karpenter/v1.0.1/karpenter.sh_nodeclaims.yaml
+++ b/content/projects/karpenter/v1.0.1/karpenter.sh_nodeclaims.yaml
@@ -1,0 +1,843 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  name: nodeclaims.karpenter.sh
+spec:
+  group: karpenter.sh
+  names:
+    categories:
+      - karpenter
+    kind: NodeClaim
+    listKind: NodeClaimList
+    plural: nodeclaims
+    singular: nodeclaim
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.labels.node\.kubernetes\.io/instance-type
+          name: Type
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/capacity-type
+          name: Capacity
+          type: string
+        - jsonPath: .metadata.labels.topology\.kubernetes\.io/zone
+          name: Zone
+          type: string
+        - jsonPath: .status.nodeName
+          name: Node
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .status.providerID
+          name: ID
+          priority: 1
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/nodepool
+          name: NodePool
+          priority: 1
+          type: string
+        - jsonPath: .spec.nodeClassRef.name
+          name: NodeClass
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: NodeClaim is the Schema for the NodeClaims API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: NodeClaimSpec describes the desired state of the NodeClaim
+              properties:
+                expireAfter:
+                  default: 720h
+                  description: |-
+                    ExpireAfter is the duration the controller will wait
+                    before terminating a node, measured from when the node is created. This
+                    is useful to implement features like eventually consistent node upgrade,
+                    memory leak protection, and disruption testing.
+                  pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                  type: string
+                nodeClassRef:
+                  description: NodeClassRef is a reference to an object that defines provider specific configuration
+                  properties:
+                    group:
+                      description: API version of the referent
+                      pattern: ^[^/]*$
+                      type: string
+                    kind:
+                      description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                      type: string
+                    name:
+                      description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                      type: string
+                  required:
+                    - group
+                    - kind
+                    - name
+                  type: object
+                requirements:
+                  description: Requirements are layered with GetLabels and applied to every node.
+                  items:
+                    description: |-
+                      A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                      and minValues that represent the requirement to have at least that many values.
+                    properties:
+                      key:
+                        description: The label key that the selector applies to.
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                        x-kubernetes-validations:
+                          - message: label domain "kubernetes.io" is restricted
+                            rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                          - message: label domain "k8s.io" is restricted
+                            rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                          - message: label domain "karpenter.sh" is restricted
+                            rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                          - message: label "kubernetes.io/hostname" is restricted
+                            rule: self != "kubernetes.io/hostname"
+                          - message: label domain "karpenter.k8s.aws" is restricted
+                            rule: self in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                      minValues:
+                        description: |-
+                          This field is ALPHA and can be dropped or replaced at any time
+                          MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                        maximum: 50
+                        minimum: 1
+                        type: integer
+                      operator:
+                        description: |-
+                          Represents a key's relationship to a set of values.
+                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                        type: string
+                        enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          - Gt
+                          - Lt
+                      values:
+                        description: |-
+                          An array of string values. If the operator is In or NotIn,
+                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                          the values array must be empty. If the operator is Gt or Lt, the values
+                          array must have a single element, which will be interpreted as an integer.
+                          This array is replaced during a strategic merge patch.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                        maxLength: 63
+                        pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                    required:
+                      - key
+                      - operator
+                    type: object
+                  maxItems: 100
+                  type: array
+                  x-kubernetes-validations:
+                    - message: requirements with operator 'In' must have a value defined
+                      rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                    - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                      rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                    - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                      rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                resources:
+                  description: Resources models the resource requirements for the NodeClaim to launch
+                  properties:
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: Requests describes the minimum required resources for the NodeClaim to launch
+                      type: object
+                  type: object
+                startupTaints:
+                  description: |-
+                    StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                    within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                    daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                    purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                taints:
+                  description: Taints will be applied to the NodeClaim's node.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                terminationGracePeriod:
+                  description: |-
+                    TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
+
+
+                    Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
+
+
+                    This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
+                    When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
+
+
+                    Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
+                    If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
+                    that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
+
+
+                    The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
+                    If left undefined, the controller will wait indefinitely for pods to be drained.
+                  pattern: ^([0-9]+(s|m|h))+$
+                  type: string
+              required:
+                - nodeClassRef
+                - requirements
+              type: object
+              x-kubernetes-validations:
+                - message: spec is immutable
+                  rule: self == oldSelf
+            status:
+              description: NodeClaimStatus defines the observed state of NodeClaim
+              properties:
+                allocatable:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Allocatable is the estimated allocatable capacity of the node
+                  type: object
+                capacity:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Capacity is the estimated full capacity of the node
+                  type: object
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        pattern: ^([A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?|)$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: |-
+                          type of condition in CamelCase or in foo.example.com/CamelCase.
+                          ---
+                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                          useful (see .node.status.conditions), the ability to deconflict is important.
+                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - status
+                      - type
+                    type: object
+                  type: array
+                imageID:
+                  description: ImageID is an identifier for the image that runs on the node
+                  type: string
+                lastPodEventTime:
+                  description: |-
+                    LastPodEventTime is updated with the last time a pod was scheduled
+                    or removed from the node. A pod going terminal or terminating
+                    is also considered as removed.
+                  format: date-time
+                  type: string
+                nodeName:
+                  description: NodeName is the name of the corresponding node object
+                  type: string
+                providerID:
+                  description: ProviderID of the corresponding node object
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.labels.node\.kubernetes\.io/instance-type
+          name: Type
+          type: string
+        - jsonPath: .metadata.labels.topology\.kubernetes\.io/zone
+          name: Zone
+          type: string
+        - jsonPath: .status.nodeName
+          name: Node
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .metadata.labels.karpenter\.sh/capacity-type
+          name: Capacity
+          priority: 1
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/nodepool
+          name: NodePool
+          priority: 1
+          type: string
+        - jsonPath: .spec.nodeClassRef.name
+          name: NodeClass
+          priority: 1
+          type: string
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: NodeClaim is the Schema for the NodeClaims API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: NodeClaimSpec describes the desired state of the NodeClaim
+              properties:
+                kubelet:
+                  description: |-
+                    Kubelet defines args to be used when configuring kubelet on provisioned nodes.
+                    They are a subset of the upstream types, recognizing not all options may be supported.
+                    Wherever possible, the types and names should reflect the upstream kubelet types.
+                  properties:
+                    clusterDNS:
+                      description: |-
+                        clusterDNS is a list of IP addresses for the cluster DNS server.
+                        Note that not all providers may use all addresses.
+                      items:
+                        type: string
+                      type: array
+                    cpuCFSQuota:
+                      description: CPUCFSQuota enables CPU CFS quota enforcement for containers that specify CPU limits.
+                      type: boolean
+                    evictionHard:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionHard is the map of signal names to quantities that define hard eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionHard are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionMaxPodGracePeriod:
+                      description: |-
+                        EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in
+                        response to soft eviction thresholds being met.
+                      format: int32
+                      type: integer
+                    evictionSoft:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionSoft is the map of signal names to quantities that define soft eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoft are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionSoftGracePeriod:
+                      additionalProperties:
+                        type: string
+                      description: EvictionSoftGracePeriod is the map of signal names to quantities that define grace periods for each eviction signal
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoftGracePeriod are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    imageGCHighThresholdPercent:
+                      description: |-
+                        ImageGCHighThresholdPercent is the percent of disk usage after which image
+                        garbage collection is always run. The percent is calculated by dividing this
+                        field value by 100, so this field must be between 0 and 100, inclusive.
+                        When specified, the value must be greater than ImageGCLowThresholdPercent.
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    imageGCLowThresholdPercent:
+                      description: |-
+                        ImageGCLowThresholdPercent is the percent of disk usage before which image
+                        garbage collection is never run. Lowest disk usage to garbage collect to.
+                        The percent is calculated by dividing this field value by 100,
+                        so the field value must be between 0 and 100, inclusive.
+                        When specified, the value must be less than imageGCHighThresholdPercent
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    kubeReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: KubeReserved contains resources reserved for Kubernetes system components.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for kubeReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: kubeReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                    maxPods:
+                      description: |-
+                        MaxPods is an override for the maximum number of pods that can run on
+                        a worker node instance.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    podsPerCore:
+                      description: |-
+                        PodsPerCore is an override for the number of pods that can run on a worker node
+                        instance based on the number of cpu cores. This value cannot exceed MaxPods, so, if
+                        MaxPods is a lower value, that value will be used.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    systemReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: SystemReserved contains resources reserved for OS system daemons and kernel memory.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for systemReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: systemReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                  type: object
+                  x-kubernetes-validations:
+                    - message: imageGCHighThresholdPercent must be greater than imageGCLowThresholdPercent
+                      rule: 'has(self.imageGCHighThresholdPercent) && has(self.imageGCLowThresholdPercent) ?  self.imageGCHighThresholdPercent > self.imageGCLowThresholdPercent  : true'
+                    - message: evictionSoft OwnerKey does not have a matching evictionSoftGracePeriod
+                      rule: has(self.evictionSoft) ? self.evictionSoft.all(e, (e in self.evictionSoftGracePeriod)):true
+                    - message: evictionSoftGracePeriod OwnerKey does not have a matching evictionSoft
+                      rule: has(self.evictionSoftGracePeriod) ? self.evictionSoftGracePeriod.all(e, (e in self.evictionSoft)):true
+                nodeClassRef:
+                  description: NodeClassRef is a reference to an object that defines provider specific configuration
+                  properties:
+                    apiVersion:
+                      description: API version of the referent
+                      type: string
+                    kind:
+                      description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                      type: string
+                    name:
+                      description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                      type: string
+                  required:
+                    - name
+                  type: object
+                requirements:
+                  description: Requirements are layered with GetLabels and applied to every node.
+                  items:
+                    description: |-
+                      A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                      and minValues that represent the requirement to have at least that many values.
+                    properties:
+                      key:
+                        description: The label key that the selector applies to.
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                        x-kubernetes-validations:
+                          - message: label domain "kubernetes.io" is restricted
+                            rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                          - message: label domain "k8s.io" is restricted
+                            rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                          - message: label domain "karpenter.sh" is restricted
+                            rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                          - message: label "kubernetes.io/hostname" is restricted
+                            rule: self != "kubernetes.io/hostname"
+                          - message: label domain "karpenter.k8s.aws" is restricted
+                            rule: self in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                      minValues:
+                        description: |-
+                          This field is ALPHA and can be dropped or replaced at any time
+                          MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                        maximum: 50
+                        minimum: 1
+                        type: integer
+                      operator:
+                        description: |-
+                          Represents a key's relationship to a set of values.
+                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                        type: string
+                        enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          - Gt
+                          - Lt
+                      values:
+                        description: |-
+                          An array of string values. If the operator is In or NotIn,
+                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                          the values array must be empty. If the operator is Gt or Lt, the values
+                          array must have a single element, which will be interpreted as an integer.
+                          This array is replaced during a strategic merge patch.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                        maxLength: 63
+                        pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                    required:
+                      - key
+                      - operator
+                    type: object
+                  maxItems: 100
+                  type: array
+                  x-kubernetes-validations:
+                    - message: requirements with operator 'In' must have a value defined
+                      rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                    - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                      rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                    - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                      rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                resources:
+                  description: Resources models the resource requirements for the NodeClaim to launch
+                  properties:
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: Requests describes the minimum required resources for the NodeClaim to launch
+                      type: object
+                  type: object
+                startupTaints:
+                  description: |-
+                    StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                    within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                    daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                    purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                taints:
+                  description: Taints will be applied to the NodeClaim's node.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+              required:
+                - nodeClassRef
+                - requirements
+              type: object
+            status:
+              description: NodeClaimStatus defines the observed state of NodeClaim
+              properties:
+                allocatable:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Allocatable is the estimated allocatable capacity of the node
+                  type: object
+                capacity:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Capacity is the estimated full capacity of the node
+                  type: object
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        pattern: ^([A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?|)$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: |-
+                          type of condition in CamelCase or in foo.example.com/CamelCase.
+                          ---
+                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                          useful (see .node.status.conditions), the ability to deconflict is important.
+                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - status
+                      - type
+                    type: object
+                  type: array
+                imageID:
+                  description: ImageID is an identifier for the image that runs on the node
+                  type: string
+                nodeName:
+                  description: NodeName is the name of the corresponding node object
+                  type: string
+                providerID:
+                  description: ProviderID of the corresponding node object
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+        - v1
+      clientConfig:
+        service:
+          name: karpenter
+          namespace: kube-system
+          port: 8443

--- a/content/projects/karpenter/v1.0.1/karpenter.sh_nodepools.yaml
+++ b/content/projects/karpenter/v1.0.1/karpenter.sh_nodepools.yaml
@@ -1,0 +1,1094 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  name: nodepools.karpenter.sh
+spec:
+  group: karpenter.sh
+  names:
+    categories:
+      - karpenter
+    kind: NodePool
+    listKind: NodePoolList
+    plural: nodepools
+    singular: nodepool
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.template.spec.nodeClassRef.name
+          name: NodeClass
+          type: string
+        - jsonPath: .status.resources.nodes
+          name: Nodes
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.weight
+          name: Weight
+          priority: 1
+          type: integer
+        - jsonPath: .status.resources.cpu
+          name: CPU
+          priority: 1
+          type: string
+        - jsonPath: .status.resources.memory
+          name: Memory
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: NodePool is the Schema for the NodePools API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                NodePoolSpec is the top level nodepool specification. Nodepools
+                launch nodes in response to pods that are unschedulable. A single nodepool
+                is capable of managing a diverse set of nodes. Node properties are determined
+                from a combination of nodepool and pod scheduling constraints.
+              properties:
+                disruption:
+                  description: Disruption contains the parameters that relate to Karpenter's disruption logic
+                  properties:
+                    budgets:
+                      default:
+                        - nodes: 10%
+                      description: |-
+                        Budgets is a list of Budgets.
+                        If there are multiple active budgets, Karpenter uses
+                        the most restrictive value. If left undefined,
+                        this will default to one budget with a value to 10%.
+                      items:
+                        description: |-
+                          Budget defines when Karpenter will restrict the
+                          number of Node Claims that can be terminating simultaneously.
+                        properties:
+                          duration:
+                            description: |-
+                              Duration determines how long a Budget is active since each Schedule hit.
+                              Only minutes and hours are accepted, as cron does not work in seconds.
+                              If omitted, the budget is always active.
+                              This is required if Schedule is set.
+                              This regex has an optional 0s at the end since the duration.String() always adds
+                              a 0s at the end.
+                            pattern: ^((([0-9]+(h|m))|([0-9]+h[0-9]+m))(0s)?)$
+                            type: string
+                          nodes:
+                            default: 10%
+                            description: |-
+                              Nodes dictates the maximum number of NodeClaims owned by this NodePool
+                              that can be terminating at once. This is calculated by counting nodes that
+                              have a deletion timestamp set, or are actively being deleted by Karpenter.
+                              This field is required when specifying a budget.
+                              This cannot be of type intstr.IntOrString since kubebuilder doesn't support pattern
+                              checking for int nodes for IntOrString nodes.
+                              Ref: https://github.com/kubernetes-sigs/controller-tools/blob/55efe4be40394a288216dab63156b0a64fb82929/pkg/crd/markers/validation.go#L379-L388
+                            pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
+                            type: string
+                          reasons:
+                            description: |-
+                              Reasons is a list of disruption methods that this budget applies to. If Reasons is not set, this budget applies to all methods.
+                              Otherwise, this will apply to each reason defined.
+                              allowed reasons are Underutilized, Empty, and Drifted.
+                            items:
+                              description: DisruptionReason defines valid reasons for disruption budgets.
+                              enum:
+                                - Underutilized
+                                - Empty
+                                - Drifted
+                              type: string
+                            type: array
+                          schedule:
+                            description: |-
+                              Schedule specifies when a budget begins being active, following
+                              the upstream cronjob syntax. If omitted, the budget is always active.
+                              Timezones are not supported.
+                              This field is required if Duration is set.
+                            pattern: ^(@(annually|yearly|monthly|weekly|daily|midnight|hourly))|((.+)\s(.+)\s(.+)\s(.+)\s(.+))$
+                            type: string
+                        required:
+                          - nodes
+                        type: object
+                      maxItems: 50
+                      type: array
+                      x-kubernetes-validations:
+                        - message: '''schedule'' must be set with ''duration'''
+                          rule: self.all(x, has(x.schedule) == has(x.duration))
+                    consolidateAfter:
+                      description: |-
+                        ConsolidateAfter is the duration the controller will wait
+                        before attempting to terminate nodes that are underutilized.
+                        Refer to ConsolidationPolicy for how underutilization is considered.
+                      pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                      type: string
+                    consolidationPolicy:
+                      default: WhenEmptyOrUnderutilized
+                      description: |-
+                        ConsolidationPolicy describes which nodes Karpenter can disrupt through its consolidation
+                        algorithm. This policy defaults to "WhenEmptyOrUnderutilized" if not specified
+                      enum:
+                        - WhenEmpty
+                        - WhenEmptyOrUnderutilized
+                      type: string
+                  required:
+                    - consolidateAfter
+                  type: object
+                limits:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Limits define a set of bounds for provisioning capacity.
+                  type: object
+                template:
+                  description: |-
+                    Template contains the template of possibilities for the provisioning logic to launch a NodeClaim with.
+                    NodeClaims launched from this NodePool will often be further constrained than the template specifies.
+                  properties:
+                    metadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Annotations is an unstructured key value map stored with a resource that may be
+                            set by external tools to store and retrieve arbitrary metadata. They are not
+                            queryable and should be preserved when modifying objects.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                            maxLength: 63
+                            pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                          description: |-
+                            Map of string keys and values that can be used to organize and categorize
+                            (scope and select) objects. May match selectors of replication controllers
+                            and services.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
+                          type: object
+                          maxProperties: 100
+                          x-kubernetes-validations:
+                            - message: label domain "kubernetes.io" is restricted
+                              rule: self.all(x, x in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region",  "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || x.find("^([^/]+)").endsWith("node.kubernetes.io") || x.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !x.find("^([^/]+)").endsWith("kubernetes.io"))
+                            - message: label domain "k8s.io" is restricted
+                              rule: self.all(x, x.find("^([^/]+)").endsWith("kops.k8s.io") || !x.find("^([^/]+)").endsWith("k8s.io"))
+                            - message: label domain "karpenter.sh" is restricted
+                              rule: self.all(x, x in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !x.find("^([^/]+)").endsWith("karpenter.sh"))
+                            - message: label "karpenter.sh/nodepool" is restricted
+                              rule: self.all(x, x != "karpenter.sh/nodepool")
+                            - message: label "kubernetes.io/hostname" is restricted
+                              rule: self.all(x, x != "kubernetes.io/hostname")
+                            - message: label domain "karpenter.k8s.aws" is restricted
+                              rule: self.all(x, x in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !x.find("^([^/]+)").endsWith("karpenter.k8s.aws"))
+                      type: object
+                    spec:
+                      description: |-
+                        NodeClaimTemplateSpec describes the desired state of the NodeClaim in the Nodepool
+                        NodeClaimTemplateSpec is used in the NodePool's NodeClaimTemplate, with the resource requests omitted since
+                        users are not able to set resource requests in the NodePool.
+                      properties:
+                        expireAfter:
+                          default: 720h
+                          description: |-
+                            ExpireAfter is the duration the controller will wait
+                            before terminating a node, measured from when the node is created. This
+                            is useful to implement features like eventually consistent node upgrade,
+                            memory leak protection, and disruption testing.
+                          pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                          type: string
+                        nodeClassRef:
+                          description: NodeClassRef is a reference to an object that defines provider specific configuration
+                          properties:
+                            group:
+                              description: API version of the referent
+                              pattern: ^[^/]*$
+                              type: string
+                            kind:
+                              description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                              type: string
+                            name:
+                              description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                          required:
+                            - group
+                            - kind
+                            - name
+                          type: object
+                        requirements:
+                          description: Requirements are layered with GetLabels and applied to every node.
+                          items:
+                            description: |-
+                              A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                              and minValues that represent the requirement to have at least that many values.
+                            properties:
+                              key:
+                                description: The label key that the selector applies to.
+                                type: string
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                                x-kubernetes-validations:
+                                  - message: label domain "kubernetes.io" is restricted
+                                    rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                                  - message: label domain "k8s.io" is restricted
+                                    rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                                  - message: label domain "karpenter.sh" is restricted
+                                    rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                                  - message: label "karpenter.sh/nodepool" is restricted
+                                    rule: self != "karpenter.sh/nodepool"
+                                  - message: label "kubernetes.io/hostname" is restricted
+                                    rule: self != "kubernetes.io/hostname"
+                                  - message: label domain "karpenter.k8s.aws" is restricted
+                                    rule: self in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                              minValues:
+                                description: |-
+                                  This field is ALPHA and can be dropped or replaced at any time
+                                  MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                                maximum: 50
+                                minimum: 1
+                                type: integer
+                              operator:
+                                description: |-
+                                  Represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                type: string
+                                enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  - Gt
+                                  - Lt
+                              values:
+                                description: |-
+                                  An array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                  array must have a single element, which will be interpreted as an integer.
+                                  This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          maxItems: 100
+                          type: array
+                          x-kubernetes-validations:
+                            - message: requirements with operator 'In' must have a value defined
+                              rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                            - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                              rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                            - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                              rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                        startupTaints:
+                          description: |-
+                            StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                            within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                            daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                            purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        taints:
+                          description: Taints will be applied to the NodeClaim's node.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        terminationGracePeriod:
+                          description: |-
+                            TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
+
+
+                            Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
+
+
+                            This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
+                            When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
+
+
+                            Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
+                            If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
+                            that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
+
+
+                            The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
+                            If left undefined, the controller will wait indefinitely for pods to be drained.
+                          pattern: ^([0-9]+(s|m|h))+$
+                          type: string
+                      required:
+                        - nodeClassRef
+                        - requirements
+                      type: object
+                  required:
+                    - spec
+                  type: object
+                weight:
+                  description: |-
+                    Weight is the priority given to the nodepool during scheduling. A higher
+                    numerical weight indicates that this nodepool will be ordered
+                    ahead of other nodepools with lower weights. A nodepool with no weight
+                    will be treated as if it is a nodepool with a weight of 0.
+                  format: int32
+                  maximum: 100
+                  minimum: 1
+                  type: integer
+              required:
+                - template
+              type: object
+            status:
+              description: NodePoolStatus defines the observed state of NodePool
+              properties:
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: |-
+                          type of condition in CamelCase or in foo.example.com/CamelCase.
+                          ---
+                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                          useful (see .node.status.conditions), the ability to deconflict is important.
+                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                resources:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Resources is the list of resources that have been provisioned.
+                  type: object
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .spec.template.spec.nodeClassRef.name
+          name: NodeClass
+          type: string
+        - jsonPath: .spec.weight
+          name: Weight
+          priority: 1
+          type: string
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: NodePool is the Schema for the NodePools API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                NodePoolSpec is the top level nodepool specification. Nodepools
+                launch nodes in response to pods that are unschedulable. A single nodepool
+                is capable of managing a diverse set of nodes. Node properties are determined
+                from a combination of nodepool and pod scheduling constraints.
+              properties:
+                disruption:
+                  default:
+                    consolidationPolicy: WhenUnderutilized
+                    expireAfter: 720h
+                  description: Disruption contains the parameters that relate to Karpenter's disruption logic
+                  properties:
+                    budgets:
+                      default:
+                        - nodes: 10%
+                      description: |-
+                        Budgets is a list of Budgets.
+                        If there are multiple active budgets, Karpenter uses
+                        the most restrictive value. If left undefined,
+                        this will default to one budget with a value to 10%.
+                      items:
+                        description: |-
+                          Budget defines when Karpenter will restrict the
+                          number of Node Claims that can be terminating simultaneously.
+                        properties:
+                          duration:
+                            description: |-
+                              Duration determines how long a Budget is active since each Schedule hit.
+                              Only minutes and hours are accepted, as cron does not work in seconds.
+                              If omitted, the budget is always active.
+                              This is required if Schedule is set.
+                              This regex has an optional 0s at the end since the duration.String() always adds
+                              a 0s at the end.
+                            pattern: ^((([0-9]+(h|m))|([0-9]+h[0-9]+m))(0s)?)$
+                            type: string
+                          nodes:
+                            default: 10%
+                            description: |-
+                              Nodes dictates the maximum number of NodeClaims owned by this NodePool
+                              that can be terminating at once. This is calculated by counting nodes that
+                              have a deletion timestamp set, or are actively being deleted by Karpenter.
+                              This field is required when specifying a budget.
+                              This cannot be of type intstr.IntOrString since kubebuilder doesn't support pattern
+                              checking for int nodes for IntOrString nodes.
+                              Ref: https://github.com/kubernetes-sigs/controller-tools/blob/55efe4be40394a288216dab63156b0a64fb82929/pkg/crd/markers/validation.go#L379-L388
+                            pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
+                            type: string
+                          schedule:
+                            description: |-
+                              Schedule specifies when a budget begins being active, following
+                              the upstream cronjob syntax. If omitted, the budget is always active.
+                              Timezones are not supported.
+                              This field is required if Duration is set.
+                            pattern: ^(@(annually|yearly|monthly|weekly|daily|midnight|hourly))|((.+)\s(.+)\s(.+)\s(.+)\s(.+))$
+                            type: string
+                        required:
+                          - nodes
+                        type: object
+                      maxItems: 50
+                      type: array
+                      x-kubernetes-validations:
+                        - message: '''schedule'' must be set with ''duration'''
+                          rule: self.all(x, has(x.schedule) == has(x.duration))
+                    consolidateAfter:
+                      description: |-
+                        ConsolidateAfter is the duration the controller will wait
+                        before attempting to terminate nodes that are underutilized.
+                        Refer to ConsolidationPolicy for how underutilization is considered.
+                      pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                      type: string
+                    consolidationPolicy:
+                      default: WhenUnderutilized
+                      description: |-
+                        ConsolidationPolicy describes which nodes Karpenter can disrupt through its consolidation
+                        algorithm. This policy defaults to "WhenUnderutilized" if not specified
+                      enum:
+                        - WhenEmpty
+                        - WhenUnderutilized
+                      type: string
+                    expireAfter:
+                      default: 720h
+                      description: |-
+                        ExpireAfter is the duration the controller will wait
+                        before terminating a node, measured from when the node is created. This
+                        is useful to implement features like eventually consistent node upgrade,
+                        memory leak protection, and disruption testing.
+                      pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                      type: string
+                  type: object
+                  x-kubernetes-validations:
+                    - message: consolidateAfter cannot be combined with consolidationPolicy=WhenUnderutilized
+                      rule: 'has(self.consolidateAfter) ? self.consolidationPolicy != ''WhenUnderutilized'' || self.consolidateAfter == ''Never'' : true'
+                    - message: consolidateAfter must be specified with consolidationPolicy=WhenEmpty
+                      rule: 'self.consolidationPolicy == ''WhenEmpty'' ? has(self.consolidateAfter) : true'
+                limits:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Limits define a set of bounds for provisioning capacity.
+                  type: object
+                template:
+                  description: |-
+                    Template contains the template of possibilities for the provisioning logic to launch a NodeClaim with.
+                    NodeClaims launched from this NodePool will often be further constrained than the template specifies.
+                  properties:
+                    metadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Annotations is an unstructured key value map stored with a resource that may be
+                            set by external tools to store and retrieve arbitrary metadata. They are not
+                            queryable and should be preserved when modifying objects.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                            maxLength: 63
+                            pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                          description: |-
+                            Map of string keys and values that can be used to organize and categorize
+                            (scope and select) objects. May match selectors of replication controllers
+                            and services.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
+                          type: object
+                          maxProperties: 100
+                          x-kubernetes-validations:
+                            - message: label domain "kubernetes.io" is restricted
+                              rule: self.all(x, x in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region",  "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || x.find("^([^/]+)").endsWith("node.kubernetes.io") || x.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !x.find("^([^/]+)").endsWith("kubernetes.io"))
+                            - message: label domain "k8s.io" is restricted
+                              rule: self.all(x, x.find("^([^/]+)").endsWith("kops.k8s.io") || !x.find("^([^/]+)").endsWith("k8s.io"))
+                            - message: label domain "karpenter.sh" is restricted
+                              rule: self.all(x, x in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !x.find("^([^/]+)").endsWith("karpenter.sh"))
+                            - message: label "karpenter.sh/nodepool" is restricted
+                              rule: self.all(x, x != "karpenter.sh/nodepool")
+                            - message: label "kubernetes.io/hostname" is restricted
+                              rule: self.all(x, x != "kubernetes.io/hostname")
+                            - message: label domain "karpenter.k8s.aws" is restricted
+                              rule: self.all(x, x in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !x.find("^([^/]+)").endsWith("karpenter.k8s.aws"))
+                      type: object
+                    spec:
+                      description: NodeClaimSpec describes the desired state of the NodeClaim
+                      properties:
+                        kubelet:
+                          description: |-
+                            Kubelet defines args to be used when configuring kubelet on provisioned nodes.
+                            They are a subset of the upstream types, recognizing not all options may be supported.
+                            Wherever possible, the types and names should reflect the upstream kubelet types.
+                          properties:
+                            clusterDNS:
+                              description: |-
+                                clusterDNS is a list of IP addresses for the cluster DNS server.
+                                Note that not all providers may use all addresses.
+                              items:
+                                type: string
+                              type: array
+                            cpuCFSQuota:
+                              description: CPUCFSQuota enables CPU CFS quota enforcement for containers that specify CPU limits.
+                              type: boolean
+                            evictionHard:
+                              additionalProperties:
+                                type: string
+                                pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                              description: EvictionHard is the map of signal names to quantities that define hard eviction thresholds
+                              type: object
+                              x-kubernetes-validations:
+                                - message: valid keys for evictionHard are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                                  rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                            evictionMaxPodGracePeriod:
+                              description: |-
+                                EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in
+                                response to soft eviction thresholds being met.
+                              format: int32
+                              type: integer
+                            evictionSoft:
+                              additionalProperties:
+                                type: string
+                                pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                              description: EvictionSoft is the map of signal names to quantities that define soft eviction thresholds
+                              type: object
+                              x-kubernetes-validations:
+                                - message: valid keys for evictionSoft are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                                  rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                            evictionSoftGracePeriod:
+                              additionalProperties:
+                                type: string
+                              description: EvictionSoftGracePeriod is the map of signal names to quantities that define grace periods for each eviction signal
+                              type: object
+                              x-kubernetes-validations:
+                                - message: valid keys for evictionSoftGracePeriod are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                                  rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                            imageGCHighThresholdPercent:
+                              description: |-
+                                ImageGCHighThresholdPercent is the percent of disk usage after which image
+                                garbage collection is always run. The percent is calculated by dividing this
+                                field value by 100, so this field must be between 0 and 100, inclusive.
+                                When specified, the value must be greater than ImageGCLowThresholdPercent.
+                              format: int32
+                              maximum: 100
+                              minimum: 0
+                              type: integer
+                            imageGCLowThresholdPercent:
+                              description: |-
+                                ImageGCLowThresholdPercent is the percent of disk usage before which image
+                                garbage collection is never run. Lowest disk usage to garbage collect to.
+                                The percent is calculated by dividing this field value by 100,
+                                so the field value must be between 0 and 100, inclusive.
+                                When specified, the value must be less than imageGCHighThresholdPercent
+                              format: int32
+                              maximum: 100
+                              minimum: 0
+                              type: integer
+                            kubeReserved:
+                              additionalProperties:
+                                type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              description: KubeReserved contains resources reserved for Kubernetes system components.
+                              type: object
+                              x-kubernetes-validations:
+                                - message: valid keys for kubeReserved are ['cpu','memory','ephemeral-storage','pid']
+                                  rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                                - message: kubeReserved value cannot be a negative resource quantity
+                                  rule: self.all(x, !self[x].startsWith('-'))
+                            maxPods:
+                              description: |-
+                                MaxPods is an override for the maximum number of pods that can run on
+                                a worker node instance.
+                              format: int32
+                              minimum: 0
+                              type: integer
+                            podsPerCore:
+                              description: |-
+                                PodsPerCore is an override for the number of pods that can run on a worker node
+                                instance based on the number of cpu cores. This value cannot exceed MaxPods, so, if
+                                MaxPods is a lower value, that value will be used.
+                              format: int32
+                              minimum: 0
+                              type: integer
+                            systemReserved:
+                              additionalProperties:
+                                type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              description: SystemReserved contains resources reserved for OS system daemons and kernel memory.
+                              type: object
+                              x-kubernetes-validations:
+                                - message: valid keys for systemReserved are ['cpu','memory','ephemeral-storage','pid']
+                                  rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                                - message: systemReserved value cannot be a negative resource quantity
+                                  rule: self.all(x, !self[x].startsWith('-'))
+                          type: object
+                          x-kubernetes-validations:
+                            - message: imageGCHighThresholdPercent must be greater than imageGCLowThresholdPercent
+                              rule: 'has(self.imageGCHighThresholdPercent) && has(self.imageGCLowThresholdPercent) ?  self.imageGCHighThresholdPercent > self.imageGCLowThresholdPercent  : true'
+                            - message: evictionSoft OwnerKey does not have a matching evictionSoftGracePeriod
+                              rule: has(self.evictionSoft) ? self.evictionSoft.all(e, (e in self.evictionSoftGracePeriod)):true
+                            - message: evictionSoftGracePeriod OwnerKey does not have a matching evictionSoft
+                              rule: has(self.evictionSoftGracePeriod) ? self.evictionSoftGracePeriod.all(e, (e in self.evictionSoft)):true
+                        nodeClassRef:
+                          description: NodeClassRef is a reference to an object that defines provider specific configuration
+                          properties:
+                            apiVersion:
+                              description: API version of the referent
+                              type: string
+                            kind:
+                              description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                              type: string
+                            name:
+                              description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        requirements:
+                          description: Requirements are layered with GetLabels and applied to every node.
+                          items:
+                            description: |-
+                              A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                              and minValues that represent the requirement to have at least that many values.
+                            properties:
+                              key:
+                                description: The label key that the selector applies to.
+                                type: string
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                                x-kubernetes-validations:
+                                  - message: label domain "kubernetes.io" is restricted
+                                    rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                                  - message: label domain "k8s.io" is restricted
+                                    rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                                  - message: label domain "karpenter.sh" is restricted
+                                    rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                                  - message: label "karpenter.sh/nodepool" is restricted
+                                    rule: self != "karpenter.sh/nodepool"
+                                  - message: label "kubernetes.io/hostname" is restricted
+                                    rule: self != "kubernetes.io/hostname"
+                                  - message: label domain "karpenter.k8s.aws" is restricted
+                                    rule: self in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                              minValues:
+                                description: |-
+                                  This field is ALPHA and can be dropped or replaced at any time
+                                  MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                                maximum: 50
+                                minimum: 1
+                                type: integer
+                              operator:
+                                description: |-
+                                  Represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                type: string
+                                enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  - Gt
+                                  - Lt
+                              values:
+                                description: |-
+                                  An array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                  array must have a single element, which will be interpreted as an integer.
+                                  This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          maxItems: 100
+                          type: array
+                          x-kubernetes-validations:
+                            - message: requirements with operator 'In' must have a value defined
+                              rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                            - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                              rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                            - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                              rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                        resources:
+                          description: Resources models the resource requirements for the NodeClaim to launch
+                          properties:
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: Requests describes the minimum required resources for the NodeClaim to launch
+                              type: object
+                          type: object
+                          maxProperties: 0
+                        startupTaints:
+                          description: |-
+                            StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                            within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                            daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                            purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        taints:
+                          description: Taints will be applied to the NodeClaim's node.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                      required:
+                        - nodeClassRef
+                        - requirements
+                      type: object
+                  required:
+                    - spec
+                  type: object
+                weight:
+                  description: |-
+                    Weight is the priority given to the nodepool during scheduling. A higher
+                    numerical weight indicates that this nodepool will be ordered
+                    ahead of other nodepools with lower weights. A nodepool with no weight
+                    will be treated as if it is a nodepool with a weight of 0.
+                  format: int32
+                  maximum: 100
+                  minimum: 1
+                  type: integer
+              required:
+                - template
+              type: object
+            status:
+              description: NodePoolStatus defines the observed state of NodePool
+              properties:
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: |-
+                          type of condition in CamelCase or in foo.example.com/CamelCase.
+                          ---
+                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                          useful (see .node.status.conditions), the ability to deconflict is important.
+                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                resources:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Resources is the list of resources that have been provisioned.
+                  type: object
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+        - v1
+      clientConfig:
+        service:
+          name: karpenter
+          namespace: kube-system
+          port: 8443

--- a/content/projects/karpenter/v1.0.2/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/content/projects/karpenter/v1.0.2/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -1,0 +1,1306 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.2
+  name: ec2nodeclasses.karpenter.k8s.aws
+spec:
+  group: karpenter.k8s.aws
+  names:
+    categories:
+      - karpenter
+    kind: EC2NodeClass
+    listKind: EC2NodeClassList
+    plural: ec2nodeclasses
+    shortNames:
+      - ec2nc
+      - ec2ncs
+    singular: ec2nodeclass
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.role
+          name: Role
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: EC2NodeClass is the Schema for the EC2NodeClass API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                EC2NodeClassSpec is the top level specification for the AWS Karpenter Provider.
+                This will contain configuration necessary to launch instances in AWS.
+              properties:
+                amiFamily:
+                  description: |-
+                    AMIFamily dictates the UserData format and default BlockDeviceMappings used when generating launch templates.
+                    This field is optional when using an alias amiSelectorTerm, and the value will be inferred from the alias'
+                    family. When an alias is specified, this field may only be set to its corresponding family or 'Custom'. If no
+                    alias is specified, this field is required.
+                    NOTE: We ignore the AMIFamily for hashing here because we hash the AMIFamily dynamically by using the alias using
+                    the AMIFamily() helper function
+                  enum:
+                    - AL2
+                    - AL2023
+                    - Bottlerocket
+                    - Custom
+                    - Windows2019
+                    - Windows2022
+                  type: string
+                amiSelectorTerms:
+                  description: AMISelectorTerms is a list of or ami selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      AMISelectorTerm defines selection logic for an ami used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      alias:
+                        description: |-
+                          Alias specifies which EKS optimized AMI to select.
+                          Each alias consists of a family and an AMI version, specified as "family@version".
+                          Valid families include: al2, al2023, bottlerocket, windows2019, and windows2022.
+                          The version can either be pinned to a specific AMI release, with that AMIs version format (ex: "al2023@v20240625" or "bottlerocket@v1.10.0").
+                          The version can also be set to "latest" for any family. Setting the version to latest will result in drift when a new AMI is released. This is **not** recommended for production environments.
+                          Note: The Windows families do **not** support version pinning, and only latest may be used.
+                        maxLength: 30
+                        type: string
+                        x-kubernetes-validations:
+                          - message: '''alias'' is improperly formatted, must match the format ''family@version'''
+                            rule: self.matches('^[a-zA-Z0-9]+@.+$')
+                          - message: 'family is not supported, must be one of the following: ''al2'', ''al2023'', ''bottlerocket'', ''windows2019'', ''windows2022'''
+                            rule: self.split('@')[0] in ['al2','al2023','bottlerocket','windows2019','windows2022']
+                          - message: windows families may only specify version 'latest'
+                            rule: 'self.split(''@'')[0] in [''windows2019'',''windows2022''] ? self.split(''@'')[1] == ''latest'' : true'
+                      id:
+                        description: ID is the ami id in EC2
+                        pattern: ami-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the ami name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      owner:
+                        description: |-
+                          Owner is the owner for the ami.
+                          You can specify a combination of AWS account IDs, "self", "amazon", and "aws-marketplace"
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  minItems: 1
+                  type: array
+                  x-kubernetes-validations:
+                    - message: expected at least one, got none, ['tags', 'id', 'name', 'alias']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name) || has(x.alias))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.exists(x, has(x.id) && (has(x.alias) || has(x.tags) || has(x.name) || has(x.owner)))'
+                    - message: '''alias'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.exists(x, has(x.alias) && (has(x.id) || has(x.tags) || has(x.name) || has(x.owner)))'
+                    - message: '''alias'' is mutually exclusive, cannot be set with a combination of other amiSelectorTerms'
+                      rule: '!(self.exists(x, has(x.alias)) && self.size() != 1)'
+                associatePublicIPAddress:
+                  description: AssociatePublicIPAddress controls if public IP addresses are assigned to instances that are launched with the nodeclass.
+                  type: boolean
+                blockDeviceMappings:
+                  description: BlockDeviceMappings to be applied to provisioned nodes.
+                  items:
+                    properties:
+                      deviceName:
+                        description: The device name (for example, /dev/sdh or xvdh).
+                        type: string
+                      ebs:
+                        description: EBS contains parameters used to automatically set up EBS volumes when an instance is launched.
+                        properties:
+                          deleteOnTermination:
+                            description: DeleteOnTermination indicates whether the EBS volume is deleted on instance termination.
+                            type: boolean
+                          encrypted:
+                            description: |-
+                              Encrypted indicates whether the EBS volume is encrypted. Encrypted volumes can only
+                              be attached to instances that support Amazon EBS encryption. If you are creating
+                              a volume from a snapshot, you can't specify an encryption value.
+                            type: boolean
+                          iops:
+                            description: |-
+                              IOPS is the number of I/O operations per second (IOPS). For gp3, io1, and io2 volumes,
+                              this represents the number of IOPS that are provisioned for the volume. For
+                              gp2 volumes, this represents the baseline performance of the volume and the
+                              rate at which the volume accumulates I/O credits for bursting.
+
+                              The following are the supported values for each volume type:
+
+                                 * gp3: 3,000-16,000 IOPS
+
+                                 * io1: 100-64,000 IOPS
+
+                                 * io2: 100-64,000 IOPS
+
+                              For io1 and io2 volumes, we guarantee 64,000 IOPS only for Instances built
+                              on the Nitro System (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances).
+                              Other instance families guarantee performance up to 32,000 IOPS.
+
+                              This parameter is supported for io1, io2, and gp3 volumes only. This parameter
+                              is not supported for gp2, st1, sc1, or standard volumes.
+                            format: int64
+                            type: integer
+                          kmsKeyID:
+                            description: KMSKeyID (ARN) of the symmetric Key Management Service (KMS) CMK used for encryption.
+                            type: string
+                          snapshotID:
+                            description: SnapshotID is the ID of an EBS snapshot
+                            type: string
+                          throughput:
+                            description: |-
+                              Throughput to provision for a gp3 volume, with a maximum of 1,000 MiB/s.
+                              Valid Range: Minimum value of 125. Maximum value of 1000.
+                            format: int64
+                            type: integer
+                          volumeSize:
+                            description: |-
+                              VolumeSize in `Gi`, `G`, `Ti`, or `T`. You must specify either a snapshot ID or
+                              a volume size. The following are the supported volumes sizes for each volume
+                              type:
+
+                                 * gp2 and gp3: 1-16,384
+
+                                 * io1 and io2: 4-16,384
+
+                                 * st1 and sc1: 125-16,384
+
+                                 * standard: 1-1,024
+                            pattern: ^((?:[1-9][0-9]{0,3}|[1-4][0-9]{4}|[5][0-8][0-9]{3}|59000)Gi|(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|[6][0-3][0-9]{3}|64000)G|([1-9]||[1-5][0-7]|58)Ti|([1-9]||[1-5][0-9]|6[0-3]|64)T)$
+                            type: string
+                          volumeType:
+                            description: |-
+                              VolumeType of the block device.
+                              For more information, see Amazon EBS volume types (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html)
+                              in the Amazon Elastic Compute Cloud User Guide.
+                            enum:
+                              - standard
+                              - io1
+                              - io2
+                              - gp2
+                              - sc1
+                              - st1
+                              - gp3
+                            type: string
+                        type: object
+                        x-kubernetes-validations:
+                          - message: snapshotID or volumeSize must be defined
+                            rule: has(self.snapshotID) || has(self.volumeSize)
+                      rootVolume:
+                        description: |-
+                          RootVolume is a flag indicating if this device is mounted as kubelet root dir. You can
+                          configure at most one root volume in BlockDeviceMappings.
+                        type: boolean
+                    type: object
+                  maxItems: 50
+                  type: array
+                  x-kubernetes-validations:
+                    - message: must have only one blockDeviceMappings with rootVolume
+                      rule: self.filter(x, has(x.rootVolume)?x.rootVolume==true:false).size() <= 1
+                context:
+                  description: |-
+                    Context is a Reserved field in EC2 APIs
+                    https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet.html
+                  type: string
+                detailedMonitoring:
+                  description: DetailedMonitoring controls if detailed monitoring is enabled for instances that are launched
+                  type: boolean
+                instanceProfile:
+                  description: |-
+                    InstanceProfile is the AWS entity that instances use.
+                    This field is mutually exclusive from role.
+                    The instance profile should already have a role assigned to it that Karpenter
+                     has PassRole permission on for instance launch using this instanceProfile to succeed.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: instanceProfile cannot be empty
+                      rule: self != ''
+                instanceStorePolicy:
+                  description: InstanceStorePolicy specifies how to handle instance-store disks.
+                  enum:
+                    - RAID0
+                  type: string
+                kubelet:
+                  description: |-
+                    Kubelet defines args to be used when configuring kubelet on provisioned nodes.
+                    They are a subset of the upstream types, recognizing not all options may be supported.
+                    Wherever possible, the types and names should reflect the upstream kubelet types.
+                  properties:
+                    clusterDNS:
+                      description: |-
+                        clusterDNS is a list of IP addresses for the cluster DNS server.
+                        Note that not all providers may use all addresses.
+                      items:
+                        type: string
+                      type: array
+                    cpuCFSQuota:
+                      description: CPUCFSQuota enables CPU CFS quota enforcement for containers that specify CPU limits.
+                      type: boolean
+                    evictionHard:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionHard is the map of signal names to quantities that define hard eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionHard are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionMaxPodGracePeriod:
+                      description: |-
+                        EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in
+                        response to soft eviction thresholds being met.
+                      format: int32
+                      type: integer
+                    evictionSoft:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionSoft is the map of signal names to quantities that define soft eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoft are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionSoftGracePeriod:
+                      additionalProperties:
+                        type: string
+                      description: EvictionSoftGracePeriod is the map of signal names to quantities that define grace periods for each eviction signal
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoftGracePeriod are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    imageGCHighThresholdPercent:
+                      description: |-
+                        ImageGCHighThresholdPercent is the percent of disk usage after which image
+                        garbage collection is always run. The percent is calculated by dividing this
+                        field value by 100, so this field must be between 0 and 100, inclusive.
+                        When specified, the value must be greater than ImageGCLowThresholdPercent.
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    imageGCLowThresholdPercent:
+                      description: |-
+                        ImageGCLowThresholdPercent is the percent of disk usage before which image
+                        garbage collection is never run. Lowest disk usage to garbage collect to.
+                        The percent is calculated by dividing this field value by 100,
+                        so the field value must be between 0 and 100, inclusive.
+                        When specified, the value must be less than imageGCHighThresholdPercent
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    kubeReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: KubeReserved contains resources reserved for Kubernetes system components.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for kubeReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: kubeReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                    maxPods:
+                      description: |-
+                        MaxPods is an override for the maximum number of pods that can run on
+                        a worker node instance.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    podsPerCore:
+                      description: |-
+                        PodsPerCore is an override for the number of pods that can run on a worker node
+                        instance based on the number of cpu cores. This value cannot exceed MaxPods, so, if
+                        MaxPods is a lower value, that value will be used.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    systemReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: SystemReserved contains resources reserved for OS system daemons and kernel memory.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for systemReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: systemReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                  type: object
+                  x-kubernetes-validations:
+                    - message: imageGCHighThresholdPercent must be greater than imageGCLowThresholdPercent
+                      rule: 'has(self.imageGCHighThresholdPercent) && has(self.imageGCLowThresholdPercent) ?  self.imageGCHighThresholdPercent > self.imageGCLowThresholdPercent  : true'
+                    - message: evictionSoft OwnerKey does not have a matching evictionSoftGracePeriod
+                      rule: has(self.evictionSoft) ? self.evictionSoft.all(e, (e in self.evictionSoftGracePeriod)):true
+                    - message: evictionSoftGracePeriod OwnerKey does not have a matching evictionSoft
+                      rule: has(self.evictionSoftGracePeriod) ? self.evictionSoftGracePeriod.all(e, (e in self.evictionSoft)):true
+                metadataOptions:
+                  default:
+                    httpEndpoint: enabled
+                    httpProtocolIPv6: disabled
+                    httpPutResponseHopLimit: 1
+                    httpTokens: required
+                  description: |-
+                    MetadataOptions for the generated launch template of provisioned nodes.
+
+                    This specifies the exposure of the Instance Metadata Service to
+                    provisioned EC2 nodes. For more information,
+                    see Instance Metadata and User Data
+                    (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
+                    in the Amazon Elastic Compute Cloud User Guide.
+
+                    Refer to recommended, security best practices
+                    (https://aws.github.io/aws-eks-best-practices/security/docs/iam/#restrict-access-to-the-instance-profile-assigned-to-the-worker-node)
+                    for limiting exposure of Instance Metadata and User Data to pods.
+                    If omitted, defaults to httpEndpoint enabled, with httpProtocolIPv6
+                    disabled, with httpPutResponseLimit of 1, and with httpTokens
+                    required.
+                  properties:
+                    httpEndpoint:
+                      default: enabled
+                      description: |-
+                        HTTPEndpoint enables or disables the HTTP metadata endpoint on provisioned
+                        nodes. If metadata options is non-nil, but this parameter is not specified,
+                        the default state is "enabled".
+
+                        If you specify a value of "disabled", instance metadata will not be accessible
+                        on the node.
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpProtocolIPv6:
+                      default: disabled
+                      description: |-
+                        HTTPProtocolIPv6 enables or disables the IPv6 endpoint for the instance metadata
+                        service on provisioned nodes. If metadata options is non-nil, but this parameter
+                        is not specified, the default state is "disabled".
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpPutResponseHopLimit:
+                      default: 1
+                      description: |-
+                        HTTPPutResponseHopLimit is the desired HTTP PUT response hop limit for
+                        instance metadata requests. The larger the number, the further instance
+                        metadata requests can travel. Possible values are integers from 1 to 64.
+                        If metadata options is non-nil, but this parameter is not specified, the
+                        default value is 1.
+                      format: int64
+                      maximum: 64
+                      minimum: 1
+                      type: integer
+                    httpTokens:
+                      default: required
+                      description: |-
+                        HTTPTokens determines the state of token usage for instance metadata
+                        requests. If metadata options is non-nil, but this parameter is not
+                        specified, the default state is "required".
+
+                        If the state is optional, one can choose to retrieve instance metadata with
+                        or without a signed token header on the request. If one retrieves the IAM
+                        role credentials without a token, the version 1.0 role credentials are
+                        returned. If one retrieves the IAM role credentials using a valid signed
+                        token, the version 2.0 role credentials are returned.
+
+                        If the state is "required", one must send a signed token header with any
+                        instance metadata retrieval requests. In this state, retrieving the IAM
+                        role credentials always returns the version 2.0 credentials; the version
+                        1.0 credentials are not available.
+                      enum:
+                        - required
+                        - optional
+                      type: string
+                  type: object
+                role:
+                  description: |-
+                    Role is the AWS identity that nodes use. This field is immutable.
+                    This field is mutually exclusive from instanceProfile.
+                    Marking this field as immutable avoids concerns around terminating managed instance profiles from running instances.
+                    This field may be made mutable in the future, assuming the correct garbage collection and drift handling is implemented
+                    for the old instance profiles on an update.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: role cannot be empty
+                      rule: self != ''
+                    - message: immutable field changed
+                      rule: self == oldSelf
+                securityGroupSelectorTerms:
+                  description: SecurityGroupSelectorTerms is a list of or security group selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SecurityGroupSelectorTerm defines selection logic for a security group used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the security group id in EC2
+                        pattern: sg-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the security group name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: securityGroupSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id', 'name']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && (has(x.tags) || has(x.name)))'
+                    - message: '''name'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.name) && (has(x.tags) || has(x.id)))'
+                subnetSelectorTerms:
+                  description: SubnetSelectorTerms is a list of or subnet selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SubnetSelectorTerm defines selection logic for a subnet used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the subnet id in EC2
+                        pattern: subnet-[0-9a-z]+
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: subnetSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id']
+                      rule: self.all(x, has(x.tags) || has(x.id))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in subnetSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && has(x.tags))'
+                tags:
+                  additionalProperties:
+                    type: string
+                  description: Tags to be applied on ec2 resources like instances and launch templates.
+                  type: object
+                  x-kubernetes-validations:
+                    - message: empty tag keys aren't supported
+                      rule: self.all(k, k != '')
+                    - message: tag contains a restricted tag matching eks:eks-cluster-name
+                      rule: self.all(k, k !='eks:eks-cluster-name')
+                    - message: tag contains a restricted tag matching kubernetes.io/cluster/
+                      rule: self.all(k, !k.startsWith('kubernetes.io/cluster') )
+                    - message: tag contains a restricted tag matching karpenter.sh/nodepool
+                      rule: self.all(k, k != 'karpenter.sh/nodepool')
+                    - message: tag contains a restricted tag matching karpenter.sh/nodeclaim
+                      rule: self.all(k, k !='karpenter.sh/nodeclaim')
+                    - message: tag contains a restricted tag matching karpenter.k8s.aws/ec2nodeclass
+                      rule: self.all(k, k !='karpenter.k8s.aws/ec2nodeclass')
+                userData:
+                  description: |-
+                    UserData to be applied to the provisioned nodes.
+                    It must be in the appropriate format based on the AMIFamily in use. Karpenter will merge certain fields into
+                    this UserData to ensure nodes are being provisioned with the correct configuration.
+                  type: string
+              required:
+                - amiSelectorTerms
+                - securityGroupSelectorTerms
+                - subnetSelectorTerms
+              type: object
+              x-kubernetes-validations:
+                - message: must specify exactly one of ['role', 'instanceProfile']
+                  rule: (has(self.role) && !has(self.instanceProfile)) || (!has(self.role) && has(self.instanceProfile))
+                - message: changing from 'instanceProfile' to 'role' is not supported. You must delete and recreate this node class if you want to change this.
+                  rule: (has(oldSelf.role) && has(self.role)) || (has(oldSelf.instanceProfile) && has(self.instanceProfile))
+                - message: if set, amiFamily must be 'AL2' or 'Custom' when using an AL2 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''al2'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''AL2'') : true)'
+                - message: if set, amiFamily must be 'AL2023' or 'Custom' when using an AL2023 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''al2023'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''AL2023'') : true)'
+                - message: if set, amiFamily must be 'Bottlerocket' or 'Custom' when using a Bottlerocket alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''bottlerocket'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Bottlerocket'') : true)'
+                - message: if set, amiFamily must be 'Windows2019' or 'Custom' when using a Windows2019 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''windows2019'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Windows2019'') : true)'
+                - message: if set, amiFamily must be 'Windows2022' or 'Custom' when using a Windows2022 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''windows2022'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Windows2022'') : true)'
+                - message: must specify amiFamily if amiSelectorTerms does not contain an alias
+                  rule: 'self.amiSelectorTerms.exists(x, has(x.alias)) ? true : has(self.amiFamily)'
+            status:
+              description: EC2NodeClassStatus contains the resolved state of the EC2NodeClass
+              properties:
+                amis:
+                  description: |-
+                    AMI contains the current AMI values that are available to the
+                    cluster under the AMI selectors.
+                  items:
+                    description: AMI contains resolved AMI selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the AMI
+                        type: string
+                      name:
+                        description: Name of the AMI
+                        type: string
+                      requirements:
+                        description: Requirements of the AMI to be utilized on an instance type
+                        items:
+                          description: |-
+                            A node selector requirement is a selector that contains values, a key, and an operator
+                            that relates the key and values.
+                          properties:
+                            key:
+                              description: The label key that the selector applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                Represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                              type: string
+                            values:
+                              description: |-
+                                An array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. If the operator is Gt or Lt, the values
+                                array must have a single element, which will be interpreted as an integer.
+                                This array is replaced during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                            - key
+                            - operator
+                          type: object
+                        type: array
+                    required:
+                      - id
+                      - requirements
+                    type: object
+                  type: array
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                instanceProfile:
+                  description: InstanceProfile contains the resolved instance profile for the role
+                  type: string
+                securityGroups:
+                  description: |-
+                    SecurityGroups contains the current Security Groups values that are available to the
+                    cluster under the SecurityGroups selectors.
+                  items:
+                    description: SecurityGroup contains resolved SecurityGroup selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the security group
+                        type: string
+                      name:
+                        description: Name of the security group
+                        type: string
+                    required:
+                      - id
+                    type: object
+                  type: array
+                subnets:
+                  description: |-
+                    Subnets contains the current Subnet values that are available to the
+                    cluster under the subnet selectors.
+                  items:
+                    description: Subnet contains resolved Subnet selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the subnet
+                        type: string
+                      zone:
+                        description: The associated availability zone
+                        type: string
+                      zoneID:
+                        description: The associated availability zone ID
+                        type: string
+                    required:
+                      - id
+                      - zone
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: EC2NodeClass is the Schema for the EC2NodeClass API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                EC2NodeClassSpec is the top level specification for the AWS Karpenter Provider.
+                This will contain configuration necessary to launch instances in AWS.
+              properties:
+                amiFamily:
+                  description: AMIFamily is the AMI family that instances use.
+                  enum:
+                    - AL2
+                    - AL2023
+                    - Bottlerocket
+                    - Ubuntu
+                    - Custom
+                    - Windows2019
+                    - Windows2022
+                  type: string
+                amiSelectorTerms:
+                  description: AMISelectorTerms is a list of or ami selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      AMISelectorTerm defines selection logic for an ami used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the ami id in EC2
+                        pattern: ami-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the ami name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      owner:
+                        description: |-
+                          Owner is the owner for the ami.
+                          You can specify a combination of AWS account IDs, "self", "amazon", and "aws-marketplace"
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: expected at least one, got none, ['tags', 'id', 'name']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && (has(x.tags) || has(x.name) || has(x.owner)))'
+                associatePublicIPAddress:
+                  description: AssociatePublicIPAddress controls if public IP addresses are assigned to instances that are launched with the nodeclass.
+                  type: boolean
+                blockDeviceMappings:
+                  description: BlockDeviceMappings to be applied to provisioned nodes.
+                  items:
+                    properties:
+                      deviceName:
+                        description: The device name (for example, /dev/sdh or xvdh).
+                        type: string
+                      ebs:
+                        description: EBS contains parameters used to automatically set up EBS volumes when an instance is launched.
+                        properties:
+                          deleteOnTermination:
+                            description: DeleteOnTermination indicates whether the EBS volume is deleted on instance termination.
+                            type: boolean
+                          encrypted:
+                            description: |-
+                              Encrypted indicates whether the EBS volume is encrypted. Encrypted volumes can only
+                              be attached to instances that support Amazon EBS encryption. If you are creating
+                              a volume from a snapshot, you can't specify an encryption value.
+                            type: boolean
+                          iops:
+                            description: |-
+                              IOPS is the number of I/O operations per second (IOPS). For gp3, io1, and io2 volumes,
+                              this represents the number of IOPS that are provisioned for the volume. For
+                              gp2 volumes, this represents the baseline performance of the volume and the
+                              rate at which the volume accumulates I/O credits for bursting.
+
+                              The following are the supported values for each volume type:
+
+                                 * gp3: 3,000-16,000 IOPS
+
+                                 * io1: 100-64,000 IOPS
+
+                                 * io2: 100-64,000 IOPS
+
+                              For io1 and io2 volumes, we guarantee 64,000 IOPS only for Instances built
+                              on the Nitro System (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances).
+                              Other instance families guarantee performance up to 32,000 IOPS.
+
+                              This parameter is supported for io1, io2, and gp3 volumes only. This parameter
+                              is not supported for gp2, st1, sc1, or standard volumes.
+                            format: int64
+                            type: integer
+                          kmsKeyID:
+                            description: KMSKeyID (ARN) of the symmetric Key Management Service (KMS) CMK used for encryption.
+                            type: string
+                          snapshotID:
+                            description: SnapshotID is the ID of an EBS snapshot
+                            type: string
+                          throughput:
+                            description: |-
+                              Throughput to provision for a gp3 volume, with a maximum of 1,000 MiB/s.
+                              Valid Range: Minimum value of 125. Maximum value of 1000.
+                            format: int64
+                            type: integer
+                          volumeSize:
+                            description: |-
+                              VolumeSize in `Gi`, `G`, `Ti`, or `T`. You must specify either a snapshot ID or
+                              a volume size. The following are the supported volumes sizes for each volume
+                              type:
+
+                                 * gp2 and gp3: 1-16,384
+
+                                 * io1 and io2: 4-16,384
+
+                                 * st1 and sc1: 125-16,384
+
+                                 * standard: 1-1,024
+                            pattern: ^((?:[1-9][0-9]{0,3}|[1-4][0-9]{4}|[5][0-8][0-9]{3}|59000)Gi|(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|[6][0-3][0-9]{3}|64000)G|([1-9]||[1-5][0-7]|58)Ti|([1-9]||[1-5][0-9]|6[0-3]|64)T)$
+                            type: string
+                          volumeType:
+                            description: |-
+                              VolumeType of the block device.
+                              For more information, see Amazon EBS volume types (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html)
+                              in the Amazon Elastic Compute Cloud User Guide.
+                            enum:
+                              - standard
+                              - io1
+                              - io2
+                              - gp2
+                              - sc1
+                              - st1
+                              - gp3
+                            type: string
+                        type: object
+                        x-kubernetes-validations:
+                          - message: snapshotID or volumeSize must be defined
+                            rule: has(self.snapshotID) || has(self.volumeSize)
+                      rootVolume:
+                        description: |-
+                          RootVolume is a flag indicating if this device is mounted as kubelet root dir. You can
+                          configure at most one root volume in BlockDeviceMappings.
+                        type: boolean
+                    type: object
+                  maxItems: 50
+                  type: array
+                  x-kubernetes-validations:
+                    - message: must have only one blockDeviceMappings with rootVolume
+                      rule: self.filter(x, has(x.rootVolume)?x.rootVolume==true:false).size() <= 1
+                context:
+                  description: |-
+                    Context is a Reserved field in EC2 APIs
+                    https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet.html
+                  type: string
+                detailedMonitoring:
+                  description: DetailedMonitoring controls if detailed monitoring is enabled for instances that are launched
+                  type: boolean
+                instanceProfile:
+                  description: |-
+                    InstanceProfile is the AWS entity that instances use.
+                    This field is mutually exclusive from role.
+                    The instance profile should already have a role assigned to it that Karpenter
+                     has PassRole permission on for instance launch using this instanceProfile to succeed.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: instanceProfile cannot be empty
+                      rule: self != ''
+                instanceStorePolicy:
+                  description: InstanceStorePolicy specifies how to handle instance-store disks.
+                  enum:
+                    - RAID0
+                  type: string
+                metadataOptions:
+                  default:
+                    httpEndpoint: enabled
+                    httpProtocolIPv6: disabled
+                    httpPutResponseHopLimit: 1
+                    httpTokens: required
+                  description: |-
+                    MetadataOptions for the generated launch template of provisioned nodes.
+
+                    This specifies the exposure of the Instance Metadata Service to
+                    provisioned EC2 nodes. For more information,
+                    see Instance Metadata and User Data
+                    (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
+                    in the Amazon Elastic Compute Cloud User Guide.
+
+                    Refer to recommended, security best practices
+                    (https://aws.github.io/aws-eks-best-practices/security/docs/iam/#restrict-access-to-the-instance-profile-assigned-to-the-worker-node)
+                    for limiting exposure of Instance Metadata and User Data to pods.
+                    If omitted, defaults to httpEndpoint enabled, with httpProtocolIPv6
+                    disabled, with httpPutResponseLimit of 1, and with httpTokens
+                    required.
+                  properties:
+                    httpEndpoint:
+                      default: enabled
+                      description: |-
+                        HTTPEndpoint enables or disables the HTTP metadata endpoint on provisioned
+                        nodes. If metadata options is non-nil, but this parameter is not specified,
+                        the default state is "enabled".
+
+                        If you specify a value of "disabled", instance metadata will not be accessible
+                        on the node.
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpProtocolIPv6:
+                      default: disabled
+                      description: |-
+                        HTTPProtocolIPv6 enables or disables the IPv6 endpoint for the instance metadata
+                        service on provisioned nodes. If metadata options is non-nil, but this parameter
+                        is not specified, the default state is "disabled".
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpPutResponseHopLimit:
+                      default: 2
+                      description: |-
+                        HTTPPutResponseHopLimit is the desired HTTP PUT response hop limit for
+                        instance metadata requests. The larger the number, the further instance
+                        metadata requests can travel. Possible values are integers from 1 to 64.
+                        If metadata options is non-nil, but this parameter is not specified, the
+                        default value is 2.
+                      format: int64
+                      maximum: 64
+                      minimum: 1
+                      type: integer
+                    httpTokens:
+                      default: required
+                      description: |-
+                        HTTPTokens determines the state of token usage for instance metadata
+                        requests. If metadata options is non-nil, but this parameter is not
+                        specified, the default state is "required".
+
+                        If the state is optional, one can choose to retrieve instance metadata with
+                        or without a signed token header on the request. If one retrieves the IAM
+                        role credentials without a token, the version 1.0 role credentials are
+                        returned. If one retrieves the IAM role credentials using a valid signed
+                        token, the version 2.0 role credentials are returned.
+
+                        If the state is "required", one must send a signed token header with any
+                        instance metadata retrieval requests. In this state, retrieving the IAM
+                        role credentials always returns the version 2.0 credentials; the version
+                        1.0 credentials are not available.
+                      enum:
+                        - required
+                        - optional
+                      type: string
+                  type: object
+                role:
+                  description: |-
+                    Role is the AWS identity that nodes use. This field is immutable.
+                    This field is mutually exclusive from instanceProfile.
+                    Marking this field as immutable avoids concerns around terminating managed instance profiles from running instances.
+                    This field may be made mutable in the future, assuming the correct garbage collection and drift handling is implemented
+                    for the old instance profiles on an update.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: role cannot be empty
+                      rule: self != ''
+                    - message: immutable field changed
+                      rule: self == oldSelf
+                securityGroupSelectorTerms:
+                  description: SecurityGroupSelectorTerms is a list of or security group selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SecurityGroupSelectorTerm defines selection logic for a security group used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the security group id in EC2
+                        pattern: sg-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the security group name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: securityGroupSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id', 'name']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && (has(x.tags) || has(x.name)))'
+                    - message: '''name'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.name) && (has(x.tags) || has(x.id)))'
+                subnetSelectorTerms:
+                  description: SubnetSelectorTerms is a list of or subnet selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SubnetSelectorTerm defines selection logic for a subnet used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the subnet id in EC2
+                        pattern: subnet-[0-9a-z]+
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: subnetSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id']
+                      rule: self.all(x, has(x.tags) || has(x.id))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in subnetSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && has(x.tags))'
+                tags:
+                  additionalProperties:
+                    type: string
+                  description: Tags to be applied on ec2 resources like instances and launch templates.
+                  type: object
+                  x-kubernetes-validations:
+                    - message: empty tag keys aren't supported
+                      rule: self.all(k, k != '')
+                    - message: tag contains a restricted tag matching kubernetes.io/cluster/
+                      rule: self.all(k, !k.startsWith('kubernetes.io/cluster') )
+                    - message: tag contains a restricted tag matching karpenter.sh/nodepool
+                      rule: self.all(k, k != 'karpenter.sh/nodepool')
+                    - message: tag contains a restricted tag matching karpenter.sh/managed-by
+                      rule: self.all(k, k !='karpenter.sh/managed-by')
+                    - message: tag contains a restricted tag matching karpenter.sh/nodeclaim
+                      rule: self.all(k, k !='karpenter.sh/nodeclaim')
+                    - message: tag contains a restricted tag matching karpenter.k8s.aws/ec2nodeclass
+                      rule: self.all(k, k !='karpenter.k8s.aws/ec2nodeclass')
+                userData:
+                  description: |-
+                    UserData to be applied to the provisioned nodes.
+                    It must be in the appropriate format based on the AMIFamily in use. Karpenter will merge certain fields into
+                    this UserData to ensure nodes are being provisioned with the correct configuration.
+                  type: string
+              required:
+                - amiFamily
+                - securityGroupSelectorTerms
+                - subnetSelectorTerms
+              type: object
+              x-kubernetes-validations:
+                - message: amiSelectorTerms is required when amiFamily == 'Custom'
+                  rule: 'self.amiFamily == ''Custom'' ? self.amiSelectorTerms.size() != 0 : true'
+                - message: must specify exactly one of ['role', 'instanceProfile']
+                  rule: (has(self.role) && !has(self.instanceProfile)) || (!has(self.role) && has(self.instanceProfile))
+                - message: changing from 'instanceProfile' to 'role' is not supported. You must delete and recreate this node class if you want to change this.
+                  rule: (has(oldSelf.role) && has(self.role)) || (has(oldSelf.instanceProfile) && has(self.instanceProfile))
+            status:
+              description: EC2NodeClassStatus contains the resolved state of the EC2NodeClass
+              properties:
+                amis:
+                  description: |-
+                    AMI contains the current AMI values that are available to the
+                    cluster under the AMI selectors.
+                  items:
+                    description: AMI contains resolved AMI selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the AMI
+                        type: string
+                      name:
+                        description: Name of the AMI
+                        type: string
+                      requirements:
+                        description: Requirements of the AMI to be utilized on an instance type
+                        items:
+                          description: |-
+                            A node selector requirement is a selector that contains values, a key, and an operator
+                            that relates the key and values.
+                          properties:
+                            key:
+                              description: The label key that the selector applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                Represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                              type: string
+                            values:
+                              description: |-
+                                An array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. If the operator is Gt or Lt, the values
+                                array must have a single element, which will be interpreted as an integer.
+                                This array is replaced during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                            - key
+                            - operator
+                          type: object
+                        type: array
+                    required:
+                      - id
+                      - requirements
+                    type: object
+                  type: array
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                instanceProfile:
+                  description: InstanceProfile contains the resolved instance profile for the role
+                  type: string
+                securityGroups:
+                  description: |-
+                    SecurityGroups contains the current Security Groups values that are available to the
+                    cluster under the SecurityGroups selectors.
+                  items:
+                    description: SecurityGroup contains resolved SecurityGroup selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the security group
+                        type: string
+                      name:
+                        description: Name of the security group
+                        type: string
+                    required:
+                      - id
+                    type: object
+                  type: array
+                subnets:
+                  description: |-
+                    Subnets contains the current Subnet values that are available to the
+                    cluster under the subnet selectors.
+                  items:
+                    description: Subnet contains resolved Subnet selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the subnet
+                        type: string
+                      zone:
+                        description: The associated availability zone
+                        type: string
+                      zoneID:
+                        description: The associated availability zone ID
+                        type: string
+                    required:
+                      - id
+                      - zone
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+        - v1
+      clientConfig:
+        service:
+          name: karpenter
+          namespace: kube-system
+          port: 8443

--- a/content/projects/karpenter/v1.0.2/karpenter.sh_nodeclaims.yaml
+++ b/content/projects/karpenter/v1.0.2/karpenter.sh_nodeclaims.yaml
@@ -1,0 +1,829 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.2
+  name: nodeclaims.karpenter.sh
+spec:
+  group: karpenter.sh
+  names:
+    categories:
+      - karpenter
+    kind: NodeClaim
+    listKind: NodeClaimList
+    plural: nodeclaims
+    singular: nodeclaim
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.labels.node\.kubernetes\.io/instance-type
+          name: Type
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/capacity-type
+          name: Capacity
+          type: string
+        - jsonPath: .metadata.labels.topology\.kubernetes\.io/zone
+          name: Zone
+          type: string
+        - jsonPath: .status.nodeName
+          name: Node
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .status.providerID
+          name: ID
+          priority: 1
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/nodepool
+          name: NodePool
+          priority: 1
+          type: string
+        - jsonPath: .spec.nodeClassRef.name
+          name: NodeClass
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: NodeClaim is the Schema for the NodeClaims API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: NodeClaimSpec describes the desired state of the NodeClaim
+              properties:
+                expireAfter:
+                  default: 720h
+                  description: |-
+                    ExpireAfter is the duration the controller will wait
+                    before terminating a node, measured from when the node is created. This
+                    is useful to implement features like eventually consistent node upgrade,
+                    memory leak protection, and disruption testing.
+                  pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                  type: string
+                nodeClassRef:
+                  description: NodeClassRef is a reference to an object that defines provider specific configuration
+                  properties:
+                    group:
+                      description: API version of the referent
+                      pattern: ^[^/]*$
+                      type: string
+                    kind:
+                      description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                      type: string
+                    name:
+                      description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                      type: string
+                  required:
+                    - group
+                    - kind
+                    - name
+                  type: object
+                requirements:
+                  description: Requirements are layered with GetLabels and applied to every node.
+                  items:
+                    description: |-
+                      A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                      and minValues that represent the requirement to have at least that many values.
+                    properties:
+                      key:
+                        description: The label key that the selector applies to.
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                        x-kubernetes-validations:
+                          - message: label domain "kubernetes.io" is restricted
+                            rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                          - message: label domain "k8s.io" is restricted
+                            rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                          - message: label domain "karpenter.sh" is restricted
+                            rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                          - message: label "kubernetes.io/hostname" is restricted
+                            rule: self != "kubernetes.io/hostname"
+                          - message: label domain "karpenter.k8s.aws" is restricted
+                            rule: self in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                      minValues:
+                        description: |-
+                          This field is ALPHA and can be dropped or replaced at any time
+                          MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                        maximum: 50
+                        minimum: 1
+                        type: integer
+                      operator:
+                        description: |-
+                          Represents a key's relationship to a set of values.
+                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                        type: string
+                        enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          - Gt
+                          - Lt
+                      values:
+                        description: |-
+                          An array of string values. If the operator is In or NotIn,
+                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                          the values array must be empty. If the operator is Gt or Lt, the values
+                          array must have a single element, which will be interpreted as an integer.
+                          This array is replaced during a strategic merge patch.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                        maxLength: 63
+                        pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                    required:
+                      - key
+                      - operator
+                    type: object
+                  maxItems: 100
+                  type: array
+                  x-kubernetes-validations:
+                    - message: requirements with operator 'In' must have a value defined
+                      rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                    - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                      rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                    - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                      rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                resources:
+                  description: Resources models the resource requirements for the NodeClaim to launch
+                  properties:
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: Requests describes the minimum required resources for the NodeClaim to launch
+                      type: object
+                  type: object
+                startupTaints:
+                  description: |-
+                    StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                    within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                    daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                    purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                taints:
+                  description: Taints will be applied to the NodeClaim's node.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                terminationGracePeriod:
+                  description: |-
+                    TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
+
+                    Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
+
+                    This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
+                    When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
+
+                    Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
+                    If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
+                    that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
+
+                    The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
+                    If left undefined, the controller will wait indefinitely for pods to be drained.
+                  pattern: ^([0-9]+(s|m|h))+$
+                  type: string
+              required:
+                - nodeClassRef
+                - requirements
+              type: object
+              x-kubernetes-validations:
+                - message: spec is immutable
+                  rule: self == oldSelf
+            status:
+              description: NodeClaimStatus defines the observed state of NodeClaim
+              properties:
+                allocatable:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Allocatable is the estimated allocatable capacity of the node
+                  type: object
+                capacity:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Capacity is the estimated full capacity of the node
+                  type: object
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        pattern: ^([A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?|)$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - status
+                      - type
+                    type: object
+                  type: array
+                imageID:
+                  description: ImageID is an identifier for the image that runs on the node
+                  type: string
+                lastPodEventTime:
+                  description: |-
+                    LastPodEventTime is updated with the last time a pod was scheduled
+                    or removed from the node. A pod going terminal or terminating
+                    is also considered as removed.
+                  format: date-time
+                  type: string
+                nodeName:
+                  description: NodeName is the name of the corresponding node object
+                  type: string
+                providerID:
+                  description: ProviderID of the corresponding node object
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.labels.node\.kubernetes\.io/instance-type
+          name: Type
+          type: string
+        - jsonPath: .metadata.labels.topology\.kubernetes\.io/zone
+          name: Zone
+          type: string
+        - jsonPath: .status.nodeName
+          name: Node
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .metadata.labels.karpenter\.sh/capacity-type
+          name: Capacity
+          priority: 1
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/nodepool
+          name: NodePool
+          priority: 1
+          type: string
+        - jsonPath: .spec.nodeClassRef.name
+          name: NodeClass
+          priority: 1
+          type: string
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: NodeClaim is the Schema for the NodeClaims API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: NodeClaimSpec describes the desired state of the NodeClaim
+              properties:
+                kubelet:
+                  description: |-
+                    Kubelet defines args to be used when configuring kubelet on provisioned nodes.
+                    They are a subset of the upstream types, recognizing not all options may be supported.
+                    Wherever possible, the types and names should reflect the upstream kubelet types.
+                  properties:
+                    clusterDNS:
+                      description: |-
+                        clusterDNS is a list of IP addresses for the cluster DNS server.
+                        Note that not all providers may use all addresses.
+                      items:
+                        type: string
+                      type: array
+                    cpuCFSQuota:
+                      description: CPUCFSQuota enables CPU CFS quota enforcement for containers that specify CPU limits.
+                      type: boolean
+                    evictionHard:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionHard is the map of signal names to quantities that define hard eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionHard are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionMaxPodGracePeriod:
+                      description: |-
+                        EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in
+                        response to soft eviction thresholds being met.
+                      format: int32
+                      type: integer
+                    evictionSoft:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionSoft is the map of signal names to quantities that define soft eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoft are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionSoftGracePeriod:
+                      additionalProperties:
+                        type: string
+                      description: EvictionSoftGracePeriod is the map of signal names to quantities that define grace periods for each eviction signal
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoftGracePeriod are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    imageGCHighThresholdPercent:
+                      description: |-
+                        ImageGCHighThresholdPercent is the percent of disk usage after which image
+                        garbage collection is always run. The percent is calculated by dividing this
+                        field value by 100, so this field must be between 0 and 100, inclusive.
+                        When specified, the value must be greater than ImageGCLowThresholdPercent.
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    imageGCLowThresholdPercent:
+                      description: |-
+                        ImageGCLowThresholdPercent is the percent of disk usage before which image
+                        garbage collection is never run. Lowest disk usage to garbage collect to.
+                        The percent is calculated by dividing this field value by 100,
+                        so the field value must be between 0 and 100, inclusive.
+                        When specified, the value must be less than imageGCHighThresholdPercent
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    kubeReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: KubeReserved contains resources reserved for Kubernetes system components.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for kubeReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: kubeReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                    maxPods:
+                      description: |-
+                        MaxPods is an override for the maximum number of pods that can run on
+                        a worker node instance.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    podsPerCore:
+                      description: |-
+                        PodsPerCore is an override for the number of pods that can run on a worker node
+                        instance based on the number of cpu cores. This value cannot exceed MaxPods, so, if
+                        MaxPods is a lower value, that value will be used.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    systemReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: SystemReserved contains resources reserved for OS system daemons and kernel memory.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for systemReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: systemReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                  type: object
+                  x-kubernetes-validations:
+                    - message: imageGCHighThresholdPercent must be greater than imageGCLowThresholdPercent
+                      rule: 'has(self.imageGCHighThresholdPercent) && has(self.imageGCLowThresholdPercent) ?  self.imageGCHighThresholdPercent > self.imageGCLowThresholdPercent  : true'
+                    - message: evictionSoft OwnerKey does not have a matching evictionSoftGracePeriod
+                      rule: has(self.evictionSoft) ? self.evictionSoft.all(e, (e in self.evictionSoftGracePeriod)):true
+                    - message: evictionSoftGracePeriod OwnerKey does not have a matching evictionSoft
+                      rule: has(self.evictionSoftGracePeriod) ? self.evictionSoftGracePeriod.all(e, (e in self.evictionSoft)):true
+                nodeClassRef:
+                  description: NodeClassRef is a reference to an object that defines provider specific configuration
+                  properties:
+                    apiVersion:
+                      description: API version of the referent
+                      type: string
+                    kind:
+                      description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                      type: string
+                    name:
+                      description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                      type: string
+                  required:
+                    - name
+                  type: object
+                requirements:
+                  description: Requirements are layered with GetLabels and applied to every node.
+                  items:
+                    description: |-
+                      A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                      and minValues that represent the requirement to have at least that many values.
+                    properties:
+                      key:
+                        description: The label key that the selector applies to.
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                        x-kubernetes-validations:
+                          - message: label domain "kubernetes.io" is restricted
+                            rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                          - message: label domain "k8s.io" is restricted
+                            rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                          - message: label domain "karpenter.sh" is restricted
+                            rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                          - message: label "kubernetes.io/hostname" is restricted
+                            rule: self != "kubernetes.io/hostname"
+                          - message: label domain "karpenter.k8s.aws" is restricted
+                            rule: self in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                      minValues:
+                        description: |-
+                          This field is ALPHA and can be dropped or replaced at any time
+                          MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                        maximum: 50
+                        minimum: 1
+                        type: integer
+                      operator:
+                        description: |-
+                          Represents a key's relationship to a set of values.
+                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                        type: string
+                        enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          - Gt
+                          - Lt
+                      values:
+                        description: |-
+                          An array of string values. If the operator is In or NotIn,
+                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                          the values array must be empty. If the operator is Gt or Lt, the values
+                          array must have a single element, which will be interpreted as an integer.
+                          This array is replaced during a strategic merge patch.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                        maxLength: 63
+                        pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                    required:
+                      - key
+                      - operator
+                    type: object
+                  maxItems: 100
+                  type: array
+                  x-kubernetes-validations:
+                    - message: requirements with operator 'In' must have a value defined
+                      rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                    - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                      rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                    - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                      rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                resources:
+                  description: Resources models the resource requirements for the NodeClaim to launch
+                  properties:
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: Requests describes the minimum required resources for the NodeClaim to launch
+                      type: object
+                  type: object
+                startupTaints:
+                  description: |-
+                    StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                    within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                    daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                    purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                taints:
+                  description: Taints will be applied to the NodeClaim's node.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+              required:
+                - nodeClassRef
+                - requirements
+              type: object
+            status:
+              description: NodeClaimStatus defines the observed state of NodeClaim
+              properties:
+                allocatable:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Allocatable is the estimated allocatable capacity of the node
+                  type: object
+                capacity:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Capacity is the estimated full capacity of the node
+                  type: object
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        pattern: ^([A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?|)$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - status
+                      - type
+                    type: object
+                  type: array
+                imageID:
+                  description: ImageID is an identifier for the image that runs on the node
+                  type: string
+                nodeName:
+                  description: NodeName is the name of the corresponding node object
+                  type: string
+                providerID:
+                  description: ProviderID of the corresponding node object
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+        - v1
+      clientConfig:
+        service:
+          name: karpenter
+          namespace: kube-system
+          port: 8443

--- a/content/projects/karpenter/v1.0.2/karpenter.sh_nodepools.yaml
+++ b/content/projects/karpenter/v1.0.2/karpenter.sh_nodepools.yaml
@@ -1,0 +1,1080 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.2
+  name: nodepools.karpenter.sh
+spec:
+  group: karpenter.sh
+  names:
+    categories:
+      - karpenter
+    kind: NodePool
+    listKind: NodePoolList
+    plural: nodepools
+    singular: nodepool
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.template.spec.nodeClassRef.name
+          name: NodeClass
+          type: string
+        - jsonPath: .status.resources.nodes
+          name: Nodes
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.weight
+          name: Weight
+          priority: 1
+          type: integer
+        - jsonPath: .status.resources.cpu
+          name: CPU
+          priority: 1
+          type: string
+        - jsonPath: .status.resources.memory
+          name: Memory
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: NodePool is the Schema for the NodePools API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                NodePoolSpec is the top level nodepool specification. Nodepools
+                launch nodes in response to pods that are unschedulable. A single nodepool
+                is capable of managing a diverse set of nodes. Node properties are determined
+                from a combination of nodepool and pod scheduling constraints.
+              properties:
+                disruption:
+                  description: Disruption contains the parameters that relate to Karpenter's disruption logic
+                  properties:
+                    budgets:
+                      default:
+                        - nodes: 10%
+                      description: |-
+                        Budgets is a list of Budgets.
+                        If there are multiple active budgets, Karpenter uses
+                        the most restrictive value. If left undefined,
+                        this will default to one budget with a value to 10%.
+                      items:
+                        description: |-
+                          Budget defines when Karpenter will restrict the
+                          number of Node Claims that can be terminating simultaneously.
+                        properties:
+                          duration:
+                            description: |-
+                              Duration determines how long a Budget is active since each Schedule hit.
+                              Only minutes and hours are accepted, as cron does not work in seconds.
+                              If omitted, the budget is always active.
+                              This is required if Schedule is set.
+                              This regex has an optional 0s at the end since the duration.String() always adds
+                              a 0s at the end.
+                            pattern: ^((([0-9]+(h|m))|([0-9]+h[0-9]+m))(0s)?)$
+                            type: string
+                          nodes:
+                            default: 10%
+                            description: |-
+                              Nodes dictates the maximum number of NodeClaims owned by this NodePool
+                              that can be terminating at once. This is calculated by counting nodes that
+                              have a deletion timestamp set, or are actively being deleted by Karpenter.
+                              This field is required when specifying a budget.
+                              This cannot be of type intstr.IntOrString since kubebuilder doesn't support pattern
+                              checking for int nodes for IntOrString nodes.
+                              Ref: https://github.com/kubernetes-sigs/controller-tools/blob/55efe4be40394a288216dab63156b0a64fb82929/pkg/crd/markers/validation.go#L379-L388
+                            pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
+                            type: string
+                          reasons:
+                            description: |-
+                              Reasons is a list of disruption methods that this budget applies to. If Reasons is not set, this budget applies to all methods.
+                              Otherwise, this will apply to each reason defined.
+                              allowed reasons are Underutilized, Empty, and Drifted.
+                            items:
+                              description: DisruptionReason defines valid reasons for disruption budgets.
+                              enum:
+                                - Underutilized
+                                - Empty
+                                - Drifted
+                              type: string
+                            type: array
+                          schedule:
+                            description: |-
+                              Schedule specifies when a budget begins being active, following
+                              the upstream cronjob syntax. If omitted, the budget is always active.
+                              Timezones are not supported.
+                              This field is required if Duration is set.
+                            pattern: ^(@(annually|yearly|monthly|weekly|daily|midnight|hourly))|((.+)\s(.+)\s(.+)\s(.+)\s(.+))$
+                            type: string
+                        required:
+                          - nodes
+                        type: object
+                      maxItems: 50
+                      type: array
+                      x-kubernetes-validations:
+                        - message: '''schedule'' must be set with ''duration'''
+                          rule: self.all(x, has(x.schedule) == has(x.duration))
+                    consolidateAfter:
+                      description: |-
+                        ConsolidateAfter is the duration the controller will wait
+                        before attempting to terminate nodes that are underutilized.
+                        Refer to ConsolidationPolicy for how underutilization is considered.
+                      pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                      type: string
+                    consolidationPolicy:
+                      default: WhenEmptyOrUnderutilized
+                      description: |-
+                        ConsolidationPolicy describes which nodes Karpenter can disrupt through its consolidation
+                        algorithm. This policy defaults to "WhenEmptyOrUnderutilized" if not specified
+                      enum:
+                        - WhenEmpty
+                        - WhenEmptyOrUnderutilized
+                      type: string
+                  required:
+                    - consolidateAfter
+                  type: object
+                limits:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Limits define a set of bounds for provisioning capacity.
+                  type: object
+                template:
+                  description: |-
+                    Template contains the template of possibilities for the provisioning logic to launch a NodeClaim with.
+                    NodeClaims launched from this NodePool will often be further constrained than the template specifies.
+                  properties:
+                    metadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Annotations is an unstructured key value map stored with a resource that may be
+                            set by external tools to store and retrieve arbitrary metadata. They are not
+                            queryable and should be preserved when modifying objects.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                            maxLength: 63
+                            pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                          description: |-
+                            Map of string keys and values that can be used to organize and categorize
+                            (scope and select) objects. May match selectors of replication controllers
+                            and services.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
+                          type: object
+                          maxProperties: 100
+                          x-kubernetes-validations:
+                            - message: label domain "kubernetes.io" is restricted
+                              rule: self.all(x, x in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region",  "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || x.find("^([^/]+)").endsWith("node.kubernetes.io") || x.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !x.find("^([^/]+)").endsWith("kubernetes.io"))
+                            - message: label domain "k8s.io" is restricted
+                              rule: self.all(x, x.find("^([^/]+)").endsWith("kops.k8s.io") || !x.find("^([^/]+)").endsWith("k8s.io"))
+                            - message: label domain "karpenter.sh" is restricted
+                              rule: self.all(x, x in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !x.find("^([^/]+)").endsWith("karpenter.sh"))
+                            - message: label "karpenter.sh/nodepool" is restricted
+                              rule: self.all(x, x != "karpenter.sh/nodepool")
+                            - message: label "kubernetes.io/hostname" is restricted
+                              rule: self.all(x, x != "kubernetes.io/hostname")
+                            - message: label domain "karpenter.k8s.aws" is restricted
+                              rule: self.all(x, x in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !x.find("^([^/]+)").endsWith("karpenter.k8s.aws"))
+                      type: object
+                    spec:
+                      description: |-
+                        NodeClaimTemplateSpec describes the desired state of the NodeClaim in the Nodepool
+                        NodeClaimTemplateSpec is used in the NodePool's NodeClaimTemplate, with the resource requests omitted since
+                        users are not able to set resource requests in the NodePool.
+                      properties:
+                        expireAfter:
+                          default: 720h
+                          description: |-
+                            ExpireAfter is the duration the controller will wait
+                            before terminating a node, measured from when the node is created. This
+                            is useful to implement features like eventually consistent node upgrade,
+                            memory leak protection, and disruption testing.
+                          pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                          type: string
+                        nodeClassRef:
+                          description: NodeClassRef is a reference to an object that defines provider specific configuration
+                          properties:
+                            group:
+                              description: API version of the referent
+                              pattern: ^[^/]*$
+                              type: string
+                            kind:
+                              description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                              type: string
+                            name:
+                              description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                          required:
+                            - group
+                            - kind
+                            - name
+                          type: object
+                        requirements:
+                          description: Requirements are layered with GetLabels and applied to every node.
+                          items:
+                            description: |-
+                              A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                              and minValues that represent the requirement to have at least that many values.
+                            properties:
+                              key:
+                                description: The label key that the selector applies to.
+                                type: string
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                                x-kubernetes-validations:
+                                  - message: label domain "kubernetes.io" is restricted
+                                    rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                                  - message: label domain "k8s.io" is restricted
+                                    rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                                  - message: label domain "karpenter.sh" is restricted
+                                    rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                                  - message: label "karpenter.sh/nodepool" is restricted
+                                    rule: self != "karpenter.sh/nodepool"
+                                  - message: label "kubernetes.io/hostname" is restricted
+                                    rule: self != "kubernetes.io/hostname"
+                                  - message: label domain "karpenter.k8s.aws" is restricted
+                                    rule: self in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                              minValues:
+                                description: |-
+                                  This field is ALPHA and can be dropped or replaced at any time
+                                  MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                                maximum: 50
+                                minimum: 1
+                                type: integer
+                              operator:
+                                description: |-
+                                  Represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                type: string
+                                enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  - Gt
+                                  - Lt
+                              values:
+                                description: |-
+                                  An array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                  array must have a single element, which will be interpreted as an integer.
+                                  This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          maxItems: 100
+                          type: array
+                          x-kubernetes-validations:
+                            - message: requirements with operator 'In' must have a value defined
+                              rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                            - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                              rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                            - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                              rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                        startupTaints:
+                          description: |-
+                            StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                            within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                            daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                            purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        taints:
+                          description: Taints will be applied to the NodeClaim's node.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        terminationGracePeriod:
+                          description: |-
+                            TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
+
+                            Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
+
+                            This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
+                            When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
+
+                            Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
+                            If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
+                            that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
+
+                            The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
+                            If left undefined, the controller will wait indefinitely for pods to be drained.
+                          pattern: ^([0-9]+(s|m|h))+$
+                          type: string
+                      required:
+                        - nodeClassRef
+                        - requirements
+                      type: object
+                  required:
+                    - spec
+                  type: object
+                weight:
+                  description: |-
+                    Weight is the priority given to the nodepool during scheduling. A higher
+                    numerical weight indicates that this nodepool will be ordered
+                    ahead of other nodepools with lower weights. A nodepool with no weight
+                    will be treated as if it is a nodepool with a weight of 0.
+                  format: int32
+                  maximum: 100
+                  minimum: 1
+                  type: integer
+              required:
+                - template
+              type: object
+            status:
+              description: NodePoolStatus defines the observed state of NodePool
+              properties:
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                resources:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Resources is the list of resources that have been provisioned.
+                  type: object
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .spec.template.spec.nodeClassRef.name
+          name: NodeClass
+          type: string
+        - jsonPath: .spec.weight
+          name: Weight
+          priority: 1
+          type: string
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: NodePool is the Schema for the NodePools API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                NodePoolSpec is the top level nodepool specification. Nodepools
+                launch nodes in response to pods that are unschedulable. A single nodepool
+                is capable of managing a diverse set of nodes. Node properties are determined
+                from a combination of nodepool and pod scheduling constraints.
+              properties:
+                disruption:
+                  default:
+                    consolidationPolicy: WhenUnderutilized
+                    expireAfter: 720h
+                  description: Disruption contains the parameters that relate to Karpenter's disruption logic
+                  properties:
+                    budgets:
+                      default:
+                        - nodes: 10%
+                      description: |-
+                        Budgets is a list of Budgets.
+                        If there are multiple active budgets, Karpenter uses
+                        the most restrictive value. If left undefined,
+                        this will default to one budget with a value to 10%.
+                      items:
+                        description: |-
+                          Budget defines when Karpenter will restrict the
+                          number of Node Claims that can be terminating simultaneously.
+                        properties:
+                          duration:
+                            description: |-
+                              Duration determines how long a Budget is active since each Schedule hit.
+                              Only minutes and hours are accepted, as cron does not work in seconds.
+                              If omitted, the budget is always active.
+                              This is required if Schedule is set.
+                              This regex has an optional 0s at the end since the duration.String() always adds
+                              a 0s at the end.
+                            pattern: ^((([0-9]+(h|m))|([0-9]+h[0-9]+m))(0s)?)$
+                            type: string
+                          nodes:
+                            default: 10%
+                            description: |-
+                              Nodes dictates the maximum number of NodeClaims owned by this NodePool
+                              that can be terminating at once. This is calculated by counting nodes that
+                              have a deletion timestamp set, or are actively being deleted by Karpenter.
+                              This field is required when specifying a budget.
+                              This cannot be of type intstr.IntOrString since kubebuilder doesn't support pattern
+                              checking for int nodes for IntOrString nodes.
+                              Ref: https://github.com/kubernetes-sigs/controller-tools/blob/55efe4be40394a288216dab63156b0a64fb82929/pkg/crd/markers/validation.go#L379-L388
+                            pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
+                            type: string
+                          schedule:
+                            description: |-
+                              Schedule specifies when a budget begins being active, following
+                              the upstream cronjob syntax. If omitted, the budget is always active.
+                              Timezones are not supported.
+                              This field is required if Duration is set.
+                            pattern: ^(@(annually|yearly|monthly|weekly|daily|midnight|hourly))|((.+)\s(.+)\s(.+)\s(.+)\s(.+))$
+                            type: string
+                        required:
+                          - nodes
+                        type: object
+                      maxItems: 50
+                      type: array
+                      x-kubernetes-validations:
+                        - message: '''schedule'' must be set with ''duration'''
+                          rule: self.all(x, has(x.schedule) == has(x.duration))
+                    consolidateAfter:
+                      description: |-
+                        ConsolidateAfter is the duration the controller will wait
+                        before attempting to terminate nodes that are underutilized.
+                        Refer to ConsolidationPolicy for how underutilization is considered.
+                      pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                      type: string
+                    consolidationPolicy:
+                      default: WhenUnderutilized
+                      description: |-
+                        ConsolidationPolicy describes which nodes Karpenter can disrupt through its consolidation
+                        algorithm. This policy defaults to "WhenUnderutilized" if not specified
+                      enum:
+                        - WhenEmpty
+                        - WhenUnderutilized
+                      type: string
+                    expireAfter:
+                      default: 720h
+                      description: |-
+                        ExpireAfter is the duration the controller will wait
+                        before terminating a node, measured from when the node is created. This
+                        is useful to implement features like eventually consistent node upgrade,
+                        memory leak protection, and disruption testing.
+                      pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                      type: string
+                  type: object
+                  x-kubernetes-validations:
+                    - message: consolidateAfter cannot be combined with consolidationPolicy=WhenUnderutilized
+                      rule: 'has(self.consolidateAfter) ? self.consolidationPolicy != ''WhenUnderutilized'' || self.consolidateAfter == ''Never'' : true'
+                    - message: consolidateAfter must be specified with consolidationPolicy=WhenEmpty
+                      rule: 'self.consolidationPolicy == ''WhenEmpty'' ? has(self.consolidateAfter) : true'
+                limits:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Limits define a set of bounds for provisioning capacity.
+                  type: object
+                template:
+                  description: |-
+                    Template contains the template of possibilities for the provisioning logic to launch a NodeClaim with.
+                    NodeClaims launched from this NodePool will often be further constrained than the template specifies.
+                  properties:
+                    metadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Annotations is an unstructured key value map stored with a resource that may be
+                            set by external tools to store and retrieve arbitrary metadata. They are not
+                            queryable and should be preserved when modifying objects.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                            maxLength: 63
+                            pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                          description: |-
+                            Map of string keys and values that can be used to organize and categorize
+                            (scope and select) objects. May match selectors of replication controllers
+                            and services.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
+                          type: object
+                          maxProperties: 100
+                          x-kubernetes-validations:
+                            - message: label domain "kubernetes.io" is restricted
+                              rule: self.all(x, x in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region",  "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || x.find("^([^/]+)").endsWith("node.kubernetes.io") || x.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !x.find("^([^/]+)").endsWith("kubernetes.io"))
+                            - message: label domain "k8s.io" is restricted
+                              rule: self.all(x, x.find("^([^/]+)").endsWith("kops.k8s.io") || !x.find("^([^/]+)").endsWith("k8s.io"))
+                            - message: label domain "karpenter.sh" is restricted
+                              rule: self.all(x, x in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !x.find("^([^/]+)").endsWith("karpenter.sh"))
+                            - message: label "karpenter.sh/nodepool" is restricted
+                              rule: self.all(x, x != "karpenter.sh/nodepool")
+                            - message: label "kubernetes.io/hostname" is restricted
+                              rule: self.all(x, x != "kubernetes.io/hostname")
+                            - message: label domain "karpenter.k8s.aws" is restricted
+                              rule: self.all(x, x in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !x.find("^([^/]+)").endsWith("karpenter.k8s.aws"))
+                      type: object
+                    spec:
+                      description: NodeClaimSpec describes the desired state of the NodeClaim
+                      properties:
+                        kubelet:
+                          description: |-
+                            Kubelet defines args to be used when configuring kubelet on provisioned nodes.
+                            They are a subset of the upstream types, recognizing not all options may be supported.
+                            Wherever possible, the types and names should reflect the upstream kubelet types.
+                          properties:
+                            clusterDNS:
+                              description: |-
+                                clusterDNS is a list of IP addresses for the cluster DNS server.
+                                Note that not all providers may use all addresses.
+                              items:
+                                type: string
+                              type: array
+                            cpuCFSQuota:
+                              description: CPUCFSQuota enables CPU CFS quota enforcement for containers that specify CPU limits.
+                              type: boolean
+                            evictionHard:
+                              additionalProperties:
+                                type: string
+                                pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                              description: EvictionHard is the map of signal names to quantities that define hard eviction thresholds
+                              type: object
+                              x-kubernetes-validations:
+                                - message: valid keys for evictionHard are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                                  rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                            evictionMaxPodGracePeriod:
+                              description: |-
+                                EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in
+                                response to soft eviction thresholds being met.
+                              format: int32
+                              type: integer
+                            evictionSoft:
+                              additionalProperties:
+                                type: string
+                                pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                              description: EvictionSoft is the map of signal names to quantities that define soft eviction thresholds
+                              type: object
+                              x-kubernetes-validations:
+                                - message: valid keys for evictionSoft are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                                  rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                            evictionSoftGracePeriod:
+                              additionalProperties:
+                                type: string
+                              description: EvictionSoftGracePeriod is the map of signal names to quantities that define grace periods for each eviction signal
+                              type: object
+                              x-kubernetes-validations:
+                                - message: valid keys for evictionSoftGracePeriod are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                                  rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                            imageGCHighThresholdPercent:
+                              description: |-
+                                ImageGCHighThresholdPercent is the percent of disk usage after which image
+                                garbage collection is always run. The percent is calculated by dividing this
+                                field value by 100, so this field must be between 0 and 100, inclusive.
+                                When specified, the value must be greater than ImageGCLowThresholdPercent.
+                              format: int32
+                              maximum: 100
+                              minimum: 0
+                              type: integer
+                            imageGCLowThresholdPercent:
+                              description: |-
+                                ImageGCLowThresholdPercent is the percent of disk usage before which image
+                                garbage collection is never run. Lowest disk usage to garbage collect to.
+                                The percent is calculated by dividing this field value by 100,
+                                so the field value must be between 0 and 100, inclusive.
+                                When specified, the value must be less than imageGCHighThresholdPercent
+                              format: int32
+                              maximum: 100
+                              minimum: 0
+                              type: integer
+                            kubeReserved:
+                              additionalProperties:
+                                type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              description: KubeReserved contains resources reserved for Kubernetes system components.
+                              type: object
+                              x-kubernetes-validations:
+                                - message: valid keys for kubeReserved are ['cpu','memory','ephemeral-storage','pid']
+                                  rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                                - message: kubeReserved value cannot be a negative resource quantity
+                                  rule: self.all(x, !self[x].startsWith('-'))
+                            maxPods:
+                              description: |-
+                                MaxPods is an override for the maximum number of pods that can run on
+                                a worker node instance.
+                              format: int32
+                              minimum: 0
+                              type: integer
+                            podsPerCore:
+                              description: |-
+                                PodsPerCore is an override for the number of pods that can run on a worker node
+                                instance based on the number of cpu cores. This value cannot exceed MaxPods, so, if
+                                MaxPods is a lower value, that value will be used.
+                              format: int32
+                              minimum: 0
+                              type: integer
+                            systemReserved:
+                              additionalProperties:
+                                type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              description: SystemReserved contains resources reserved for OS system daemons and kernel memory.
+                              type: object
+                              x-kubernetes-validations:
+                                - message: valid keys for systemReserved are ['cpu','memory','ephemeral-storage','pid']
+                                  rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                                - message: systemReserved value cannot be a negative resource quantity
+                                  rule: self.all(x, !self[x].startsWith('-'))
+                          type: object
+                          x-kubernetes-validations:
+                            - message: imageGCHighThresholdPercent must be greater than imageGCLowThresholdPercent
+                              rule: 'has(self.imageGCHighThresholdPercent) && has(self.imageGCLowThresholdPercent) ?  self.imageGCHighThresholdPercent > self.imageGCLowThresholdPercent  : true'
+                            - message: evictionSoft OwnerKey does not have a matching evictionSoftGracePeriod
+                              rule: has(self.evictionSoft) ? self.evictionSoft.all(e, (e in self.evictionSoftGracePeriod)):true
+                            - message: evictionSoftGracePeriod OwnerKey does not have a matching evictionSoft
+                              rule: has(self.evictionSoftGracePeriod) ? self.evictionSoftGracePeriod.all(e, (e in self.evictionSoft)):true
+                        nodeClassRef:
+                          description: NodeClassRef is a reference to an object that defines provider specific configuration
+                          properties:
+                            apiVersion:
+                              description: API version of the referent
+                              type: string
+                            kind:
+                              description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                              type: string
+                            name:
+                              description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        requirements:
+                          description: Requirements are layered with GetLabels and applied to every node.
+                          items:
+                            description: |-
+                              A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                              and minValues that represent the requirement to have at least that many values.
+                            properties:
+                              key:
+                                description: The label key that the selector applies to.
+                                type: string
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                                x-kubernetes-validations:
+                                  - message: label domain "kubernetes.io" is restricted
+                                    rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                                  - message: label domain "k8s.io" is restricted
+                                    rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                                  - message: label domain "karpenter.sh" is restricted
+                                    rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                                  - message: label "karpenter.sh/nodepool" is restricted
+                                    rule: self != "karpenter.sh/nodepool"
+                                  - message: label "kubernetes.io/hostname" is restricted
+                                    rule: self != "kubernetes.io/hostname"
+                                  - message: label domain "karpenter.k8s.aws" is restricted
+                                    rule: self in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                              minValues:
+                                description: |-
+                                  This field is ALPHA and can be dropped or replaced at any time
+                                  MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                                maximum: 50
+                                minimum: 1
+                                type: integer
+                              operator:
+                                description: |-
+                                  Represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                type: string
+                                enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  - Gt
+                                  - Lt
+                              values:
+                                description: |-
+                                  An array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                  array must have a single element, which will be interpreted as an integer.
+                                  This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          maxItems: 100
+                          type: array
+                          x-kubernetes-validations:
+                            - message: requirements with operator 'In' must have a value defined
+                              rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                            - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                              rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                            - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                              rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                        resources:
+                          description: Resources models the resource requirements for the NodeClaim to launch
+                          properties:
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: Requests describes the minimum required resources for the NodeClaim to launch
+                              type: object
+                          type: object
+                          maxProperties: 0
+                        startupTaints:
+                          description: |-
+                            StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                            within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                            daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                            purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        taints:
+                          description: Taints will be applied to the NodeClaim's node.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                      required:
+                        - nodeClassRef
+                        - requirements
+                      type: object
+                  required:
+                    - spec
+                  type: object
+                weight:
+                  description: |-
+                    Weight is the priority given to the nodepool during scheduling. A higher
+                    numerical weight indicates that this nodepool will be ordered
+                    ahead of other nodepools with lower weights. A nodepool with no weight
+                    will be treated as if it is a nodepool with a weight of 0.
+                  format: int32
+                  maximum: 100
+                  minimum: 1
+                  type: integer
+              required:
+                - template
+              type: object
+            status:
+              description: NodePoolStatus defines the observed state of NodePool
+              properties:
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                resources:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Resources is the list of resources that have been provisioned.
+                  type: object
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+        - v1
+      clientConfig:
+        service:
+          name: karpenter
+          namespace: kube-system
+          port: 8443

--- a/content/projects/karpenter/v1.0.3/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/content/projects/karpenter/v1.0.3/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -1,0 +1,1306 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.2
+  name: ec2nodeclasses.karpenter.k8s.aws
+spec:
+  group: karpenter.k8s.aws
+  names:
+    categories:
+      - karpenter
+    kind: EC2NodeClass
+    listKind: EC2NodeClassList
+    plural: ec2nodeclasses
+    shortNames:
+      - ec2nc
+      - ec2ncs
+    singular: ec2nodeclass
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.role
+          name: Role
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: EC2NodeClass is the Schema for the EC2NodeClass API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                EC2NodeClassSpec is the top level specification for the AWS Karpenter Provider.
+                This will contain configuration necessary to launch instances in AWS.
+              properties:
+                amiFamily:
+                  description: |-
+                    AMIFamily dictates the UserData format and default BlockDeviceMappings used when generating launch templates.
+                    This field is optional when using an alias amiSelectorTerm, and the value will be inferred from the alias'
+                    family. When an alias is specified, this field may only be set to its corresponding family or 'Custom'. If no
+                    alias is specified, this field is required.
+                    NOTE: We ignore the AMIFamily for hashing here because we hash the AMIFamily dynamically by using the alias using
+                    the AMIFamily() helper function
+                  enum:
+                    - AL2
+                    - AL2023
+                    - Bottlerocket
+                    - Custom
+                    - Windows2019
+                    - Windows2022
+                  type: string
+                amiSelectorTerms:
+                  description: AMISelectorTerms is a list of or ami selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      AMISelectorTerm defines selection logic for an ami used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      alias:
+                        description: |-
+                          Alias specifies which EKS optimized AMI to select.
+                          Each alias consists of a family and an AMI version, specified as "family@version".
+                          Valid families include: al2, al2023, bottlerocket, windows2019, and windows2022.
+                          The version can either be pinned to a specific AMI release, with that AMIs version format (ex: "al2023@v20240625" or "bottlerocket@v1.10.0").
+                          The version can also be set to "latest" for any family. Setting the version to latest will result in drift when a new AMI is released. This is **not** recommended for production environments.
+                          Note: The Windows families do **not** support version pinning, and only latest may be used.
+                        maxLength: 30
+                        type: string
+                        x-kubernetes-validations:
+                          - message: '''alias'' is improperly formatted, must match the format ''family@version'''
+                            rule: self.matches('^[a-zA-Z0-9]+@.+$')
+                          - message: 'family is not supported, must be one of the following: ''al2'', ''al2023'', ''bottlerocket'', ''windows2019'', ''windows2022'''
+                            rule: self.split('@')[0] in ['al2','al2023','bottlerocket','windows2019','windows2022']
+                          - message: windows families may only specify version 'latest'
+                            rule: 'self.split(''@'')[0] in [''windows2019'',''windows2022''] ? self.split(''@'')[1] == ''latest'' : true'
+                      id:
+                        description: ID is the ami id in EC2
+                        pattern: ami-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the ami name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      owner:
+                        description: |-
+                          Owner is the owner for the ami.
+                          You can specify a combination of AWS account IDs, "self", "amazon", and "aws-marketplace"
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  minItems: 1
+                  type: array
+                  x-kubernetes-validations:
+                    - message: expected at least one, got none, ['tags', 'id', 'name', 'alias']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name) || has(x.alias))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.exists(x, has(x.id) && (has(x.alias) || has(x.tags) || has(x.name) || has(x.owner)))'
+                    - message: '''alias'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.exists(x, has(x.alias) && (has(x.id) || has(x.tags) || has(x.name) || has(x.owner)))'
+                    - message: '''alias'' is mutually exclusive, cannot be set with a combination of other amiSelectorTerms'
+                      rule: '!(self.exists(x, has(x.alias)) && self.size() != 1)'
+                associatePublicIPAddress:
+                  description: AssociatePublicIPAddress controls if public IP addresses are assigned to instances that are launched with the nodeclass.
+                  type: boolean
+                blockDeviceMappings:
+                  description: BlockDeviceMappings to be applied to provisioned nodes.
+                  items:
+                    properties:
+                      deviceName:
+                        description: The device name (for example, /dev/sdh or xvdh).
+                        type: string
+                      ebs:
+                        description: EBS contains parameters used to automatically set up EBS volumes when an instance is launched.
+                        properties:
+                          deleteOnTermination:
+                            description: DeleteOnTermination indicates whether the EBS volume is deleted on instance termination.
+                            type: boolean
+                          encrypted:
+                            description: |-
+                              Encrypted indicates whether the EBS volume is encrypted. Encrypted volumes can only
+                              be attached to instances that support Amazon EBS encryption. If you are creating
+                              a volume from a snapshot, you can't specify an encryption value.
+                            type: boolean
+                          iops:
+                            description: |-
+                              IOPS is the number of I/O operations per second (IOPS). For gp3, io1, and io2 volumes,
+                              this represents the number of IOPS that are provisioned for the volume. For
+                              gp2 volumes, this represents the baseline performance of the volume and the
+                              rate at which the volume accumulates I/O credits for bursting.
+
+                              The following are the supported values for each volume type:
+
+                                 * gp3: 3,000-16,000 IOPS
+
+                                 * io1: 100-64,000 IOPS
+
+                                 * io2: 100-64,000 IOPS
+
+                              For io1 and io2 volumes, we guarantee 64,000 IOPS only for Instances built
+                              on the Nitro System (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances).
+                              Other instance families guarantee performance up to 32,000 IOPS.
+
+                              This parameter is supported for io1, io2, and gp3 volumes only. This parameter
+                              is not supported for gp2, st1, sc1, or standard volumes.
+                            format: int64
+                            type: integer
+                          kmsKeyID:
+                            description: KMSKeyID (ARN) of the symmetric Key Management Service (KMS) CMK used for encryption.
+                            type: string
+                          snapshotID:
+                            description: SnapshotID is the ID of an EBS snapshot
+                            type: string
+                          throughput:
+                            description: |-
+                              Throughput to provision for a gp3 volume, with a maximum of 1,000 MiB/s.
+                              Valid Range: Minimum value of 125. Maximum value of 1000.
+                            format: int64
+                            type: integer
+                          volumeSize:
+                            description: |-
+                              VolumeSize in `Gi`, `G`, `Ti`, or `T`. You must specify either a snapshot ID or
+                              a volume size. The following are the supported volumes sizes for each volume
+                              type:
+
+                                 * gp2 and gp3: 1-16,384
+
+                                 * io1 and io2: 4-16,384
+
+                                 * st1 and sc1: 125-16,384
+
+                                 * standard: 1-1,024
+                            pattern: ^((?:[1-9][0-9]{0,3}|[1-4][0-9]{4}|[5][0-8][0-9]{3}|59000)Gi|(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|[6][0-3][0-9]{3}|64000)G|([1-9]||[1-5][0-7]|58)Ti|([1-9]||[1-5][0-9]|6[0-3]|64)T)$
+                            type: string
+                          volumeType:
+                            description: |-
+                              VolumeType of the block device.
+                              For more information, see Amazon EBS volume types (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html)
+                              in the Amazon Elastic Compute Cloud User Guide.
+                            enum:
+                              - standard
+                              - io1
+                              - io2
+                              - gp2
+                              - sc1
+                              - st1
+                              - gp3
+                            type: string
+                        type: object
+                        x-kubernetes-validations:
+                          - message: snapshotID or volumeSize must be defined
+                            rule: has(self.snapshotID) || has(self.volumeSize)
+                      rootVolume:
+                        description: |-
+                          RootVolume is a flag indicating if this device is mounted as kubelet root dir. You can
+                          configure at most one root volume in BlockDeviceMappings.
+                        type: boolean
+                    type: object
+                  maxItems: 50
+                  type: array
+                  x-kubernetes-validations:
+                    - message: must have only one blockDeviceMappings with rootVolume
+                      rule: self.filter(x, has(x.rootVolume)?x.rootVolume==true:false).size() <= 1
+                context:
+                  description: |-
+                    Context is a Reserved field in EC2 APIs
+                    https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet.html
+                  type: string
+                detailedMonitoring:
+                  description: DetailedMonitoring controls if detailed monitoring is enabled for instances that are launched
+                  type: boolean
+                instanceProfile:
+                  description: |-
+                    InstanceProfile is the AWS entity that instances use.
+                    This field is mutually exclusive from role.
+                    The instance profile should already have a role assigned to it that Karpenter
+                     has PassRole permission on for instance launch using this instanceProfile to succeed.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: instanceProfile cannot be empty
+                      rule: self != ''
+                instanceStorePolicy:
+                  description: InstanceStorePolicy specifies how to handle instance-store disks.
+                  enum:
+                    - RAID0
+                  type: string
+                kubelet:
+                  description: |-
+                    Kubelet defines args to be used when configuring kubelet on provisioned nodes.
+                    They are a subset of the upstream types, recognizing not all options may be supported.
+                    Wherever possible, the types and names should reflect the upstream kubelet types.
+                  properties:
+                    clusterDNS:
+                      description: |-
+                        clusterDNS is a list of IP addresses for the cluster DNS server.
+                        Note that not all providers may use all addresses.
+                      items:
+                        type: string
+                      type: array
+                    cpuCFSQuota:
+                      description: CPUCFSQuota enables CPU CFS quota enforcement for containers that specify CPU limits.
+                      type: boolean
+                    evictionHard:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionHard is the map of signal names to quantities that define hard eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionHard are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionMaxPodGracePeriod:
+                      description: |-
+                        EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in
+                        response to soft eviction thresholds being met.
+                      format: int32
+                      type: integer
+                    evictionSoft:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionSoft is the map of signal names to quantities that define soft eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoft are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionSoftGracePeriod:
+                      additionalProperties:
+                        type: string
+                      description: EvictionSoftGracePeriod is the map of signal names to quantities that define grace periods for each eviction signal
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoftGracePeriod are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    imageGCHighThresholdPercent:
+                      description: |-
+                        ImageGCHighThresholdPercent is the percent of disk usage after which image
+                        garbage collection is always run. The percent is calculated by dividing this
+                        field value by 100, so this field must be between 0 and 100, inclusive.
+                        When specified, the value must be greater than ImageGCLowThresholdPercent.
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    imageGCLowThresholdPercent:
+                      description: |-
+                        ImageGCLowThresholdPercent is the percent of disk usage before which image
+                        garbage collection is never run. Lowest disk usage to garbage collect to.
+                        The percent is calculated by dividing this field value by 100,
+                        so the field value must be between 0 and 100, inclusive.
+                        When specified, the value must be less than imageGCHighThresholdPercent
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    kubeReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: KubeReserved contains resources reserved for Kubernetes system components.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for kubeReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: kubeReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                    maxPods:
+                      description: |-
+                        MaxPods is an override for the maximum number of pods that can run on
+                        a worker node instance.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    podsPerCore:
+                      description: |-
+                        PodsPerCore is an override for the number of pods that can run on a worker node
+                        instance based on the number of cpu cores. This value cannot exceed MaxPods, so, if
+                        MaxPods is a lower value, that value will be used.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    systemReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: SystemReserved contains resources reserved for OS system daemons and kernel memory.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for systemReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: systemReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                  type: object
+                  x-kubernetes-validations:
+                    - message: imageGCHighThresholdPercent must be greater than imageGCLowThresholdPercent
+                      rule: 'has(self.imageGCHighThresholdPercent) && has(self.imageGCLowThresholdPercent) ?  self.imageGCHighThresholdPercent > self.imageGCLowThresholdPercent  : true'
+                    - message: evictionSoft OwnerKey does not have a matching evictionSoftGracePeriod
+                      rule: has(self.evictionSoft) ? self.evictionSoft.all(e, (e in self.evictionSoftGracePeriod)):true
+                    - message: evictionSoftGracePeriod OwnerKey does not have a matching evictionSoft
+                      rule: has(self.evictionSoftGracePeriod) ? self.evictionSoftGracePeriod.all(e, (e in self.evictionSoft)):true
+                metadataOptions:
+                  default:
+                    httpEndpoint: enabled
+                    httpProtocolIPv6: disabled
+                    httpPutResponseHopLimit: 1
+                    httpTokens: required
+                  description: |-
+                    MetadataOptions for the generated launch template of provisioned nodes.
+
+                    This specifies the exposure of the Instance Metadata Service to
+                    provisioned EC2 nodes. For more information,
+                    see Instance Metadata and User Data
+                    (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
+                    in the Amazon Elastic Compute Cloud User Guide.
+
+                    Refer to recommended, security best practices
+                    (https://aws.github.io/aws-eks-best-practices/security/docs/iam/#restrict-access-to-the-instance-profile-assigned-to-the-worker-node)
+                    for limiting exposure of Instance Metadata and User Data to pods.
+                    If omitted, defaults to httpEndpoint enabled, with httpProtocolIPv6
+                    disabled, with httpPutResponseLimit of 1, and with httpTokens
+                    required.
+                  properties:
+                    httpEndpoint:
+                      default: enabled
+                      description: |-
+                        HTTPEndpoint enables or disables the HTTP metadata endpoint on provisioned
+                        nodes. If metadata options is non-nil, but this parameter is not specified,
+                        the default state is "enabled".
+
+                        If you specify a value of "disabled", instance metadata will not be accessible
+                        on the node.
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpProtocolIPv6:
+                      default: disabled
+                      description: |-
+                        HTTPProtocolIPv6 enables or disables the IPv6 endpoint for the instance metadata
+                        service on provisioned nodes. If metadata options is non-nil, but this parameter
+                        is not specified, the default state is "disabled".
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpPutResponseHopLimit:
+                      default: 1
+                      description: |-
+                        HTTPPutResponseHopLimit is the desired HTTP PUT response hop limit for
+                        instance metadata requests. The larger the number, the further instance
+                        metadata requests can travel. Possible values are integers from 1 to 64.
+                        If metadata options is non-nil, but this parameter is not specified, the
+                        default value is 1.
+                      format: int64
+                      maximum: 64
+                      minimum: 1
+                      type: integer
+                    httpTokens:
+                      default: required
+                      description: |-
+                        HTTPTokens determines the state of token usage for instance metadata
+                        requests. If metadata options is non-nil, but this parameter is not
+                        specified, the default state is "required".
+
+                        If the state is optional, one can choose to retrieve instance metadata with
+                        or without a signed token header on the request. If one retrieves the IAM
+                        role credentials without a token, the version 1.0 role credentials are
+                        returned. If one retrieves the IAM role credentials using a valid signed
+                        token, the version 2.0 role credentials are returned.
+
+                        If the state is "required", one must send a signed token header with any
+                        instance metadata retrieval requests. In this state, retrieving the IAM
+                        role credentials always returns the version 2.0 credentials; the version
+                        1.0 credentials are not available.
+                      enum:
+                        - required
+                        - optional
+                      type: string
+                  type: object
+                role:
+                  description: |-
+                    Role is the AWS identity that nodes use. This field is immutable.
+                    This field is mutually exclusive from instanceProfile.
+                    Marking this field as immutable avoids concerns around terminating managed instance profiles from running instances.
+                    This field may be made mutable in the future, assuming the correct garbage collection and drift handling is implemented
+                    for the old instance profiles on an update.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: role cannot be empty
+                      rule: self != ''
+                    - message: immutable field changed
+                      rule: self == oldSelf
+                securityGroupSelectorTerms:
+                  description: SecurityGroupSelectorTerms is a list of or security group selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SecurityGroupSelectorTerm defines selection logic for a security group used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the security group id in EC2
+                        pattern: sg-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the security group name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: securityGroupSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id', 'name']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && (has(x.tags) || has(x.name)))'
+                    - message: '''name'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.name) && (has(x.tags) || has(x.id)))'
+                subnetSelectorTerms:
+                  description: SubnetSelectorTerms is a list of or subnet selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SubnetSelectorTerm defines selection logic for a subnet used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the subnet id in EC2
+                        pattern: subnet-[0-9a-z]+
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: subnetSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id']
+                      rule: self.all(x, has(x.tags) || has(x.id))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in subnetSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && has(x.tags))'
+                tags:
+                  additionalProperties:
+                    type: string
+                  description: Tags to be applied on ec2 resources like instances and launch templates.
+                  type: object
+                  x-kubernetes-validations:
+                    - message: empty tag keys aren't supported
+                      rule: self.all(k, k != '')
+                    - message: tag contains a restricted tag matching eks:eks-cluster-name
+                      rule: self.all(k, k !='eks:eks-cluster-name')
+                    - message: tag contains a restricted tag matching kubernetes.io/cluster/
+                      rule: self.all(k, !k.startsWith('kubernetes.io/cluster') )
+                    - message: tag contains a restricted tag matching karpenter.sh/nodepool
+                      rule: self.all(k, k != 'karpenter.sh/nodepool')
+                    - message: tag contains a restricted tag matching karpenter.sh/nodeclaim
+                      rule: self.all(k, k !='karpenter.sh/nodeclaim')
+                    - message: tag contains a restricted tag matching karpenter.k8s.aws/ec2nodeclass
+                      rule: self.all(k, k !='karpenter.k8s.aws/ec2nodeclass')
+                userData:
+                  description: |-
+                    UserData to be applied to the provisioned nodes.
+                    It must be in the appropriate format based on the AMIFamily in use. Karpenter will merge certain fields into
+                    this UserData to ensure nodes are being provisioned with the correct configuration.
+                  type: string
+              required:
+                - amiSelectorTerms
+                - securityGroupSelectorTerms
+                - subnetSelectorTerms
+              type: object
+              x-kubernetes-validations:
+                - message: must specify exactly one of ['role', 'instanceProfile']
+                  rule: (has(self.role) && !has(self.instanceProfile)) || (!has(self.role) && has(self.instanceProfile))
+                - message: changing from 'instanceProfile' to 'role' is not supported. You must delete and recreate this node class if you want to change this.
+                  rule: (has(oldSelf.role) && has(self.role)) || (has(oldSelf.instanceProfile) && has(self.instanceProfile))
+                - message: if set, amiFamily must be 'AL2' or 'Custom' when using an AL2 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''al2'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''AL2'') : true)'
+                - message: if set, amiFamily must be 'AL2023' or 'Custom' when using an AL2023 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''al2023'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''AL2023'') : true)'
+                - message: if set, amiFamily must be 'Bottlerocket' or 'Custom' when using a Bottlerocket alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''bottlerocket'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Bottlerocket'') : true)'
+                - message: if set, amiFamily must be 'Windows2019' or 'Custom' when using a Windows2019 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''windows2019'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Windows2019'') : true)'
+                - message: if set, amiFamily must be 'Windows2022' or 'Custom' when using a Windows2022 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''windows2022'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Windows2022'') : true)'
+                - message: must specify amiFamily if amiSelectorTerms does not contain an alias
+                  rule: 'self.amiSelectorTerms.exists(x, has(x.alias)) ? true : has(self.amiFamily)'
+            status:
+              description: EC2NodeClassStatus contains the resolved state of the EC2NodeClass
+              properties:
+                amis:
+                  description: |-
+                    AMI contains the current AMI values that are available to the
+                    cluster under the AMI selectors.
+                  items:
+                    description: AMI contains resolved AMI selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the AMI
+                        type: string
+                      name:
+                        description: Name of the AMI
+                        type: string
+                      requirements:
+                        description: Requirements of the AMI to be utilized on an instance type
+                        items:
+                          description: |-
+                            A node selector requirement is a selector that contains values, a key, and an operator
+                            that relates the key and values.
+                          properties:
+                            key:
+                              description: The label key that the selector applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                Represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                              type: string
+                            values:
+                              description: |-
+                                An array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. If the operator is Gt or Lt, the values
+                                array must have a single element, which will be interpreted as an integer.
+                                This array is replaced during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                            - key
+                            - operator
+                          type: object
+                        type: array
+                    required:
+                      - id
+                      - requirements
+                    type: object
+                  type: array
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                instanceProfile:
+                  description: InstanceProfile contains the resolved instance profile for the role
+                  type: string
+                securityGroups:
+                  description: |-
+                    SecurityGroups contains the current Security Groups values that are available to the
+                    cluster under the SecurityGroups selectors.
+                  items:
+                    description: SecurityGroup contains resolved SecurityGroup selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the security group
+                        type: string
+                      name:
+                        description: Name of the security group
+                        type: string
+                    required:
+                      - id
+                    type: object
+                  type: array
+                subnets:
+                  description: |-
+                    Subnets contains the current Subnet values that are available to the
+                    cluster under the subnet selectors.
+                  items:
+                    description: Subnet contains resolved Subnet selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the subnet
+                        type: string
+                      zone:
+                        description: The associated availability zone
+                        type: string
+                      zoneID:
+                        description: The associated availability zone ID
+                        type: string
+                    required:
+                      - id
+                      - zone
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: EC2NodeClass is the Schema for the EC2NodeClass API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                EC2NodeClassSpec is the top level specification for the AWS Karpenter Provider.
+                This will contain configuration necessary to launch instances in AWS.
+              properties:
+                amiFamily:
+                  description: AMIFamily is the AMI family that instances use.
+                  enum:
+                    - AL2
+                    - AL2023
+                    - Bottlerocket
+                    - Ubuntu
+                    - Custom
+                    - Windows2019
+                    - Windows2022
+                  type: string
+                amiSelectorTerms:
+                  description: AMISelectorTerms is a list of or ami selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      AMISelectorTerm defines selection logic for an ami used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the ami id in EC2
+                        pattern: ami-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the ami name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      owner:
+                        description: |-
+                          Owner is the owner for the ami.
+                          You can specify a combination of AWS account IDs, "self", "amazon", and "aws-marketplace"
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: expected at least one, got none, ['tags', 'id', 'name']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && (has(x.tags) || has(x.name) || has(x.owner)))'
+                associatePublicIPAddress:
+                  description: AssociatePublicIPAddress controls if public IP addresses are assigned to instances that are launched with the nodeclass.
+                  type: boolean
+                blockDeviceMappings:
+                  description: BlockDeviceMappings to be applied to provisioned nodes.
+                  items:
+                    properties:
+                      deviceName:
+                        description: The device name (for example, /dev/sdh or xvdh).
+                        type: string
+                      ebs:
+                        description: EBS contains parameters used to automatically set up EBS volumes when an instance is launched.
+                        properties:
+                          deleteOnTermination:
+                            description: DeleteOnTermination indicates whether the EBS volume is deleted on instance termination.
+                            type: boolean
+                          encrypted:
+                            description: |-
+                              Encrypted indicates whether the EBS volume is encrypted. Encrypted volumes can only
+                              be attached to instances that support Amazon EBS encryption. If you are creating
+                              a volume from a snapshot, you can't specify an encryption value.
+                            type: boolean
+                          iops:
+                            description: |-
+                              IOPS is the number of I/O operations per second (IOPS). For gp3, io1, and io2 volumes,
+                              this represents the number of IOPS that are provisioned for the volume. For
+                              gp2 volumes, this represents the baseline performance of the volume and the
+                              rate at which the volume accumulates I/O credits for bursting.
+
+                              The following are the supported values for each volume type:
+
+                                 * gp3: 3,000-16,000 IOPS
+
+                                 * io1: 100-64,000 IOPS
+
+                                 * io2: 100-64,000 IOPS
+
+                              For io1 and io2 volumes, we guarantee 64,000 IOPS only for Instances built
+                              on the Nitro System (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances).
+                              Other instance families guarantee performance up to 32,000 IOPS.
+
+                              This parameter is supported for io1, io2, and gp3 volumes only. This parameter
+                              is not supported for gp2, st1, sc1, or standard volumes.
+                            format: int64
+                            type: integer
+                          kmsKeyID:
+                            description: KMSKeyID (ARN) of the symmetric Key Management Service (KMS) CMK used for encryption.
+                            type: string
+                          snapshotID:
+                            description: SnapshotID is the ID of an EBS snapshot
+                            type: string
+                          throughput:
+                            description: |-
+                              Throughput to provision for a gp3 volume, with a maximum of 1,000 MiB/s.
+                              Valid Range: Minimum value of 125. Maximum value of 1000.
+                            format: int64
+                            type: integer
+                          volumeSize:
+                            description: |-
+                              VolumeSize in `Gi`, `G`, `Ti`, or `T`. You must specify either a snapshot ID or
+                              a volume size. The following are the supported volumes sizes for each volume
+                              type:
+
+                                 * gp2 and gp3: 1-16,384
+
+                                 * io1 and io2: 4-16,384
+
+                                 * st1 and sc1: 125-16,384
+
+                                 * standard: 1-1,024
+                            pattern: ^((?:[1-9][0-9]{0,3}|[1-4][0-9]{4}|[5][0-8][0-9]{3}|59000)Gi|(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|[6][0-3][0-9]{3}|64000)G|([1-9]||[1-5][0-7]|58)Ti|([1-9]||[1-5][0-9]|6[0-3]|64)T)$
+                            type: string
+                          volumeType:
+                            description: |-
+                              VolumeType of the block device.
+                              For more information, see Amazon EBS volume types (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html)
+                              in the Amazon Elastic Compute Cloud User Guide.
+                            enum:
+                              - standard
+                              - io1
+                              - io2
+                              - gp2
+                              - sc1
+                              - st1
+                              - gp3
+                            type: string
+                        type: object
+                        x-kubernetes-validations:
+                          - message: snapshotID or volumeSize must be defined
+                            rule: has(self.snapshotID) || has(self.volumeSize)
+                      rootVolume:
+                        description: |-
+                          RootVolume is a flag indicating if this device is mounted as kubelet root dir. You can
+                          configure at most one root volume in BlockDeviceMappings.
+                        type: boolean
+                    type: object
+                  maxItems: 50
+                  type: array
+                  x-kubernetes-validations:
+                    - message: must have only one blockDeviceMappings with rootVolume
+                      rule: self.filter(x, has(x.rootVolume)?x.rootVolume==true:false).size() <= 1
+                context:
+                  description: |-
+                    Context is a Reserved field in EC2 APIs
+                    https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet.html
+                  type: string
+                detailedMonitoring:
+                  description: DetailedMonitoring controls if detailed monitoring is enabled for instances that are launched
+                  type: boolean
+                instanceProfile:
+                  description: |-
+                    InstanceProfile is the AWS entity that instances use.
+                    This field is mutually exclusive from role.
+                    The instance profile should already have a role assigned to it that Karpenter
+                     has PassRole permission on for instance launch using this instanceProfile to succeed.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: instanceProfile cannot be empty
+                      rule: self != ''
+                instanceStorePolicy:
+                  description: InstanceStorePolicy specifies how to handle instance-store disks.
+                  enum:
+                    - RAID0
+                  type: string
+                metadataOptions:
+                  default:
+                    httpEndpoint: enabled
+                    httpProtocolIPv6: disabled
+                    httpPutResponseHopLimit: 1
+                    httpTokens: required
+                  description: |-
+                    MetadataOptions for the generated launch template of provisioned nodes.
+
+                    This specifies the exposure of the Instance Metadata Service to
+                    provisioned EC2 nodes. For more information,
+                    see Instance Metadata and User Data
+                    (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
+                    in the Amazon Elastic Compute Cloud User Guide.
+
+                    Refer to recommended, security best practices
+                    (https://aws.github.io/aws-eks-best-practices/security/docs/iam/#restrict-access-to-the-instance-profile-assigned-to-the-worker-node)
+                    for limiting exposure of Instance Metadata and User Data to pods.
+                    If omitted, defaults to httpEndpoint enabled, with httpProtocolIPv6
+                    disabled, with httpPutResponseLimit of 1, and with httpTokens
+                    required.
+                  properties:
+                    httpEndpoint:
+                      default: enabled
+                      description: |-
+                        HTTPEndpoint enables or disables the HTTP metadata endpoint on provisioned
+                        nodes. If metadata options is non-nil, but this parameter is not specified,
+                        the default state is "enabled".
+
+                        If you specify a value of "disabled", instance metadata will not be accessible
+                        on the node.
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpProtocolIPv6:
+                      default: disabled
+                      description: |-
+                        HTTPProtocolIPv6 enables or disables the IPv6 endpoint for the instance metadata
+                        service on provisioned nodes. If metadata options is non-nil, but this parameter
+                        is not specified, the default state is "disabled".
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpPutResponseHopLimit:
+                      default: 2
+                      description: |-
+                        HTTPPutResponseHopLimit is the desired HTTP PUT response hop limit for
+                        instance metadata requests. The larger the number, the further instance
+                        metadata requests can travel. Possible values are integers from 1 to 64.
+                        If metadata options is non-nil, but this parameter is not specified, the
+                        default value is 2.
+                      format: int64
+                      maximum: 64
+                      minimum: 1
+                      type: integer
+                    httpTokens:
+                      default: required
+                      description: |-
+                        HTTPTokens determines the state of token usage for instance metadata
+                        requests. If metadata options is non-nil, but this parameter is not
+                        specified, the default state is "required".
+
+                        If the state is optional, one can choose to retrieve instance metadata with
+                        or without a signed token header on the request. If one retrieves the IAM
+                        role credentials without a token, the version 1.0 role credentials are
+                        returned. If one retrieves the IAM role credentials using a valid signed
+                        token, the version 2.0 role credentials are returned.
+
+                        If the state is "required", one must send a signed token header with any
+                        instance metadata retrieval requests. In this state, retrieving the IAM
+                        role credentials always returns the version 2.0 credentials; the version
+                        1.0 credentials are not available.
+                      enum:
+                        - required
+                        - optional
+                      type: string
+                  type: object
+                role:
+                  description: |-
+                    Role is the AWS identity that nodes use. This field is immutable.
+                    This field is mutually exclusive from instanceProfile.
+                    Marking this field as immutable avoids concerns around terminating managed instance profiles from running instances.
+                    This field may be made mutable in the future, assuming the correct garbage collection and drift handling is implemented
+                    for the old instance profiles on an update.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: role cannot be empty
+                      rule: self != ''
+                    - message: immutable field changed
+                      rule: self == oldSelf
+                securityGroupSelectorTerms:
+                  description: SecurityGroupSelectorTerms is a list of or security group selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SecurityGroupSelectorTerm defines selection logic for a security group used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the security group id in EC2
+                        pattern: sg-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the security group name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: securityGroupSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id', 'name']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && (has(x.tags) || has(x.name)))'
+                    - message: '''name'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.name) && (has(x.tags) || has(x.id)))'
+                subnetSelectorTerms:
+                  description: SubnetSelectorTerms is a list of or subnet selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SubnetSelectorTerm defines selection logic for a subnet used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the subnet id in EC2
+                        pattern: subnet-[0-9a-z]+
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: subnetSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id']
+                      rule: self.all(x, has(x.tags) || has(x.id))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in subnetSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && has(x.tags))'
+                tags:
+                  additionalProperties:
+                    type: string
+                  description: Tags to be applied on ec2 resources like instances and launch templates.
+                  type: object
+                  x-kubernetes-validations:
+                    - message: empty tag keys aren't supported
+                      rule: self.all(k, k != '')
+                    - message: tag contains a restricted tag matching kubernetes.io/cluster/
+                      rule: self.all(k, !k.startsWith('kubernetes.io/cluster') )
+                    - message: tag contains a restricted tag matching karpenter.sh/nodepool
+                      rule: self.all(k, k != 'karpenter.sh/nodepool')
+                    - message: tag contains a restricted tag matching karpenter.sh/managed-by
+                      rule: self.all(k, k !='karpenter.sh/managed-by')
+                    - message: tag contains a restricted tag matching karpenter.sh/nodeclaim
+                      rule: self.all(k, k !='karpenter.sh/nodeclaim')
+                    - message: tag contains a restricted tag matching karpenter.k8s.aws/ec2nodeclass
+                      rule: self.all(k, k !='karpenter.k8s.aws/ec2nodeclass')
+                userData:
+                  description: |-
+                    UserData to be applied to the provisioned nodes.
+                    It must be in the appropriate format based on the AMIFamily in use. Karpenter will merge certain fields into
+                    this UserData to ensure nodes are being provisioned with the correct configuration.
+                  type: string
+              required:
+                - amiFamily
+                - securityGroupSelectorTerms
+                - subnetSelectorTerms
+              type: object
+              x-kubernetes-validations:
+                - message: amiSelectorTerms is required when amiFamily == 'Custom'
+                  rule: 'self.amiFamily == ''Custom'' ? self.amiSelectorTerms.size() != 0 : true'
+                - message: must specify exactly one of ['role', 'instanceProfile']
+                  rule: (has(self.role) && !has(self.instanceProfile)) || (!has(self.role) && has(self.instanceProfile))
+                - message: changing from 'instanceProfile' to 'role' is not supported. You must delete and recreate this node class if you want to change this.
+                  rule: (has(oldSelf.role) && has(self.role)) || (has(oldSelf.instanceProfile) && has(self.instanceProfile))
+            status:
+              description: EC2NodeClassStatus contains the resolved state of the EC2NodeClass
+              properties:
+                amis:
+                  description: |-
+                    AMI contains the current AMI values that are available to the
+                    cluster under the AMI selectors.
+                  items:
+                    description: AMI contains resolved AMI selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the AMI
+                        type: string
+                      name:
+                        description: Name of the AMI
+                        type: string
+                      requirements:
+                        description: Requirements of the AMI to be utilized on an instance type
+                        items:
+                          description: |-
+                            A node selector requirement is a selector that contains values, a key, and an operator
+                            that relates the key and values.
+                          properties:
+                            key:
+                              description: The label key that the selector applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                Represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                              type: string
+                            values:
+                              description: |-
+                                An array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. If the operator is Gt or Lt, the values
+                                array must have a single element, which will be interpreted as an integer.
+                                This array is replaced during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                            - key
+                            - operator
+                          type: object
+                        type: array
+                    required:
+                      - id
+                      - requirements
+                    type: object
+                  type: array
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                instanceProfile:
+                  description: InstanceProfile contains the resolved instance profile for the role
+                  type: string
+                securityGroups:
+                  description: |-
+                    SecurityGroups contains the current Security Groups values that are available to the
+                    cluster under the SecurityGroups selectors.
+                  items:
+                    description: SecurityGroup contains resolved SecurityGroup selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the security group
+                        type: string
+                      name:
+                        description: Name of the security group
+                        type: string
+                    required:
+                      - id
+                    type: object
+                  type: array
+                subnets:
+                  description: |-
+                    Subnets contains the current Subnet values that are available to the
+                    cluster under the subnet selectors.
+                  items:
+                    description: Subnet contains resolved Subnet selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the subnet
+                        type: string
+                      zone:
+                        description: The associated availability zone
+                        type: string
+                      zoneID:
+                        description: The associated availability zone ID
+                        type: string
+                    required:
+                      - id
+                      - zone
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+        - v1
+      clientConfig:
+        service:
+          name: karpenter
+          namespace: kube-system
+          port: 8443

--- a/content/projects/karpenter/v1.0.3/karpenter.sh_nodeclaims.yaml
+++ b/content/projects/karpenter/v1.0.3/karpenter.sh_nodeclaims.yaml
@@ -1,0 +1,829 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.2
+  name: nodeclaims.karpenter.sh
+spec:
+  group: karpenter.sh
+  names:
+    categories:
+      - karpenter
+    kind: NodeClaim
+    listKind: NodeClaimList
+    plural: nodeclaims
+    singular: nodeclaim
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.labels.node\.kubernetes\.io/instance-type
+          name: Type
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/capacity-type
+          name: Capacity
+          type: string
+        - jsonPath: .metadata.labels.topology\.kubernetes\.io/zone
+          name: Zone
+          type: string
+        - jsonPath: .status.nodeName
+          name: Node
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .status.providerID
+          name: ID
+          priority: 1
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/nodepool
+          name: NodePool
+          priority: 1
+          type: string
+        - jsonPath: .spec.nodeClassRef.name
+          name: NodeClass
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: NodeClaim is the Schema for the NodeClaims API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: NodeClaimSpec describes the desired state of the NodeClaim
+              properties:
+                expireAfter:
+                  default: 720h
+                  description: |-
+                    ExpireAfter is the duration the controller will wait
+                    before terminating a node, measured from when the node is created. This
+                    is useful to implement features like eventually consistent node upgrade,
+                    memory leak protection, and disruption testing.
+                  pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                  type: string
+                nodeClassRef:
+                  description: NodeClassRef is a reference to an object that defines provider specific configuration
+                  properties:
+                    group:
+                      description: API version of the referent
+                      pattern: ^[^/]*$
+                      type: string
+                    kind:
+                      description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                      type: string
+                    name:
+                      description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                      type: string
+                  required:
+                    - group
+                    - kind
+                    - name
+                  type: object
+                requirements:
+                  description: Requirements are layered with GetLabels and applied to every node.
+                  items:
+                    description: |-
+                      A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                      and minValues that represent the requirement to have at least that many values.
+                    properties:
+                      key:
+                        description: The label key that the selector applies to.
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                        x-kubernetes-validations:
+                          - message: label domain "kubernetes.io" is restricted
+                            rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                          - message: label domain "k8s.io" is restricted
+                            rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                          - message: label domain "karpenter.sh" is restricted
+                            rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                          - message: label "kubernetes.io/hostname" is restricted
+                            rule: self != "kubernetes.io/hostname"
+                          - message: label domain "karpenter.k8s.aws" is restricted
+                            rule: self in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                      minValues:
+                        description: |-
+                          This field is ALPHA and can be dropped or replaced at any time
+                          MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                        maximum: 50
+                        minimum: 1
+                        type: integer
+                      operator:
+                        description: |-
+                          Represents a key's relationship to a set of values.
+                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                        type: string
+                        enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          - Gt
+                          - Lt
+                      values:
+                        description: |-
+                          An array of string values. If the operator is In or NotIn,
+                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                          the values array must be empty. If the operator is Gt or Lt, the values
+                          array must have a single element, which will be interpreted as an integer.
+                          This array is replaced during a strategic merge patch.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                        maxLength: 63
+                        pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                    required:
+                      - key
+                      - operator
+                    type: object
+                  maxItems: 100
+                  type: array
+                  x-kubernetes-validations:
+                    - message: requirements with operator 'In' must have a value defined
+                      rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                    - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                      rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                    - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                      rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                resources:
+                  description: Resources models the resource requirements for the NodeClaim to launch
+                  properties:
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: Requests describes the minimum required resources for the NodeClaim to launch
+                      type: object
+                  type: object
+                startupTaints:
+                  description: |-
+                    StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                    within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                    daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                    purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                taints:
+                  description: Taints will be applied to the NodeClaim's node.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                terminationGracePeriod:
+                  description: |-
+                    TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
+
+                    Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
+
+                    This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
+                    When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
+
+                    Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
+                    If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
+                    that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
+
+                    The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
+                    If left undefined, the controller will wait indefinitely for pods to be drained.
+                  pattern: ^([0-9]+(s|m|h))+$
+                  type: string
+              required:
+                - nodeClassRef
+                - requirements
+              type: object
+              x-kubernetes-validations:
+                - message: spec is immutable
+                  rule: self == oldSelf
+            status:
+              description: NodeClaimStatus defines the observed state of NodeClaim
+              properties:
+                allocatable:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Allocatable is the estimated allocatable capacity of the node
+                  type: object
+                capacity:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Capacity is the estimated full capacity of the node
+                  type: object
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        pattern: ^([A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?|)$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - status
+                      - type
+                    type: object
+                  type: array
+                imageID:
+                  description: ImageID is an identifier for the image that runs on the node
+                  type: string
+                lastPodEventTime:
+                  description: |-
+                    LastPodEventTime is updated with the last time a pod was scheduled
+                    or removed from the node. A pod going terminal or terminating
+                    is also considered as removed.
+                  format: date-time
+                  type: string
+                nodeName:
+                  description: NodeName is the name of the corresponding node object
+                  type: string
+                providerID:
+                  description: ProviderID of the corresponding node object
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.labels.node\.kubernetes\.io/instance-type
+          name: Type
+          type: string
+        - jsonPath: .metadata.labels.topology\.kubernetes\.io/zone
+          name: Zone
+          type: string
+        - jsonPath: .status.nodeName
+          name: Node
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .metadata.labels.karpenter\.sh/capacity-type
+          name: Capacity
+          priority: 1
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/nodepool
+          name: NodePool
+          priority: 1
+          type: string
+        - jsonPath: .spec.nodeClassRef.name
+          name: NodeClass
+          priority: 1
+          type: string
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: NodeClaim is the Schema for the NodeClaims API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: NodeClaimSpec describes the desired state of the NodeClaim
+              properties:
+                kubelet:
+                  description: |-
+                    Kubelet defines args to be used when configuring kubelet on provisioned nodes.
+                    They are a subset of the upstream types, recognizing not all options may be supported.
+                    Wherever possible, the types and names should reflect the upstream kubelet types.
+                  properties:
+                    clusterDNS:
+                      description: |-
+                        clusterDNS is a list of IP addresses for the cluster DNS server.
+                        Note that not all providers may use all addresses.
+                      items:
+                        type: string
+                      type: array
+                    cpuCFSQuota:
+                      description: CPUCFSQuota enables CPU CFS quota enforcement for containers that specify CPU limits.
+                      type: boolean
+                    evictionHard:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionHard is the map of signal names to quantities that define hard eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionHard are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionMaxPodGracePeriod:
+                      description: |-
+                        EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in
+                        response to soft eviction thresholds being met.
+                      format: int32
+                      type: integer
+                    evictionSoft:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionSoft is the map of signal names to quantities that define soft eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoft are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionSoftGracePeriod:
+                      additionalProperties:
+                        type: string
+                      description: EvictionSoftGracePeriod is the map of signal names to quantities that define grace periods for each eviction signal
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoftGracePeriod are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    imageGCHighThresholdPercent:
+                      description: |-
+                        ImageGCHighThresholdPercent is the percent of disk usage after which image
+                        garbage collection is always run. The percent is calculated by dividing this
+                        field value by 100, so this field must be between 0 and 100, inclusive.
+                        When specified, the value must be greater than ImageGCLowThresholdPercent.
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    imageGCLowThresholdPercent:
+                      description: |-
+                        ImageGCLowThresholdPercent is the percent of disk usage before which image
+                        garbage collection is never run. Lowest disk usage to garbage collect to.
+                        The percent is calculated by dividing this field value by 100,
+                        so the field value must be between 0 and 100, inclusive.
+                        When specified, the value must be less than imageGCHighThresholdPercent
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    kubeReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: KubeReserved contains resources reserved for Kubernetes system components.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for kubeReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: kubeReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                    maxPods:
+                      description: |-
+                        MaxPods is an override for the maximum number of pods that can run on
+                        a worker node instance.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    podsPerCore:
+                      description: |-
+                        PodsPerCore is an override for the number of pods that can run on a worker node
+                        instance based on the number of cpu cores. This value cannot exceed MaxPods, so, if
+                        MaxPods is a lower value, that value will be used.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    systemReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: SystemReserved contains resources reserved for OS system daemons and kernel memory.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for systemReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: systemReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                  type: object
+                  x-kubernetes-validations:
+                    - message: imageGCHighThresholdPercent must be greater than imageGCLowThresholdPercent
+                      rule: 'has(self.imageGCHighThresholdPercent) && has(self.imageGCLowThresholdPercent) ?  self.imageGCHighThresholdPercent > self.imageGCLowThresholdPercent  : true'
+                    - message: evictionSoft OwnerKey does not have a matching evictionSoftGracePeriod
+                      rule: has(self.evictionSoft) ? self.evictionSoft.all(e, (e in self.evictionSoftGracePeriod)):true
+                    - message: evictionSoftGracePeriod OwnerKey does not have a matching evictionSoft
+                      rule: has(self.evictionSoftGracePeriod) ? self.evictionSoftGracePeriod.all(e, (e in self.evictionSoft)):true
+                nodeClassRef:
+                  description: NodeClassRef is a reference to an object that defines provider specific configuration
+                  properties:
+                    apiVersion:
+                      description: API version of the referent
+                      type: string
+                    kind:
+                      description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                      type: string
+                    name:
+                      description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                      type: string
+                  required:
+                    - name
+                  type: object
+                requirements:
+                  description: Requirements are layered with GetLabels and applied to every node.
+                  items:
+                    description: |-
+                      A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                      and minValues that represent the requirement to have at least that many values.
+                    properties:
+                      key:
+                        description: The label key that the selector applies to.
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                        x-kubernetes-validations:
+                          - message: label domain "kubernetes.io" is restricted
+                            rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                          - message: label domain "k8s.io" is restricted
+                            rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                          - message: label domain "karpenter.sh" is restricted
+                            rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                          - message: label "kubernetes.io/hostname" is restricted
+                            rule: self != "kubernetes.io/hostname"
+                          - message: label domain "karpenter.k8s.aws" is restricted
+                            rule: self in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                      minValues:
+                        description: |-
+                          This field is ALPHA and can be dropped or replaced at any time
+                          MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                        maximum: 50
+                        minimum: 1
+                        type: integer
+                      operator:
+                        description: |-
+                          Represents a key's relationship to a set of values.
+                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                        type: string
+                        enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          - Gt
+                          - Lt
+                      values:
+                        description: |-
+                          An array of string values. If the operator is In or NotIn,
+                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                          the values array must be empty. If the operator is Gt or Lt, the values
+                          array must have a single element, which will be interpreted as an integer.
+                          This array is replaced during a strategic merge patch.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                        maxLength: 63
+                        pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                    required:
+                      - key
+                      - operator
+                    type: object
+                  maxItems: 100
+                  type: array
+                  x-kubernetes-validations:
+                    - message: requirements with operator 'In' must have a value defined
+                      rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                    - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                      rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                    - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                      rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                resources:
+                  description: Resources models the resource requirements for the NodeClaim to launch
+                  properties:
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: Requests describes the minimum required resources for the NodeClaim to launch
+                      type: object
+                  type: object
+                startupTaints:
+                  description: |-
+                    StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                    within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                    daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                    purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                taints:
+                  description: Taints will be applied to the NodeClaim's node.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+              required:
+                - nodeClassRef
+                - requirements
+              type: object
+            status:
+              description: NodeClaimStatus defines the observed state of NodeClaim
+              properties:
+                allocatable:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Allocatable is the estimated allocatable capacity of the node
+                  type: object
+                capacity:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Capacity is the estimated full capacity of the node
+                  type: object
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        pattern: ^([A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?|)$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - status
+                      - type
+                    type: object
+                  type: array
+                imageID:
+                  description: ImageID is an identifier for the image that runs on the node
+                  type: string
+                nodeName:
+                  description: NodeName is the name of the corresponding node object
+                  type: string
+                providerID:
+                  description: ProviderID of the corresponding node object
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+        - v1
+      clientConfig:
+        service:
+          name: karpenter
+          namespace: kube-system
+          port: 8443

--- a/content/projects/karpenter/v1.0.3/karpenter.sh_nodepools.yaml
+++ b/content/projects/karpenter/v1.0.3/karpenter.sh_nodepools.yaml
@@ -1,0 +1,1080 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.2
+  name: nodepools.karpenter.sh
+spec:
+  group: karpenter.sh
+  names:
+    categories:
+      - karpenter
+    kind: NodePool
+    listKind: NodePoolList
+    plural: nodepools
+    singular: nodepool
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.template.spec.nodeClassRef.name
+          name: NodeClass
+          type: string
+        - jsonPath: .status.resources.nodes
+          name: Nodes
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.weight
+          name: Weight
+          priority: 1
+          type: integer
+        - jsonPath: .status.resources.cpu
+          name: CPU
+          priority: 1
+          type: string
+        - jsonPath: .status.resources.memory
+          name: Memory
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: NodePool is the Schema for the NodePools API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                NodePoolSpec is the top level nodepool specification. Nodepools
+                launch nodes in response to pods that are unschedulable. A single nodepool
+                is capable of managing a diverse set of nodes. Node properties are determined
+                from a combination of nodepool and pod scheduling constraints.
+              properties:
+                disruption:
+                  description: Disruption contains the parameters that relate to Karpenter's disruption logic
+                  properties:
+                    budgets:
+                      default:
+                        - nodes: 10%
+                      description: |-
+                        Budgets is a list of Budgets.
+                        If there are multiple active budgets, Karpenter uses
+                        the most restrictive value. If left undefined,
+                        this will default to one budget with a value to 10%.
+                      items:
+                        description: |-
+                          Budget defines when Karpenter will restrict the
+                          number of Node Claims that can be terminating simultaneously.
+                        properties:
+                          duration:
+                            description: |-
+                              Duration determines how long a Budget is active since each Schedule hit.
+                              Only minutes and hours are accepted, as cron does not work in seconds.
+                              If omitted, the budget is always active.
+                              This is required if Schedule is set.
+                              This regex has an optional 0s at the end since the duration.String() always adds
+                              a 0s at the end.
+                            pattern: ^((([0-9]+(h|m))|([0-9]+h[0-9]+m))(0s)?)$
+                            type: string
+                          nodes:
+                            default: 10%
+                            description: |-
+                              Nodes dictates the maximum number of NodeClaims owned by this NodePool
+                              that can be terminating at once. This is calculated by counting nodes that
+                              have a deletion timestamp set, or are actively being deleted by Karpenter.
+                              This field is required when specifying a budget.
+                              This cannot be of type intstr.IntOrString since kubebuilder doesn't support pattern
+                              checking for int nodes for IntOrString nodes.
+                              Ref: https://github.com/kubernetes-sigs/controller-tools/blob/55efe4be40394a288216dab63156b0a64fb82929/pkg/crd/markers/validation.go#L379-L388
+                            pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
+                            type: string
+                          reasons:
+                            description: |-
+                              Reasons is a list of disruption methods that this budget applies to. If Reasons is not set, this budget applies to all methods.
+                              Otherwise, this will apply to each reason defined.
+                              allowed reasons are Underutilized, Empty, and Drifted.
+                            items:
+                              description: DisruptionReason defines valid reasons for disruption budgets.
+                              enum:
+                                - Underutilized
+                                - Empty
+                                - Drifted
+                              type: string
+                            type: array
+                          schedule:
+                            description: |-
+                              Schedule specifies when a budget begins being active, following
+                              the upstream cronjob syntax. If omitted, the budget is always active.
+                              Timezones are not supported.
+                              This field is required if Duration is set.
+                            pattern: ^(@(annually|yearly|monthly|weekly|daily|midnight|hourly))|((.+)\s(.+)\s(.+)\s(.+)\s(.+))$
+                            type: string
+                        required:
+                          - nodes
+                        type: object
+                      maxItems: 50
+                      type: array
+                      x-kubernetes-validations:
+                        - message: '''schedule'' must be set with ''duration'''
+                          rule: self.all(x, has(x.schedule) == has(x.duration))
+                    consolidateAfter:
+                      description: |-
+                        ConsolidateAfter is the duration the controller will wait
+                        before attempting to terminate nodes that are underutilized.
+                        Refer to ConsolidationPolicy for how underutilization is considered.
+                      pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                      type: string
+                    consolidationPolicy:
+                      default: WhenEmptyOrUnderutilized
+                      description: |-
+                        ConsolidationPolicy describes which nodes Karpenter can disrupt through its consolidation
+                        algorithm. This policy defaults to "WhenEmptyOrUnderutilized" if not specified
+                      enum:
+                        - WhenEmpty
+                        - WhenEmptyOrUnderutilized
+                      type: string
+                  required:
+                    - consolidateAfter
+                  type: object
+                limits:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Limits define a set of bounds for provisioning capacity.
+                  type: object
+                template:
+                  description: |-
+                    Template contains the template of possibilities for the provisioning logic to launch a NodeClaim with.
+                    NodeClaims launched from this NodePool will often be further constrained than the template specifies.
+                  properties:
+                    metadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Annotations is an unstructured key value map stored with a resource that may be
+                            set by external tools to store and retrieve arbitrary metadata. They are not
+                            queryable and should be preserved when modifying objects.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                            maxLength: 63
+                            pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                          description: |-
+                            Map of string keys and values that can be used to organize and categorize
+                            (scope and select) objects. May match selectors of replication controllers
+                            and services.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
+                          type: object
+                          maxProperties: 100
+                          x-kubernetes-validations:
+                            - message: label domain "kubernetes.io" is restricted
+                              rule: self.all(x, x in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region",  "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || x.find("^([^/]+)").endsWith("node.kubernetes.io") || x.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !x.find("^([^/]+)").endsWith("kubernetes.io"))
+                            - message: label domain "k8s.io" is restricted
+                              rule: self.all(x, x.find("^([^/]+)").endsWith("kops.k8s.io") || !x.find("^([^/]+)").endsWith("k8s.io"))
+                            - message: label domain "karpenter.sh" is restricted
+                              rule: self.all(x, x in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !x.find("^([^/]+)").endsWith("karpenter.sh"))
+                            - message: label "karpenter.sh/nodepool" is restricted
+                              rule: self.all(x, x != "karpenter.sh/nodepool")
+                            - message: label "kubernetes.io/hostname" is restricted
+                              rule: self.all(x, x != "kubernetes.io/hostname")
+                            - message: label domain "karpenter.k8s.aws" is restricted
+                              rule: self.all(x, x in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !x.find("^([^/]+)").endsWith("karpenter.k8s.aws"))
+                      type: object
+                    spec:
+                      description: |-
+                        NodeClaimTemplateSpec describes the desired state of the NodeClaim in the Nodepool
+                        NodeClaimTemplateSpec is used in the NodePool's NodeClaimTemplate, with the resource requests omitted since
+                        users are not able to set resource requests in the NodePool.
+                      properties:
+                        expireAfter:
+                          default: 720h
+                          description: |-
+                            ExpireAfter is the duration the controller will wait
+                            before terminating a node, measured from when the node is created. This
+                            is useful to implement features like eventually consistent node upgrade,
+                            memory leak protection, and disruption testing.
+                          pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                          type: string
+                        nodeClassRef:
+                          description: NodeClassRef is a reference to an object that defines provider specific configuration
+                          properties:
+                            group:
+                              description: API version of the referent
+                              pattern: ^[^/]*$
+                              type: string
+                            kind:
+                              description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                              type: string
+                            name:
+                              description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                          required:
+                            - group
+                            - kind
+                            - name
+                          type: object
+                        requirements:
+                          description: Requirements are layered with GetLabels and applied to every node.
+                          items:
+                            description: |-
+                              A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                              and minValues that represent the requirement to have at least that many values.
+                            properties:
+                              key:
+                                description: The label key that the selector applies to.
+                                type: string
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                                x-kubernetes-validations:
+                                  - message: label domain "kubernetes.io" is restricted
+                                    rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                                  - message: label domain "k8s.io" is restricted
+                                    rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                                  - message: label domain "karpenter.sh" is restricted
+                                    rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                                  - message: label "karpenter.sh/nodepool" is restricted
+                                    rule: self != "karpenter.sh/nodepool"
+                                  - message: label "kubernetes.io/hostname" is restricted
+                                    rule: self != "kubernetes.io/hostname"
+                                  - message: label domain "karpenter.k8s.aws" is restricted
+                                    rule: self in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                              minValues:
+                                description: |-
+                                  This field is ALPHA and can be dropped or replaced at any time
+                                  MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                                maximum: 50
+                                minimum: 1
+                                type: integer
+                              operator:
+                                description: |-
+                                  Represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                type: string
+                                enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  - Gt
+                                  - Lt
+                              values:
+                                description: |-
+                                  An array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                  array must have a single element, which will be interpreted as an integer.
+                                  This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          maxItems: 100
+                          type: array
+                          x-kubernetes-validations:
+                            - message: requirements with operator 'In' must have a value defined
+                              rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                            - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                              rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                            - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                              rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                        startupTaints:
+                          description: |-
+                            StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                            within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                            daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                            purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        taints:
+                          description: Taints will be applied to the NodeClaim's node.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        terminationGracePeriod:
+                          description: |-
+                            TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
+
+                            Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
+
+                            This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
+                            When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
+
+                            Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
+                            If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
+                            that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
+
+                            The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
+                            If left undefined, the controller will wait indefinitely for pods to be drained.
+                          pattern: ^([0-9]+(s|m|h))+$
+                          type: string
+                      required:
+                        - nodeClassRef
+                        - requirements
+                      type: object
+                  required:
+                    - spec
+                  type: object
+                weight:
+                  description: |-
+                    Weight is the priority given to the nodepool during scheduling. A higher
+                    numerical weight indicates that this nodepool will be ordered
+                    ahead of other nodepools with lower weights. A nodepool with no weight
+                    will be treated as if it is a nodepool with a weight of 0.
+                  format: int32
+                  maximum: 100
+                  minimum: 1
+                  type: integer
+              required:
+                - template
+              type: object
+            status:
+              description: NodePoolStatus defines the observed state of NodePool
+              properties:
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                resources:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Resources is the list of resources that have been provisioned.
+                  type: object
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .spec.template.spec.nodeClassRef.name
+          name: NodeClass
+          type: string
+        - jsonPath: .spec.weight
+          name: Weight
+          priority: 1
+          type: string
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: NodePool is the Schema for the NodePools API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                NodePoolSpec is the top level nodepool specification. Nodepools
+                launch nodes in response to pods that are unschedulable. A single nodepool
+                is capable of managing a diverse set of nodes. Node properties are determined
+                from a combination of nodepool and pod scheduling constraints.
+              properties:
+                disruption:
+                  default:
+                    consolidationPolicy: WhenUnderutilized
+                    expireAfter: 720h
+                  description: Disruption contains the parameters that relate to Karpenter's disruption logic
+                  properties:
+                    budgets:
+                      default:
+                        - nodes: 10%
+                      description: |-
+                        Budgets is a list of Budgets.
+                        If there are multiple active budgets, Karpenter uses
+                        the most restrictive value. If left undefined,
+                        this will default to one budget with a value to 10%.
+                      items:
+                        description: |-
+                          Budget defines when Karpenter will restrict the
+                          number of Node Claims that can be terminating simultaneously.
+                        properties:
+                          duration:
+                            description: |-
+                              Duration determines how long a Budget is active since each Schedule hit.
+                              Only minutes and hours are accepted, as cron does not work in seconds.
+                              If omitted, the budget is always active.
+                              This is required if Schedule is set.
+                              This regex has an optional 0s at the end since the duration.String() always adds
+                              a 0s at the end.
+                            pattern: ^((([0-9]+(h|m))|([0-9]+h[0-9]+m))(0s)?)$
+                            type: string
+                          nodes:
+                            default: 10%
+                            description: |-
+                              Nodes dictates the maximum number of NodeClaims owned by this NodePool
+                              that can be terminating at once. This is calculated by counting nodes that
+                              have a deletion timestamp set, or are actively being deleted by Karpenter.
+                              This field is required when specifying a budget.
+                              This cannot be of type intstr.IntOrString since kubebuilder doesn't support pattern
+                              checking for int nodes for IntOrString nodes.
+                              Ref: https://github.com/kubernetes-sigs/controller-tools/blob/55efe4be40394a288216dab63156b0a64fb82929/pkg/crd/markers/validation.go#L379-L388
+                            pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
+                            type: string
+                          schedule:
+                            description: |-
+                              Schedule specifies when a budget begins being active, following
+                              the upstream cronjob syntax. If omitted, the budget is always active.
+                              Timezones are not supported.
+                              This field is required if Duration is set.
+                            pattern: ^(@(annually|yearly|monthly|weekly|daily|midnight|hourly))|((.+)\s(.+)\s(.+)\s(.+)\s(.+))$
+                            type: string
+                        required:
+                          - nodes
+                        type: object
+                      maxItems: 50
+                      type: array
+                      x-kubernetes-validations:
+                        - message: '''schedule'' must be set with ''duration'''
+                          rule: self.all(x, has(x.schedule) == has(x.duration))
+                    consolidateAfter:
+                      description: |-
+                        ConsolidateAfter is the duration the controller will wait
+                        before attempting to terminate nodes that are underutilized.
+                        Refer to ConsolidationPolicy for how underutilization is considered.
+                      pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                      type: string
+                    consolidationPolicy:
+                      default: WhenUnderutilized
+                      description: |-
+                        ConsolidationPolicy describes which nodes Karpenter can disrupt through its consolidation
+                        algorithm. This policy defaults to "WhenUnderutilized" if not specified
+                      enum:
+                        - WhenEmpty
+                        - WhenUnderutilized
+                      type: string
+                    expireAfter:
+                      default: 720h
+                      description: |-
+                        ExpireAfter is the duration the controller will wait
+                        before terminating a node, measured from when the node is created. This
+                        is useful to implement features like eventually consistent node upgrade,
+                        memory leak protection, and disruption testing.
+                      pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                      type: string
+                  type: object
+                  x-kubernetes-validations:
+                    - message: consolidateAfter cannot be combined with consolidationPolicy=WhenUnderutilized
+                      rule: 'has(self.consolidateAfter) ? self.consolidationPolicy != ''WhenUnderutilized'' || self.consolidateAfter == ''Never'' : true'
+                    - message: consolidateAfter must be specified with consolidationPolicy=WhenEmpty
+                      rule: 'self.consolidationPolicy == ''WhenEmpty'' ? has(self.consolidateAfter) : true'
+                limits:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Limits define a set of bounds for provisioning capacity.
+                  type: object
+                template:
+                  description: |-
+                    Template contains the template of possibilities for the provisioning logic to launch a NodeClaim with.
+                    NodeClaims launched from this NodePool will often be further constrained than the template specifies.
+                  properties:
+                    metadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Annotations is an unstructured key value map stored with a resource that may be
+                            set by external tools to store and retrieve arbitrary metadata. They are not
+                            queryable and should be preserved when modifying objects.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                            maxLength: 63
+                            pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                          description: |-
+                            Map of string keys and values that can be used to organize and categorize
+                            (scope and select) objects. May match selectors of replication controllers
+                            and services.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
+                          type: object
+                          maxProperties: 100
+                          x-kubernetes-validations:
+                            - message: label domain "kubernetes.io" is restricted
+                              rule: self.all(x, x in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region",  "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || x.find("^([^/]+)").endsWith("node.kubernetes.io") || x.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !x.find("^([^/]+)").endsWith("kubernetes.io"))
+                            - message: label domain "k8s.io" is restricted
+                              rule: self.all(x, x.find("^([^/]+)").endsWith("kops.k8s.io") || !x.find("^([^/]+)").endsWith("k8s.io"))
+                            - message: label domain "karpenter.sh" is restricted
+                              rule: self.all(x, x in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !x.find("^([^/]+)").endsWith("karpenter.sh"))
+                            - message: label "karpenter.sh/nodepool" is restricted
+                              rule: self.all(x, x != "karpenter.sh/nodepool")
+                            - message: label "kubernetes.io/hostname" is restricted
+                              rule: self.all(x, x != "kubernetes.io/hostname")
+                            - message: label domain "karpenter.k8s.aws" is restricted
+                              rule: self.all(x, x in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !x.find("^([^/]+)").endsWith("karpenter.k8s.aws"))
+                      type: object
+                    spec:
+                      description: NodeClaimSpec describes the desired state of the NodeClaim
+                      properties:
+                        kubelet:
+                          description: |-
+                            Kubelet defines args to be used when configuring kubelet on provisioned nodes.
+                            They are a subset of the upstream types, recognizing not all options may be supported.
+                            Wherever possible, the types and names should reflect the upstream kubelet types.
+                          properties:
+                            clusterDNS:
+                              description: |-
+                                clusterDNS is a list of IP addresses for the cluster DNS server.
+                                Note that not all providers may use all addresses.
+                              items:
+                                type: string
+                              type: array
+                            cpuCFSQuota:
+                              description: CPUCFSQuota enables CPU CFS quota enforcement for containers that specify CPU limits.
+                              type: boolean
+                            evictionHard:
+                              additionalProperties:
+                                type: string
+                                pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                              description: EvictionHard is the map of signal names to quantities that define hard eviction thresholds
+                              type: object
+                              x-kubernetes-validations:
+                                - message: valid keys for evictionHard are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                                  rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                            evictionMaxPodGracePeriod:
+                              description: |-
+                                EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in
+                                response to soft eviction thresholds being met.
+                              format: int32
+                              type: integer
+                            evictionSoft:
+                              additionalProperties:
+                                type: string
+                                pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                              description: EvictionSoft is the map of signal names to quantities that define soft eviction thresholds
+                              type: object
+                              x-kubernetes-validations:
+                                - message: valid keys for evictionSoft are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                                  rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                            evictionSoftGracePeriod:
+                              additionalProperties:
+                                type: string
+                              description: EvictionSoftGracePeriod is the map of signal names to quantities that define grace periods for each eviction signal
+                              type: object
+                              x-kubernetes-validations:
+                                - message: valid keys for evictionSoftGracePeriod are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                                  rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                            imageGCHighThresholdPercent:
+                              description: |-
+                                ImageGCHighThresholdPercent is the percent of disk usage after which image
+                                garbage collection is always run. The percent is calculated by dividing this
+                                field value by 100, so this field must be between 0 and 100, inclusive.
+                                When specified, the value must be greater than ImageGCLowThresholdPercent.
+                              format: int32
+                              maximum: 100
+                              minimum: 0
+                              type: integer
+                            imageGCLowThresholdPercent:
+                              description: |-
+                                ImageGCLowThresholdPercent is the percent of disk usage before which image
+                                garbage collection is never run. Lowest disk usage to garbage collect to.
+                                The percent is calculated by dividing this field value by 100,
+                                so the field value must be between 0 and 100, inclusive.
+                                When specified, the value must be less than imageGCHighThresholdPercent
+                              format: int32
+                              maximum: 100
+                              minimum: 0
+                              type: integer
+                            kubeReserved:
+                              additionalProperties:
+                                type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              description: KubeReserved contains resources reserved for Kubernetes system components.
+                              type: object
+                              x-kubernetes-validations:
+                                - message: valid keys for kubeReserved are ['cpu','memory','ephemeral-storage','pid']
+                                  rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                                - message: kubeReserved value cannot be a negative resource quantity
+                                  rule: self.all(x, !self[x].startsWith('-'))
+                            maxPods:
+                              description: |-
+                                MaxPods is an override for the maximum number of pods that can run on
+                                a worker node instance.
+                              format: int32
+                              minimum: 0
+                              type: integer
+                            podsPerCore:
+                              description: |-
+                                PodsPerCore is an override for the number of pods that can run on a worker node
+                                instance based on the number of cpu cores. This value cannot exceed MaxPods, so, if
+                                MaxPods is a lower value, that value will be used.
+                              format: int32
+                              minimum: 0
+                              type: integer
+                            systemReserved:
+                              additionalProperties:
+                                type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              description: SystemReserved contains resources reserved for OS system daemons and kernel memory.
+                              type: object
+                              x-kubernetes-validations:
+                                - message: valid keys for systemReserved are ['cpu','memory','ephemeral-storage','pid']
+                                  rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                                - message: systemReserved value cannot be a negative resource quantity
+                                  rule: self.all(x, !self[x].startsWith('-'))
+                          type: object
+                          x-kubernetes-validations:
+                            - message: imageGCHighThresholdPercent must be greater than imageGCLowThresholdPercent
+                              rule: 'has(self.imageGCHighThresholdPercent) && has(self.imageGCLowThresholdPercent) ?  self.imageGCHighThresholdPercent > self.imageGCLowThresholdPercent  : true'
+                            - message: evictionSoft OwnerKey does not have a matching evictionSoftGracePeriod
+                              rule: has(self.evictionSoft) ? self.evictionSoft.all(e, (e in self.evictionSoftGracePeriod)):true
+                            - message: evictionSoftGracePeriod OwnerKey does not have a matching evictionSoft
+                              rule: has(self.evictionSoftGracePeriod) ? self.evictionSoftGracePeriod.all(e, (e in self.evictionSoft)):true
+                        nodeClassRef:
+                          description: NodeClassRef is a reference to an object that defines provider specific configuration
+                          properties:
+                            apiVersion:
+                              description: API version of the referent
+                              type: string
+                            kind:
+                              description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                              type: string
+                            name:
+                              description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        requirements:
+                          description: Requirements are layered with GetLabels and applied to every node.
+                          items:
+                            description: |-
+                              A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                              and minValues that represent the requirement to have at least that many values.
+                            properties:
+                              key:
+                                description: The label key that the selector applies to.
+                                type: string
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                                x-kubernetes-validations:
+                                  - message: label domain "kubernetes.io" is restricted
+                                    rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                                  - message: label domain "k8s.io" is restricted
+                                    rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                                  - message: label domain "karpenter.sh" is restricted
+                                    rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                                  - message: label "karpenter.sh/nodepool" is restricted
+                                    rule: self != "karpenter.sh/nodepool"
+                                  - message: label "kubernetes.io/hostname" is restricted
+                                    rule: self != "kubernetes.io/hostname"
+                                  - message: label domain "karpenter.k8s.aws" is restricted
+                                    rule: self in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                              minValues:
+                                description: |-
+                                  This field is ALPHA and can be dropped or replaced at any time
+                                  MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                                maximum: 50
+                                minimum: 1
+                                type: integer
+                              operator:
+                                description: |-
+                                  Represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                type: string
+                                enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  - Gt
+                                  - Lt
+                              values:
+                                description: |-
+                                  An array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                  array must have a single element, which will be interpreted as an integer.
+                                  This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          maxItems: 100
+                          type: array
+                          x-kubernetes-validations:
+                            - message: requirements with operator 'In' must have a value defined
+                              rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                            - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                              rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                            - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                              rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                        resources:
+                          description: Resources models the resource requirements for the NodeClaim to launch
+                          properties:
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: Requests describes the minimum required resources for the NodeClaim to launch
+                              type: object
+                          type: object
+                          maxProperties: 0
+                        startupTaints:
+                          description: |-
+                            StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                            within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                            daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                            purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        taints:
+                          description: Taints will be applied to the NodeClaim's node.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                      required:
+                        - nodeClassRef
+                        - requirements
+                      type: object
+                  required:
+                    - spec
+                  type: object
+                weight:
+                  description: |-
+                    Weight is the priority given to the nodepool during scheduling. A higher
+                    numerical weight indicates that this nodepool will be ordered
+                    ahead of other nodepools with lower weights. A nodepool with no weight
+                    will be treated as if it is a nodepool with a weight of 0.
+                  format: int32
+                  maximum: 100
+                  minimum: 1
+                  type: integer
+              required:
+                - template
+              type: object
+            status:
+              description: NodePoolStatus defines the observed state of NodePool
+              properties:
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                resources:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Resources is the list of resources that have been provisioned.
+                  type: object
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+        - v1
+      clientConfig:
+        service:
+          name: karpenter
+          namespace: kube-system
+          port: 8443

--- a/content/projects/karpenter/v1.0.4/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/content/projects/karpenter/v1.0.4/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -1,0 +1,1306 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.3
+  name: ec2nodeclasses.karpenter.k8s.aws
+spec:
+  group: karpenter.k8s.aws
+  names:
+    categories:
+      - karpenter
+    kind: EC2NodeClass
+    listKind: EC2NodeClassList
+    plural: ec2nodeclasses
+    shortNames:
+      - ec2nc
+      - ec2ncs
+    singular: ec2nodeclass
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.role
+          name: Role
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: EC2NodeClass is the Schema for the EC2NodeClass API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                EC2NodeClassSpec is the top level specification for the AWS Karpenter Provider.
+                This will contain configuration necessary to launch instances in AWS.
+              properties:
+                amiFamily:
+                  description: |-
+                    AMIFamily dictates the UserData format and default BlockDeviceMappings used when generating launch templates.
+                    This field is optional when using an alias amiSelectorTerm, and the value will be inferred from the alias'
+                    family. When an alias is specified, this field may only be set to its corresponding family or 'Custom'. If no
+                    alias is specified, this field is required.
+                    NOTE: We ignore the AMIFamily for hashing here because we hash the AMIFamily dynamically by using the alias using
+                    the AMIFamily() helper function
+                  enum:
+                    - AL2
+                    - AL2023
+                    - Bottlerocket
+                    - Custom
+                    - Windows2019
+                    - Windows2022
+                  type: string
+                amiSelectorTerms:
+                  description: AMISelectorTerms is a list of or ami selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      AMISelectorTerm defines selection logic for an ami used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      alias:
+                        description: |-
+                          Alias specifies which EKS optimized AMI to select.
+                          Each alias consists of a family and an AMI version, specified as "family@version".
+                          Valid families include: al2, al2023, bottlerocket, windows2019, and windows2022.
+                          The version can either be pinned to a specific AMI release, with that AMIs version format (ex: "al2023@v20240625" or "bottlerocket@v1.10.0").
+                          The version can also be set to "latest" for any family. Setting the version to latest will result in drift when a new AMI is released. This is **not** recommended for production environments.
+                          Note: The Windows families do **not** support version pinning, and only latest may be used.
+                        maxLength: 30
+                        type: string
+                        x-kubernetes-validations:
+                          - message: '''alias'' is improperly formatted, must match the format ''family@version'''
+                            rule: self.matches('^[a-zA-Z0-9]+@.+$')
+                          - message: 'family is not supported, must be one of the following: ''al2'', ''al2023'', ''bottlerocket'', ''windows2019'', ''windows2022'''
+                            rule: self.split('@')[0] in ['al2','al2023','bottlerocket','windows2019','windows2022']
+                          - message: windows families may only specify version 'latest'
+                            rule: 'self.split(''@'')[0] in [''windows2019'',''windows2022''] ? self.split(''@'')[1] == ''latest'' : true'
+                      id:
+                        description: ID is the ami id in EC2
+                        pattern: ami-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the ami name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      owner:
+                        description: |-
+                          Owner is the owner for the ami.
+                          You can specify a combination of AWS account IDs, "self", "amazon", and "aws-marketplace"
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  minItems: 1
+                  type: array
+                  x-kubernetes-validations:
+                    - message: expected at least one, got none, ['tags', 'id', 'name', 'alias']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name) || has(x.alias))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.exists(x, has(x.id) && (has(x.alias) || has(x.tags) || has(x.name) || has(x.owner)))'
+                    - message: '''alias'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.exists(x, has(x.alias) && (has(x.id) || has(x.tags) || has(x.name) || has(x.owner)))'
+                    - message: '''alias'' is mutually exclusive, cannot be set with a combination of other amiSelectorTerms'
+                      rule: '!(self.exists(x, has(x.alias)) && self.size() != 1)'
+                associatePublicIPAddress:
+                  description: AssociatePublicIPAddress controls if public IP addresses are assigned to instances that are launched with the nodeclass.
+                  type: boolean
+                blockDeviceMappings:
+                  description: BlockDeviceMappings to be applied to provisioned nodes.
+                  items:
+                    properties:
+                      deviceName:
+                        description: The device name (for example, /dev/sdh or xvdh).
+                        type: string
+                      ebs:
+                        description: EBS contains parameters used to automatically set up EBS volumes when an instance is launched.
+                        properties:
+                          deleteOnTermination:
+                            description: DeleteOnTermination indicates whether the EBS volume is deleted on instance termination.
+                            type: boolean
+                          encrypted:
+                            description: |-
+                              Encrypted indicates whether the EBS volume is encrypted. Encrypted volumes can only
+                              be attached to instances that support Amazon EBS encryption. If you are creating
+                              a volume from a snapshot, you can't specify an encryption value.
+                            type: boolean
+                          iops:
+                            description: |-
+                              IOPS is the number of I/O operations per second (IOPS). For gp3, io1, and io2 volumes,
+                              this represents the number of IOPS that are provisioned for the volume. For
+                              gp2 volumes, this represents the baseline performance of the volume and the
+                              rate at which the volume accumulates I/O credits for bursting.
+
+                              The following are the supported values for each volume type:
+
+                                 * gp3: 3,000-16,000 IOPS
+
+                                 * io1: 100-64,000 IOPS
+
+                                 * io2: 100-64,000 IOPS
+
+                              For io1 and io2 volumes, we guarantee 64,000 IOPS only for Instances built
+                              on the Nitro System (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances).
+                              Other instance families guarantee performance up to 32,000 IOPS.
+
+                              This parameter is supported for io1, io2, and gp3 volumes only. This parameter
+                              is not supported for gp2, st1, sc1, or standard volumes.
+                            format: int64
+                            type: integer
+                          kmsKeyID:
+                            description: KMSKeyID (ARN) of the symmetric Key Management Service (KMS) CMK used for encryption.
+                            type: string
+                          snapshotID:
+                            description: SnapshotID is the ID of an EBS snapshot
+                            type: string
+                          throughput:
+                            description: |-
+                              Throughput to provision for a gp3 volume, with a maximum of 1,000 MiB/s.
+                              Valid Range: Minimum value of 125. Maximum value of 1000.
+                            format: int64
+                            type: integer
+                          volumeSize:
+                            description: |-
+                              VolumeSize in `Gi`, `G`, `Ti`, or `T`. You must specify either a snapshot ID or
+                              a volume size. The following are the supported volumes sizes for each volume
+                              type:
+
+                                 * gp2 and gp3: 1-16,384
+
+                                 * io1 and io2: 4-16,384
+
+                                 * st1 and sc1: 125-16,384
+
+                                 * standard: 1-1,024
+                            pattern: ^((?:[1-9][0-9]{0,3}|[1-4][0-9]{4}|[5][0-8][0-9]{3}|59000)Gi|(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|[6][0-3][0-9]{3}|64000)G|([1-9]||[1-5][0-7]|58)Ti|([1-9]||[1-5][0-9]|6[0-3]|64)T)$
+                            type: string
+                          volumeType:
+                            description: |-
+                              VolumeType of the block device.
+                              For more information, see Amazon EBS volume types (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html)
+                              in the Amazon Elastic Compute Cloud User Guide.
+                            enum:
+                              - standard
+                              - io1
+                              - io2
+                              - gp2
+                              - sc1
+                              - st1
+                              - gp3
+                            type: string
+                        type: object
+                        x-kubernetes-validations:
+                          - message: snapshotID or volumeSize must be defined
+                            rule: has(self.snapshotID) || has(self.volumeSize)
+                      rootVolume:
+                        description: |-
+                          RootVolume is a flag indicating if this device is mounted as kubelet root dir. You can
+                          configure at most one root volume in BlockDeviceMappings.
+                        type: boolean
+                    type: object
+                  maxItems: 50
+                  type: array
+                  x-kubernetes-validations:
+                    - message: must have only one blockDeviceMappings with rootVolume
+                      rule: self.filter(x, has(x.rootVolume)?x.rootVolume==true:false).size() <= 1
+                context:
+                  description: |-
+                    Context is a Reserved field in EC2 APIs
+                    https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet.html
+                  type: string
+                detailedMonitoring:
+                  description: DetailedMonitoring controls if detailed monitoring is enabled for instances that are launched
+                  type: boolean
+                instanceProfile:
+                  description: |-
+                    InstanceProfile is the AWS entity that instances use.
+                    This field is mutually exclusive from role.
+                    The instance profile should already have a role assigned to it that Karpenter
+                     has PassRole permission on for instance launch using this instanceProfile to succeed.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: instanceProfile cannot be empty
+                      rule: self != ''
+                instanceStorePolicy:
+                  description: InstanceStorePolicy specifies how to handle instance-store disks.
+                  enum:
+                    - RAID0
+                  type: string
+                kubelet:
+                  description: |-
+                    Kubelet defines args to be used when configuring kubelet on provisioned nodes.
+                    They are a subset of the upstream types, recognizing not all options may be supported.
+                    Wherever possible, the types and names should reflect the upstream kubelet types.
+                  properties:
+                    clusterDNS:
+                      description: |-
+                        clusterDNS is a list of IP addresses for the cluster DNS server.
+                        Note that not all providers may use all addresses.
+                      items:
+                        type: string
+                      type: array
+                    cpuCFSQuota:
+                      description: CPUCFSQuota enables CPU CFS quota enforcement for containers that specify CPU limits.
+                      type: boolean
+                    evictionHard:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionHard is the map of signal names to quantities that define hard eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionHard are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionMaxPodGracePeriod:
+                      description: |-
+                        EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in
+                        response to soft eviction thresholds being met.
+                      format: int32
+                      type: integer
+                    evictionSoft:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionSoft is the map of signal names to quantities that define soft eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoft are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionSoftGracePeriod:
+                      additionalProperties:
+                        type: string
+                      description: EvictionSoftGracePeriod is the map of signal names to quantities that define grace periods for each eviction signal
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoftGracePeriod are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    imageGCHighThresholdPercent:
+                      description: |-
+                        ImageGCHighThresholdPercent is the percent of disk usage after which image
+                        garbage collection is always run. The percent is calculated by dividing this
+                        field value by 100, so this field must be between 0 and 100, inclusive.
+                        When specified, the value must be greater than ImageGCLowThresholdPercent.
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    imageGCLowThresholdPercent:
+                      description: |-
+                        ImageGCLowThresholdPercent is the percent of disk usage before which image
+                        garbage collection is never run. Lowest disk usage to garbage collect to.
+                        The percent is calculated by dividing this field value by 100,
+                        so the field value must be between 0 and 100, inclusive.
+                        When specified, the value must be less than imageGCHighThresholdPercent
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    kubeReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: KubeReserved contains resources reserved for Kubernetes system components.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for kubeReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: kubeReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                    maxPods:
+                      description: |-
+                        MaxPods is an override for the maximum number of pods that can run on
+                        a worker node instance.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    podsPerCore:
+                      description: |-
+                        PodsPerCore is an override for the number of pods that can run on a worker node
+                        instance based on the number of cpu cores. This value cannot exceed MaxPods, so, if
+                        MaxPods is a lower value, that value will be used.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    systemReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: SystemReserved contains resources reserved for OS system daemons and kernel memory.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for systemReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: systemReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                  type: object
+                  x-kubernetes-validations:
+                    - message: imageGCHighThresholdPercent must be greater than imageGCLowThresholdPercent
+                      rule: 'has(self.imageGCHighThresholdPercent) && has(self.imageGCLowThresholdPercent) ?  self.imageGCHighThresholdPercent > self.imageGCLowThresholdPercent  : true'
+                    - message: evictionSoft OwnerKey does not have a matching evictionSoftGracePeriod
+                      rule: has(self.evictionSoft) ? self.evictionSoft.all(e, (e in self.evictionSoftGracePeriod)):true
+                    - message: evictionSoftGracePeriod OwnerKey does not have a matching evictionSoft
+                      rule: has(self.evictionSoftGracePeriod) ? self.evictionSoftGracePeriod.all(e, (e in self.evictionSoft)):true
+                metadataOptions:
+                  default:
+                    httpEndpoint: enabled
+                    httpProtocolIPv6: disabled
+                    httpPutResponseHopLimit: 1
+                    httpTokens: required
+                  description: |-
+                    MetadataOptions for the generated launch template of provisioned nodes.
+
+                    This specifies the exposure of the Instance Metadata Service to
+                    provisioned EC2 nodes. For more information,
+                    see Instance Metadata and User Data
+                    (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
+                    in the Amazon Elastic Compute Cloud User Guide.
+
+                    Refer to recommended, security best practices
+                    (https://aws.github.io/aws-eks-best-practices/security/docs/iam/#restrict-access-to-the-instance-profile-assigned-to-the-worker-node)
+                    for limiting exposure of Instance Metadata and User Data to pods.
+                    If omitted, defaults to httpEndpoint enabled, with httpProtocolIPv6
+                    disabled, with httpPutResponseLimit of 1, and with httpTokens
+                    required.
+                  properties:
+                    httpEndpoint:
+                      default: enabled
+                      description: |-
+                        HTTPEndpoint enables or disables the HTTP metadata endpoint on provisioned
+                        nodes. If metadata options is non-nil, but this parameter is not specified,
+                        the default state is "enabled".
+
+                        If you specify a value of "disabled", instance metadata will not be accessible
+                        on the node.
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpProtocolIPv6:
+                      default: disabled
+                      description: |-
+                        HTTPProtocolIPv6 enables or disables the IPv6 endpoint for the instance metadata
+                        service on provisioned nodes. If metadata options is non-nil, but this parameter
+                        is not specified, the default state is "disabled".
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpPutResponseHopLimit:
+                      default: 1
+                      description: |-
+                        HTTPPutResponseHopLimit is the desired HTTP PUT response hop limit for
+                        instance metadata requests. The larger the number, the further instance
+                        metadata requests can travel. Possible values are integers from 1 to 64.
+                        If metadata options is non-nil, but this parameter is not specified, the
+                        default value is 1.
+                      format: int64
+                      maximum: 64
+                      minimum: 1
+                      type: integer
+                    httpTokens:
+                      default: required
+                      description: |-
+                        HTTPTokens determines the state of token usage for instance metadata
+                        requests. If metadata options is non-nil, but this parameter is not
+                        specified, the default state is "required".
+
+                        If the state is optional, one can choose to retrieve instance metadata with
+                        or without a signed token header on the request. If one retrieves the IAM
+                        role credentials without a token, the version 1.0 role credentials are
+                        returned. If one retrieves the IAM role credentials using a valid signed
+                        token, the version 2.0 role credentials are returned.
+
+                        If the state is "required", one must send a signed token header with any
+                        instance metadata retrieval requests. In this state, retrieving the IAM
+                        role credentials always returns the version 2.0 credentials; the version
+                        1.0 credentials are not available.
+                      enum:
+                        - required
+                        - optional
+                      type: string
+                  type: object
+                role:
+                  description: |-
+                    Role is the AWS identity that nodes use. This field is immutable.
+                    This field is mutually exclusive from instanceProfile.
+                    Marking this field as immutable avoids concerns around terminating managed instance profiles from running instances.
+                    This field may be made mutable in the future, assuming the correct garbage collection and drift handling is implemented
+                    for the old instance profiles on an update.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: role cannot be empty
+                      rule: self != ''
+                    - message: immutable field changed
+                      rule: self == oldSelf
+                securityGroupSelectorTerms:
+                  description: SecurityGroupSelectorTerms is a list of or security group selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SecurityGroupSelectorTerm defines selection logic for a security group used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the security group id in EC2
+                        pattern: sg-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the security group name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: securityGroupSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id', 'name']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && (has(x.tags) || has(x.name)))'
+                    - message: '''name'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.name) && (has(x.tags) || has(x.id)))'
+                subnetSelectorTerms:
+                  description: SubnetSelectorTerms is a list of or subnet selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SubnetSelectorTerm defines selection logic for a subnet used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the subnet id in EC2
+                        pattern: subnet-[0-9a-z]+
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: subnetSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id']
+                      rule: self.all(x, has(x.tags) || has(x.id))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in subnetSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && has(x.tags))'
+                tags:
+                  additionalProperties:
+                    type: string
+                  description: Tags to be applied on ec2 resources like instances and launch templates.
+                  type: object
+                  x-kubernetes-validations:
+                    - message: empty tag keys aren't supported
+                      rule: self.all(k, k != '')
+                    - message: tag contains a restricted tag matching eks:eks-cluster-name
+                      rule: self.all(k, k !='eks:eks-cluster-name')
+                    - message: tag contains a restricted tag matching kubernetes.io/cluster/
+                      rule: self.all(k, !k.startsWith('kubernetes.io/cluster') )
+                    - message: tag contains a restricted tag matching karpenter.sh/nodepool
+                      rule: self.all(k, k != 'karpenter.sh/nodepool')
+                    - message: tag contains a restricted tag matching karpenter.sh/nodeclaim
+                      rule: self.all(k, k !='karpenter.sh/nodeclaim')
+                    - message: tag contains a restricted tag matching karpenter.k8s.aws/ec2nodeclass
+                      rule: self.all(k, k !='karpenter.k8s.aws/ec2nodeclass')
+                userData:
+                  description: |-
+                    UserData to be applied to the provisioned nodes.
+                    It must be in the appropriate format based on the AMIFamily in use. Karpenter will merge certain fields into
+                    this UserData to ensure nodes are being provisioned with the correct configuration.
+                  type: string
+              required:
+                - amiSelectorTerms
+                - securityGroupSelectorTerms
+                - subnetSelectorTerms
+              type: object
+              x-kubernetes-validations:
+                - message: must specify exactly one of ['role', 'instanceProfile']
+                  rule: (has(self.role) && !has(self.instanceProfile)) || (!has(self.role) && has(self.instanceProfile))
+                - message: changing from 'instanceProfile' to 'role' is not supported. You must delete and recreate this node class if you want to change this.
+                  rule: (has(oldSelf.role) && has(self.role)) || (has(oldSelf.instanceProfile) && has(self.instanceProfile))
+                - message: if set, amiFamily must be 'AL2' or 'Custom' when using an AL2 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''al2'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''AL2'') : true)'
+                - message: if set, amiFamily must be 'AL2023' or 'Custom' when using an AL2023 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''al2023'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''AL2023'') : true)'
+                - message: if set, amiFamily must be 'Bottlerocket' or 'Custom' when using a Bottlerocket alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''bottlerocket'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Bottlerocket'') : true)'
+                - message: if set, amiFamily must be 'Windows2019' or 'Custom' when using a Windows2019 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''windows2019'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Windows2019'') : true)'
+                - message: if set, amiFamily must be 'Windows2022' or 'Custom' when using a Windows2022 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''windows2022'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Windows2022'') : true)'
+                - message: must specify amiFamily if amiSelectorTerms does not contain an alias
+                  rule: 'self.amiSelectorTerms.exists(x, has(x.alias)) ? true : has(self.amiFamily)'
+            status:
+              description: EC2NodeClassStatus contains the resolved state of the EC2NodeClass
+              properties:
+                amis:
+                  description: |-
+                    AMI contains the current AMI values that are available to the
+                    cluster under the AMI selectors.
+                  items:
+                    description: AMI contains resolved AMI selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the AMI
+                        type: string
+                      name:
+                        description: Name of the AMI
+                        type: string
+                      requirements:
+                        description: Requirements of the AMI to be utilized on an instance type
+                        items:
+                          description: |-
+                            A node selector requirement is a selector that contains values, a key, and an operator
+                            that relates the key and values.
+                          properties:
+                            key:
+                              description: The label key that the selector applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                Represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                              type: string
+                            values:
+                              description: |-
+                                An array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. If the operator is Gt or Lt, the values
+                                array must have a single element, which will be interpreted as an integer.
+                                This array is replaced during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                            - key
+                            - operator
+                          type: object
+                        type: array
+                    required:
+                      - id
+                      - requirements
+                    type: object
+                  type: array
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                instanceProfile:
+                  description: InstanceProfile contains the resolved instance profile for the role
+                  type: string
+                securityGroups:
+                  description: |-
+                    SecurityGroups contains the current Security Groups values that are available to the
+                    cluster under the SecurityGroups selectors.
+                  items:
+                    description: SecurityGroup contains resolved SecurityGroup selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the security group
+                        type: string
+                      name:
+                        description: Name of the security group
+                        type: string
+                    required:
+                      - id
+                    type: object
+                  type: array
+                subnets:
+                  description: |-
+                    Subnets contains the current Subnet values that are available to the
+                    cluster under the subnet selectors.
+                  items:
+                    description: Subnet contains resolved Subnet selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the subnet
+                        type: string
+                      zone:
+                        description: The associated availability zone
+                        type: string
+                      zoneID:
+                        description: The associated availability zone ID
+                        type: string
+                    required:
+                      - id
+                      - zone
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: EC2NodeClass is the Schema for the EC2NodeClass API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                EC2NodeClassSpec is the top level specification for the AWS Karpenter Provider.
+                This will contain configuration necessary to launch instances in AWS.
+              properties:
+                amiFamily:
+                  description: AMIFamily is the AMI family that instances use.
+                  enum:
+                    - AL2
+                    - AL2023
+                    - Bottlerocket
+                    - Ubuntu
+                    - Custom
+                    - Windows2019
+                    - Windows2022
+                  type: string
+                amiSelectorTerms:
+                  description: AMISelectorTerms is a list of or ami selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      AMISelectorTerm defines selection logic for an ami used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the ami id in EC2
+                        pattern: ami-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the ami name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      owner:
+                        description: |-
+                          Owner is the owner for the ami.
+                          You can specify a combination of AWS account IDs, "self", "amazon", and "aws-marketplace"
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: expected at least one, got none, ['tags', 'id', 'name']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && (has(x.tags) || has(x.name) || has(x.owner)))'
+                associatePublicIPAddress:
+                  description: AssociatePublicIPAddress controls if public IP addresses are assigned to instances that are launched with the nodeclass.
+                  type: boolean
+                blockDeviceMappings:
+                  description: BlockDeviceMappings to be applied to provisioned nodes.
+                  items:
+                    properties:
+                      deviceName:
+                        description: The device name (for example, /dev/sdh or xvdh).
+                        type: string
+                      ebs:
+                        description: EBS contains parameters used to automatically set up EBS volumes when an instance is launched.
+                        properties:
+                          deleteOnTermination:
+                            description: DeleteOnTermination indicates whether the EBS volume is deleted on instance termination.
+                            type: boolean
+                          encrypted:
+                            description: |-
+                              Encrypted indicates whether the EBS volume is encrypted. Encrypted volumes can only
+                              be attached to instances that support Amazon EBS encryption. If you are creating
+                              a volume from a snapshot, you can't specify an encryption value.
+                            type: boolean
+                          iops:
+                            description: |-
+                              IOPS is the number of I/O operations per second (IOPS). For gp3, io1, and io2 volumes,
+                              this represents the number of IOPS that are provisioned for the volume. For
+                              gp2 volumes, this represents the baseline performance of the volume and the
+                              rate at which the volume accumulates I/O credits for bursting.
+
+                              The following are the supported values for each volume type:
+
+                                 * gp3: 3,000-16,000 IOPS
+
+                                 * io1: 100-64,000 IOPS
+
+                                 * io2: 100-64,000 IOPS
+
+                              For io1 and io2 volumes, we guarantee 64,000 IOPS only for Instances built
+                              on the Nitro System (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances).
+                              Other instance families guarantee performance up to 32,000 IOPS.
+
+                              This parameter is supported for io1, io2, and gp3 volumes only. This parameter
+                              is not supported for gp2, st1, sc1, or standard volumes.
+                            format: int64
+                            type: integer
+                          kmsKeyID:
+                            description: KMSKeyID (ARN) of the symmetric Key Management Service (KMS) CMK used for encryption.
+                            type: string
+                          snapshotID:
+                            description: SnapshotID is the ID of an EBS snapshot
+                            type: string
+                          throughput:
+                            description: |-
+                              Throughput to provision for a gp3 volume, with a maximum of 1,000 MiB/s.
+                              Valid Range: Minimum value of 125. Maximum value of 1000.
+                            format: int64
+                            type: integer
+                          volumeSize:
+                            description: |-
+                              VolumeSize in `Gi`, `G`, `Ti`, or `T`. You must specify either a snapshot ID or
+                              a volume size. The following are the supported volumes sizes for each volume
+                              type:
+
+                                 * gp2 and gp3: 1-16,384
+
+                                 * io1 and io2: 4-16,384
+
+                                 * st1 and sc1: 125-16,384
+
+                                 * standard: 1-1,024
+                            pattern: ^((?:[1-9][0-9]{0,3}|[1-4][0-9]{4}|[5][0-8][0-9]{3}|59000)Gi|(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|[6][0-3][0-9]{3}|64000)G|([1-9]||[1-5][0-7]|58)Ti|([1-9]||[1-5][0-9]|6[0-3]|64)T)$
+                            type: string
+                          volumeType:
+                            description: |-
+                              VolumeType of the block device.
+                              For more information, see Amazon EBS volume types (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html)
+                              in the Amazon Elastic Compute Cloud User Guide.
+                            enum:
+                              - standard
+                              - io1
+                              - io2
+                              - gp2
+                              - sc1
+                              - st1
+                              - gp3
+                            type: string
+                        type: object
+                        x-kubernetes-validations:
+                          - message: snapshotID or volumeSize must be defined
+                            rule: has(self.snapshotID) || has(self.volumeSize)
+                      rootVolume:
+                        description: |-
+                          RootVolume is a flag indicating if this device is mounted as kubelet root dir. You can
+                          configure at most one root volume in BlockDeviceMappings.
+                        type: boolean
+                    type: object
+                  maxItems: 50
+                  type: array
+                  x-kubernetes-validations:
+                    - message: must have only one blockDeviceMappings with rootVolume
+                      rule: self.filter(x, has(x.rootVolume)?x.rootVolume==true:false).size() <= 1
+                context:
+                  description: |-
+                    Context is a Reserved field in EC2 APIs
+                    https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet.html
+                  type: string
+                detailedMonitoring:
+                  description: DetailedMonitoring controls if detailed monitoring is enabled for instances that are launched
+                  type: boolean
+                instanceProfile:
+                  description: |-
+                    InstanceProfile is the AWS entity that instances use.
+                    This field is mutually exclusive from role.
+                    The instance profile should already have a role assigned to it that Karpenter
+                     has PassRole permission on for instance launch using this instanceProfile to succeed.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: instanceProfile cannot be empty
+                      rule: self != ''
+                instanceStorePolicy:
+                  description: InstanceStorePolicy specifies how to handle instance-store disks.
+                  enum:
+                    - RAID0
+                  type: string
+                metadataOptions:
+                  default:
+                    httpEndpoint: enabled
+                    httpProtocolIPv6: disabled
+                    httpPutResponseHopLimit: 1
+                    httpTokens: required
+                  description: |-
+                    MetadataOptions for the generated launch template of provisioned nodes.
+
+                    This specifies the exposure of the Instance Metadata Service to
+                    provisioned EC2 nodes. For more information,
+                    see Instance Metadata and User Data
+                    (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
+                    in the Amazon Elastic Compute Cloud User Guide.
+
+                    Refer to recommended, security best practices
+                    (https://aws.github.io/aws-eks-best-practices/security/docs/iam/#restrict-access-to-the-instance-profile-assigned-to-the-worker-node)
+                    for limiting exposure of Instance Metadata and User Data to pods.
+                    If omitted, defaults to httpEndpoint enabled, with httpProtocolIPv6
+                    disabled, with httpPutResponseLimit of 1, and with httpTokens
+                    required.
+                  properties:
+                    httpEndpoint:
+                      default: enabled
+                      description: |-
+                        HTTPEndpoint enables or disables the HTTP metadata endpoint on provisioned
+                        nodes. If metadata options is non-nil, but this parameter is not specified,
+                        the default state is "enabled".
+
+                        If you specify a value of "disabled", instance metadata will not be accessible
+                        on the node.
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpProtocolIPv6:
+                      default: disabled
+                      description: |-
+                        HTTPProtocolIPv6 enables or disables the IPv6 endpoint for the instance metadata
+                        service on provisioned nodes. If metadata options is non-nil, but this parameter
+                        is not specified, the default state is "disabled".
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpPutResponseHopLimit:
+                      default: 2
+                      description: |-
+                        HTTPPutResponseHopLimit is the desired HTTP PUT response hop limit for
+                        instance metadata requests. The larger the number, the further instance
+                        metadata requests can travel. Possible values are integers from 1 to 64.
+                        If metadata options is non-nil, but this parameter is not specified, the
+                        default value is 2.
+                      format: int64
+                      maximum: 64
+                      minimum: 1
+                      type: integer
+                    httpTokens:
+                      default: required
+                      description: |-
+                        HTTPTokens determines the state of token usage for instance metadata
+                        requests. If metadata options is non-nil, but this parameter is not
+                        specified, the default state is "required".
+
+                        If the state is optional, one can choose to retrieve instance metadata with
+                        or without a signed token header on the request. If one retrieves the IAM
+                        role credentials without a token, the version 1.0 role credentials are
+                        returned. If one retrieves the IAM role credentials using a valid signed
+                        token, the version 2.0 role credentials are returned.
+
+                        If the state is "required", one must send a signed token header with any
+                        instance metadata retrieval requests. In this state, retrieving the IAM
+                        role credentials always returns the version 2.0 credentials; the version
+                        1.0 credentials are not available.
+                      enum:
+                        - required
+                        - optional
+                      type: string
+                  type: object
+                role:
+                  description: |-
+                    Role is the AWS identity that nodes use. This field is immutable.
+                    This field is mutually exclusive from instanceProfile.
+                    Marking this field as immutable avoids concerns around terminating managed instance profiles from running instances.
+                    This field may be made mutable in the future, assuming the correct garbage collection and drift handling is implemented
+                    for the old instance profiles on an update.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: role cannot be empty
+                      rule: self != ''
+                    - message: immutable field changed
+                      rule: self == oldSelf
+                securityGroupSelectorTerms:
+                  description: SecurityGroupSelectorTerms is a list of or security group selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SecurityGroupSelectorTerm defines selection logic for a security group used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the security group id in EC2
+                        pattern: sg-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the security group name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: securityGroupSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id', 'name']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && (has(x.tags) || has(x.name)))'
+                    - message: '''name'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.name) && (has(x.tags) || has(x.id)))'
+                subnetSelectorTerms:
+                  description: SubnetSelectorTerms is a list of or subnet selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SubnetSelectorTerm defines selection logic for a subnet used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the subnet id in EC2
+                        pattern: subnet-[0-9a-z]+
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: subnetSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id']
+                      rule: self.all(x, has(x.tags) || has(x.id))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in subnetSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && has(x.tags))'
+                tags:
+                  additionalProperties:
+                    type: string
+                  description: Tags to be applied on ec2 resources like instances and launch templates.
+                  type: object
+                  x-kubernetes-validations:
+                    - message: empty tag keys aren't supported
+                      rule: self.all(k, k != '')
+                    - message: tag contains a restricted tag matching kubernetes.io/cluster/
+                      rule: self.all(k, !k.startsWith('kubernetes.io/cluster') )
+                    - message: tag contains a restricted tag matching karpenter.sh/nodepool
+                      rule: self.all(k, k != 'karpenter.sh/nodepool')
+                    - message: tag contains a restricted tag matching karpenter.sh/managed-by
+                      rule: self.all(k, k !='karpenter.sh/managed-by')
+                    - message: tag contains a restricted tag matching karpenter.sh/nodeclaim
+                      rule: self.all(k, k !='karpenter.sh/nodeclaim')
+                    - message: tag contains a restricted tag matching karpenter.k8s.aws/ec2nodeclass
+                      rule: self.all(k, k !='karpenter.k8s.aws/ec2nodeclass')
+                userData:
+                  description: |-
+                    UserData to be applied to the provisioned nodes.
+                    It must be in the appropriate format based on the AMIFamily in use. Karpenter will merge certain fields into
+                    this UserData to ensure nodes are being provisioned with the correct configuration.
+                  type: string
+              required:
+                - amiFamily
+                - securityGroupSelectorTerms
+                - subnetSelectorTerms
+              type: object
+              x-kubernetes-validations:
+                - message: amiSelectorTerms is required when amiFamily == 'Custom'
+                  rule: 'self.amiFamily == ''Custom'' ? self.amiSelectorTerms.size() != 0 : true'
+                - message: must specify exactly one of ['role', 'instanceProfile']
+                  rule: (has(self.role) && !has(self.instanceProfile)) || (!has(self.role) && has(self.instanceProfile))
+                - message: changing from 'instanceProfile' to 'role' is not supported. You must delete and recreate this node class if you want to change this.
+                  rule: (has(oldSelf.role) && has(self.role)) || (has(oldSelf.instanceProfile) && has(self.instanceProfile))
+            status:
+              description: EC2NodeClassStatus contains the resolved state of the EC2NodeClass
+              properties:
+                amis:
+                  description: |-
+                    AMI contains the current AMI values that are available to the
+                    cluster under the AMI selectors.
+                  items:
+                    description: AMI contains resolved AMI selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the AMI
+                        type: string
+                      name:
+                        description: Name of the AMI
+                        type: string
+                      requirements:
+                        description: Requirements of the AMI to be utilized on an instance type
+                        items:
+                          description: |-
+                            A node selector requirement is a selector that contains values, a key, and an operator
+                            that relates the key and values.
+                          properties:
+                            key:
+                              description: The label key that the selector applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                Represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                              type: string
+                            values:
+                              description: |-
+                                An array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. If the operator is Gt or Lt, the values
+                                array must have a single element, which will be interpreted as an integer.
+                                This array is replaced during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                            - key
+                            - operator
+                          type: object
+                        type: array
+                    required:
+                      - id
+                      - requirements
+                    type: object
+                  type: array
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                instanceProfile:
+                  description: InstanceProfile contains the resolved instance profile for the role
+                  type: string
+                securityGroups:
+                  description: |-
+                    SecurityGroups contains the current Security Groups values that are available to the
+                    cluster under the SecurityGroups selectors.
+                  items:
+                    description: SecurityGroup contains resolved SecurityGroup selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the security group
+                        type: string
+                      name:
+                        description: Name of the security group
+                        type: string
+                    required:
+                      - id
+                    type: object
+                  type: array
+                subnets:
+                  description: |-
+                    Subnets contains the current Subnet values that are available to the
+                    cluster under the subnet selectors.
+                  items:
+                    description: Subnet contains resolved Subnet selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the subnet
+                        type: string
+                      zone:
+                        description: The associated availability zone
+                        type: string
+                      zoneID:
+                        description: The associated availability zone ID
+                        type: string
+                    required:
+                      - id
+                      - zone
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+        - v1
+      clientConfig:
+        service:
+          name: karpenter
+          namespace: kube-system
+          port: 8443

--- a/content/projects/karpenter/v1.0.4/karpenter.sh_nodeclaims.yaml
+++ b/content/projects/karpenter/v1.0.4/karpenter.sh_nodeclaims.yaml
@@ -1,0 +1,829 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.3
+  name: nodeclaims.karpenter.sh
+spec:
+  group: karpenter.sh
+  names:
+    categories:
+      - karpenter
+    kind: NodeClaim
+    listKind: NodeClaimList
+    plural: nodeclaims
+    singular: nodeclaim
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.labels.node\.kubernetes\.io/instance-type
+          name: Type
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/capacity-type
+          name: Capacity
+          type: string
+        - jsonPath: .metadata.labels.topology\.kubernetes\.io/zone
+          name: Zone
+          type: string
+        - jsonPath: .status.nodeName
+          name: Node
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .status.providerID
+          name: ID
+          priority: 1
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/nodepool
+          name: NodePool
+          priority: 1
+          type: string
+        - jsonPath: .spec.nodeClassRef.name
+          name: NodeClass
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: NodeClaim is the Schema for the NodeClaims API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: NodeClaimSpec describes the desired state of the NodeClaim
+              properties:
+                expireAfter:
+                  default: 720h
+                  description: |-
+                    ExpireAfter is the duration the controller will wait
+                    before terminating a node, measured from when the node is created. This
+                    is useful to implement features like eventually consistent node upgrade,
+                    memory leak protection, and disruption testing.
+                  pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                  type: string
+                nodeClassRef:
+                  description: NodeClassRef is a reference to an object that defines provider specific configuration
+                  properties:
+                    group:
+                      description: API version of the referent
+                      pattern: ^[^/]*$
+                      type: string
+                    kind:
+                      description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                      type: string
+                    name:
+                      description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                      type: string
+                  required:
+                    - group
+                    - kind
+                    - name
+                  type: object
+                requirements:
+                  description: Requirements are layered with GetLabels and applied to every node.
+                  items:
+                    description: |-
+                      A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                      and minValues that represent the requirement to have at least that many values.
+                    properties:
+                      key:
+                        description: The label key that the selector applies to.
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                        x-kubernetes-validations:
+                          - message: label domain "kubernetes.io" is restricted
+                            rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                          - message: label domain "k8s.io" is restricted
+                            rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                          - message: label domain "karpenter.sh" is restricted
+                            rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                          - message: label "kubernetes.io/hostname" is restricted
+                            rule: self != "kubernetes.io/hostname"
+                          - message: label domain "karpenter.k8s.aws" is restricted
+                            rule: self in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                      minValues:
+                        description: |-
+                          This field is ALPHA and can be dropped or replaced at any time
+                          MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                        maximum: 50
+                        minimum: 1
+                        type: integer
+                      operator:
+                        description: |-
+                          Represents a key's relationship to a set of values.
+                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                        type: string
+                        enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          - Gt
+                          - Lt
+                      values:
+                        description: |-
+                          An array of string values. If the operator is In or NotIn,
+                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                          the values array must be empty. If the operator is Gt or Lt, the values
+                          array must have a single element, which will be interpreted as an integer.
+                          This array is replaced during a strategic merge patch.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                        maxLength: 63
+                        pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                    required:
+                      - key
+                      - operator
+                    type: object
+                  maxItems: 100
+                  type: array
+                  x-kubernetes-validations:
+                    - message: requirements with operator 'In' must have a value defined
+                      rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                    - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                      rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                    - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                      rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                resources:
+                  description: Resources models the resource requirements for the NodeClaim to launch
+                  properties:
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: Requests describes the minimum required resources for the NodeClaim to launch
+                      type: object
+                  type: object
+                startupTaints:
+                  description: |-
+                    StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                    within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                    daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                    purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                taints:
+                  description: Taints will be applied to the NodeClaim's node.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                terminationGracePeriod:
+                  description: |-
+                    TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
+
+                    Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
+
+                    This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
+                    When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
+
+                    Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
+                    If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
+                    that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
+
+                    The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
+                    If left undefined, the controller will wait indefinitely for pods to be drained.
+                  pattern: ^([0-9]+(s|m|h))+$
+                  type: string
+              required:
+                - nodeClassRef
+                - requirements
+              type: object
+              x-kubernetes-validations:
+                - message: spec is immutable
+                  rule: self == oldSelf
+            status:
+              description: NodeClaimStatus defines the observed state of NodeClaim
+              properties:
+                allocatable:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Allocatable is the estimated allocatable capacity of the node
+                  type: object
+                capacity:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Capacity is the estimated full capacity of the node
+                  type: object
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        pattern: ^([A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?|)$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - status
+                      - type
+                    type: object
+                  type: array
+                imageID:
+                  description: ImageID is an identifier for the image that runs on the node
+                  type: string
+                lastPodEventTime:
+                  description: |-
+                    LastPodEventTime is updated with the last time a pod was scheduled
+                    or removed from the node. A pod going terminal or terminating
+                    is also considered as removed.
+                  format: date-time
+                  type: string
+                nodeName:
+                  description: NodeName is the name of the corresponding node object
+                  type: string
+                providerID:
+                  description: ProviderID of the corresponding node object
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.labels.node\.kubernetes\.io/instance-type
+          name: Type
+          type: string
+        - jsonPath: .metadata.labels.topology\.kubernetes\.io/zone
+          name: Zone
+          type: string
+        - jsonPath: .status.nodeName
+          name: Node
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .metadata.labels.karpenter\.sh/capacity-type
+          name: Capacity
+          priority: 1
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/nodepool
+          name: NodePool
+          priority: 1
+          type: string
+        - jsonPath: .spec.nodeClassRef.name
+          name: NodeClass
+          priority: 1
+          type: string
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: NodeClaim is the Schema for the NodeClaims API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: NodeClaimSpec describes the desired state of the NodeClaim
+              properties:
+                kubelet:
+                  description: |-
+                    Kubelet defines args to be used when configuring kubelet on provisioned nodes.
+                    They are a subset of the upstream types, recognizing not all options may be supported.
+                    Wherever possible, the types and names should reflect the upstream kubelet types.
+                  properties:
+                    clusterDNS:
+                      description: |-
+                        clusterDNS is a list of IP addresses for the cluster DNS server.
+                        Note that not all providers may use all addresses.
+                      items:
+                        type: string
+                      type: array
+                    cpuCFSQuota:
+                      description: CPUCFSQuota enables CPU CFS quota enforcement for containers that specify CPU limits.
+                      type: boolean
+                    evictionHard:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionHard is the map of signal names to quantities that define hard eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionHard are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionMaxPodGracePeriod:
+                      description: |-
+                        EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in
+                        response to soft eviction thresholds being met.
+                      format: int32
+                      type: integer
+                    evictionSoft:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionSoft is the map of signal names to quantities that define soft eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoft are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionSoftGracePeriod:
+                      additionalProperties:
+                        type: string
+                      description: EvictionSoftGracePeriod is the map of signal names to quantities that define grace periods for each eviction signal
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoftGracePeriod are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    imageGCHighThresholdPercent:
+                      description: |-
+                        ImageGCHighThresholdPercent is the percent of disk usage after which image
+                        garbage collection is always run. The percent is calculated by dividing this
+                        field value by 100, so this field must be between 0 and 100, inclusive.
+                        When specified, the value must be greater than ImageGCLowThresholdPercent.
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    imageGCLowThresholdPercent:
+                      description: |-
+                        ImageGCLowThresholdPercent is the percent of disk usage before which image
+                        garbage collection is never run. Lowest disk usage to garbage collect to.
+                        The percent is calculated by dividing this field value by 100,
+                        so the field value must be between 0 and 100, inclusive.
+                        When specified, the value must be less than imageGCHighThresholdPercent
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    kubeReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: KubeReserved contains resources reserved for Kubernetes system components.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for kubeReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: kubeReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                    maxPods:
+                      description: |-
+                        MaxPods is an override for the maximum number of pods that can run on
+                        a worker node instance.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    podsPerCore:
+                      description: |-
+                        PodsPerCore is an override for the number of pods that can run on a worker node
+                        instance based on the number of cpu cores. This value cannot exceed MaxPods, so, if
+                        MaxPods is a lower value, that value will be used.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    systemReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: SystemReserved contains resources reserved for OS system daemons and kernel memory.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for systemReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: systemReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                  type: object
+                  x-kubernetes-validations:
+                    - message: imageGCHighThresholdPercent must be greater than imageGCLowThresholdPercent
+                      rule: 'has(self.imageGCHighThresholdPercent) && has(self.imageGCLowThresholdPercent) ?  self.imageGCHighThresholdPercent > self.imageGCLowThresholdPercent  : true'
+                    - message: evictionSoft OwnerKey does not have a matching evictionSoftGracePeriod
+                      rule: has(self.evictionSoft) ? self.evictionSoft.all(e, (e in self.evictionSoftGracePeriod)):true
+                    - message: evictionSoftGracePeriod OwnerKey does not have a matching evictionSoft
+                      rule: has(self.evictionSoftGracePeriod) ? self.evictionSoftGracePeriod.all(e, (e in self.evictionSoft)):true
+                nodeClassRef:
+                  description: NodeClassRef is a reference to an object that defines provider specific configuration
+                  properties:
+                    apiVersion:
+                      description: API version of the referent
+                      type: string
+                    kind:
+                      description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                      type: string
+                    name:
+                      description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                      type: string
+                  required:
+                    - name
+                  type: object
+                requirements:
+                  description: Requirements are layered with GetLabels and applied to every node.
+                  items:
+                    description: |-
+                      A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                      and minValues that represent the requirement to have at least that many values.
+                    properties:
+                      key:
+                        description: The label key that the selector applies to.
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                        x-kubernetes-validations:
+                          - message: label domain "kubernetes.io" is restricted
+                            rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                          - message: label domain "k8s.io" is restricted
+                            rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                          - message: label domain "karpenter.sh" is restricted
+                            rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                          - message: label "kubernetes.io/hostname" is restricted
+                            rule: self != "kubernetes.io/hostname"
+                          - message: label domain "karpenter.k8s.aws" is restricted
+                            rule: self in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                      minValues:
+                        description: |-
+                          This field is ALPHA and can be dropped or replaced at any time
+                          MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                        maximum: 50
+                        minimum: 1
+                        type: integer
+                      operator:
+                        description: |-
+                          Represents a key's relationship to a set of values.
+                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                        type: string
+                        enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          - Gt
+                          - Lt
+                      values:
+                        description: |-
+                          An array of string values. If the operator is In or NotIn,
+                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                          the values array must be empty. If the operator is Gt or Lt, the values
+                          array must have a single element, which will be interpreted as an integer.
+                          This array is replaced during a strategic merge patch.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                        maxLength: 63
+                        pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                    required:
+                      - key
+                      - operator
+                    type: object
+                  maxItems: 100
+                  type: array
+                  x-kubernetes-validations:
+                    - message: requirements with operator 'In' must have a value defined
+                      rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                    - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                      rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                    - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                      rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                resources:
+                  description: Resources models the resource requirements for the NodeClaim to launch
+                  properties:
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: Requests describes the minimum required resources for the NodeClaim to launch
+                      type: object
+                  type: object
+                startupTaints:
+                  description: |-
+                    StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                    within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                    daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                    purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                taints:
+                  description: Taints will be applied to the NodeClaim's node.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+              required:
+                - nodeClassRef
+                - requirements
+              type: object
+            status:
+              description: NodeClaimStatus defines the observed state of NodeClaim
+              properties:
+                allocatable:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Allocatable is the estimated allocatable capacity of the node
+                  type: object
+                capacity:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Capacity is the estimated full capacity of the node
+                  type: object
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        pattern: ^([A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?|)$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - status
+                      - type
+                    type: object
+                  type: array
+                imageID:
+                  description: ImageID is an identifier for the image that runs on the node
+                  type: string
+                nodeName:
+                  description: NodeName is the name of the corresponding node object
+                  type: string
+                providerID:
+                  description: ProviderID of the corresponding node object
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+        - v1
+      clientConfig:
+        service:
+          name: karpenter
+          namespace: kube-system
+          port: 8443

--- a/content/projects/karpenter/v1.0.4/karpenter.sh_nodepools.yaml
+++ b/content/projects/karpenter/v1.0.4/karpenter.sh_nodepools.yaml
@@ -1,0 +1,1082 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.3
+  name: nodepools.karpenter.sh
+spec:
+  group: karpenter.sh
+  names:
+    categories:
+      - karpenter
+    kind: NodePool
+    listKind: NodePoolList
+    plural: nodepools
+    singular: nodepool
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.template.spec.nodeClassRef.name
+          name: NodeClass
+          type: string
+        - jsonPath: .status.resources.nodes
+          name: Nodes
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.weight
+          name: Weight
+          priority: 1
+          type: integer
+        - jsonPath: .status.resources.cpu
+          name: CPU
+          priority: 1
+          type: string
+        - jsonPath: .status.resources.memory
+          name: Memory
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: NodePool is the Schema for the NodePools API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                NodePoolSpec is the top level nodepool specification. Nodepools
+                launch nodes in response to pods that are unschedulable. A single nodepool
+                is capable of managing a diverse set of nodes. Node properties are determined
+                from a combination of nodepool and pod scheduling constraints.
+              properties:
+                disruption:
+                  default:
+                    consolidateAfter: 0s
+                  description: Disruption contains the parameters that relate to Karpenter's disruption logic
+                  properties:
+                    budgets:
+                      default:
+                        - nodes: 10%
+                      description: |-
+                        Budgets is a list of Budgets.
+                        If there are multiple active budgets, Karpenter uses
+                        the most restrictive value. If left undefined,
+                        this will default to one budget with a value to 10%.
+                      items:
+                        description: |-
+                          Budget defines when Karpenter will restrict the
+                          number of Node Claims that can be terminating simultaneously.
+                        properties:
+                          duration:
+                            description: |-
+                              Duration determines how long a Budget is active since each Schedule hit.
+                              Only minutes and hours are accepted, as cron does not work in seconds.
+                              If omitted, the budget is always active.
+                              This is required if Schedule is set.
+                              This regex has an optional 0s at the end since the duration.String() always adds
+                              a 0s at the end.
+                            pattern: ^((([0-9]+(h|m))|([0-9]+h[0-9]+m))(0s)?)$
+                            type: string
+                          nodes:
+                            default: 10%
+                            description: |-
+                              Nodes dictates the maximum number of NodeClaims owned by this NodePool
+                              that can be terminating at once. This is calculated by counting nodes that
+                              have a deletion timestamp set, or are actively being deleted by Karpenter.
+                              This field is required when specifying a budget.
+                              This cannot be of type intstr.IntOrString since kubebuilder doesn't support pattern
+                              checking for int nodes for IntOrString nodes.
+                              Ref: https://github.com/kubernetes-sigs/controller-tools/blob/55efe4be40394a288216dab63156b0a64fb82929/pkg/crd/markers/validation.go#L379-L388
+                            pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
+                            type: string
+                          reasons:
+                            description: |-
+                              Reasons is a list of disruption methods that this budget applies to. If Reasons is not set, this budget applies to all methods.
+                              Otherwise, this will apply to each reason defined.
+                              allowed reasons are Underutilized, Empty, and Drifted.
+                            items:
+                              description: DisruptionReason defines valid reasons for disruption budgets.
+                              enum:
+                                - Underutilized
+                                - Empty
+                                - Drifted
+                              type: string
+                            type: array
+                          schedule:
+                            description: |-
+                              Schedule specifies when a budget begins being active, following
+                              the upstream cronjob syntax. If omitted, the budget is always active.
+                              Timezones are not supported.
+                              This field is required if Duration is set.
+                            pattern: ^(@(annually|yearly|monthly|weekly|daily|midnight|hourly))|((.+)\s(.+)\s(.+)\s(.+)\s(.+))$
+                            type: string
+                        required:
+                          - nodes
+                        type: object
+                      maxItems: 50
+                      type: array
+                      x-kubernetes-validations:
+                        - message: '''schedule'' must be set with ''duration'''
+                          rule: self.all(x, has(x.schedule) == has(x.duration))
+                    consolidateAfter:
+                      description: |-
+                        ConsolidateAfter is the duration the controller will wait
+                        before attempting to terminate nodes that are underutilized.
+                        Refer to ConsolidationPolicy for how underutilization is considered.
+                      pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                      type: string
+                    consolidationPolicy:
+                      default: WhenEmptyOrUnderutilized
+                      description: |-
+                        ConsolidationPolicy describes which nodes Karpenter can disrupt through its consolidation
+                        algorithm. This policy defaults to "WhenEmptyOrUnderutilized" if not specified
+                      enum:
+                        - WhenEmpty
+                        - WhenEmptyOrUnderutilized
+                      type: string
+                  required:
+                    - consolidateAfter
+                  type: object
+                limits:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Limits define a set of bounds for provisioning capacity.
+                  type: object
+                template:
+                  description: |-
+                    Template contains the template of possibilities for the provisioning logic to launch a NodeClaim with.
+                    NodeClaims launched from this NodePool will often be further constrained than the template specifies.
+                  properties:
+                    metadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Annotations is an unstructured key value map stored with a resource that may be
+                            set by external tools to store and retrieve arbitrary metadata. They are not
+                            queryable and should be preserved when modifying objects.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                            maxLength: 63
+                            pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                          description: |-
+                            Map of string keys and values that can be used to organize and categorize
+                            (scope and select) objects. May match selectors of replication controllers
+                            and services.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
+                          type: object
+                          maxProperties: 100
+                          x-kubernetes-validations:
+                            - message: label domain "kubernetes.io" is restricted
+                              rule: self.all(x, x in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region",  "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || x.find("^([^/]+)").endsWith("node.kubernetes.io") || x.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !x.find("^([^/]+)").endsWith("kubernetes.io"))
+                            - message: label domain "k8s.io" is restricted
+                              rule: self.all(x, x.find("^([^/]+)").endsWith("kops.k8s.io") || !x.find("^([^/]+)").endsWith("k8s.io"))
+                            - message: label domain "karpenter.sh" is restricted
+                              rule: self.all(x, x in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !x.find("^([^/]+)").endsWith("karpenter.sh"))
+                            - message: label "karpenter.sh/nodepool" is restricted
+                              rule: self.all(x, x != "karpenter.sh/nodepool")
+                            - message: label "kubernetes.io/hostname" is restricted
+                              rule: self.all(x, x != "kubernetes.io/hostname")
+                            - message: label domain "karpenter.k8s.aws" is restricted
+                              rule: self.all(x, x in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !x.find("^([^/]+)").endsWith("karpenter.k8s.aws"))
+                      type: object
+                    spec:
+                      description: |-
+                        NodeClaimTemplateSpec describes the desired state of the NodeClaim in the Nodepool
+                        NodeClaimTemplateSpec is used in the NodePool's NodeClaimTemplate, with the resource requests omitted since
+                        users are not able to set resource requests in the NodePool.
+                      properties:
+                        expireAfter:
+                          default: 720h
+                          description: |-
+                            ExpireAfter is the duration the controller will wait
+                            before terminating a node, measured from when the node is created. This
+                            is useful to implement features like eventually consistent node upgrade,
+                            memory leak protection, and disruption testing.
+                          pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                          type: string
+                        nodeClassRef:
+                          description: NodeClassRef is a reference to an object that defines provider specific configuration
+                          properties:
+                            group:
+                              description: API version of the referent
+                              pattern: ^[^/]*$
+                              type: string
+                            kind:
+                              description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                              type: string
+                            name:
+                              description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                          required:
+                            - group
+                            - kind
+                            - name
+                          type: object
+                        requirements:
+                          description: Requirements are layered with GetLabels and applied to every node.
+                          items:
+                            description: |-
+                              A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                              and minValues that represent the requirement to have at least that many values.
+                            properties:
+                              key:
+                                description: The label key that the selector applies to.
+                                type: string
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                                x-kubernetes-validations:
+                                  - message: label domain "kubernetes.io" is restricted
+                                    rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                                  - message: label domain "k8s.io" is restricted
+                                    rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                                  - message: label domain "karpenter.sh" is restricted
+                                    rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                                  - message: label "karpenter.sh/nodepool" is restricted
+                                    rule: self != "karpenter.sh/nodepool"
+                                  - message: label "kubernetes.io/hostname" is restricted
+                                    rule: self != "kubernetes.io/hostname"
+                                  - message: label domain "karpenter.k8s.aws" is restricted
+                                    rule: self in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                              minValues:
+                                description: |-
+                                  This field is ALPHA and can be dropped or replaced at any time
+                                  MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                                maximum: 50
+                                minimum: 1
+                                type: integer
+                              operator:
+                                description: |-
+                                  Represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                type: string
+                                enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  - Gt
+                                  - Lt
+                              values:
+                                description: |-
+                                  An array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                  array must have a single element, which will be interpreted as an integer.
+                                  This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          maxItems: 100
+                          type: array
+                          x-kubernetes-validations:
+                            - message: requirements with operator 'In' must have a value defined
+                              rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                            - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                              rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                            - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                              rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                        startupTaints:
+                          description: |-
+                            StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                            within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                            daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                            purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        taints:
+                          description: Taints will be applied to the NodeClaim's node.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        terminationGracePeriod:
+                          description: |-
+                            TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
+
+                            Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
+
+                            This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
+                            When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
+
+                            Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
+                            If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
+                            that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
+
+                            The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
+                            If left undefined, the controller will wait indefinitely for pods to be drained.
+                          pattern: ^([0-9]+(s|m|h))+$
+                          type: string
+                      required:
+                        - nodeClassRef
+                        - requirements
+                      type: object
+                  required:
+                    - spec
+                  type: object
+                weight:
+                  description: |-
+                    Weight is the priority given to the nodepool during scheduling. A higher
+                    numerical weight indicates that this nodepool will be ordered
+                    ahead of other nodepools with lower weights. A nodepool with no weight
+                    will be treated as if it is a nodepool with a weight of 0.
+                  format: int32
+                  maximum: 100
+                  minimum: 1
+                  type: integer
+              required:
+                - template
+              type: object
+            status:
+              description: NodePoolStatus defines the observed state of NodePool
+              properties:
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                resources:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Resources is the list of resources that have been provisioned.
+                  type: object
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .spec.template.spec.nodeClassRef.name
+          name: NodeClass
+          type: string
+        - jsonPath: .spec.weight
+          name: Weight
+          priority: 1
+          type: string
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: NodePool is the Schema for the NodePools API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                NodePoolSpec is the top level nodepool specification. Nodepools
+                launch nodes in response to pods that are unschedulable. A single nodepool
+                is capable of managing a diverse set of nodes. Node properties are determined
+                from a combination of nodepool and pod scheduling constraints.
+              properties:
+                disruption:
+                  default:
+                    consolidationPolicy: WhenUnderutilized
+                    expireAfter: 720h
+                  description: Disruption contains the parameters that relate to Karpenter's disruption logic
+                  properties:
+                    budgets:
+                      default:
+                        - nodes: 10%
+                      description: |-
+                        Budgets is a list of Budgets.
+                        If there are multiple active budgets, Karpenter uses
+                        the most restrictive value. If left undefined,
+                        this will default to one budget with a value to 10%.
+                      items:
+                        description: |-
+                          Budget defines when Karpenter will restrict the
+                          number of Node Claims that can be terminating simultaneously.
+                        properties:
+                          duration:
+                            description: |-
+                              Duration determines how long a Budget is active since each Schedule hit.
+                              Only minutes and hours are accepted, as cron does not work in seconds.
+                              If omitted, the budget is always active.
+                              This is required if Schedule is set.
+                              This regex has an optional 0s at the end since the duration.String() always adds
+                              a 0s at the end.
+                            pattern: ^((([0-9]+(h|m))|([0-9]+h[0-9]+m))(0s)?)$
+                            type: string
+                          nodes:
+                            default: 10%
+                            description: |-
+                              Nodes dictates the maximum number of NodeClaims owned by this NodePool
+                              that can be terminating at once. This is calculated by counting nodes that
+                              have a deletion timestamp set, or are actively being deleted by Karpenter.
+                              This field is required when specifying a budget.
+                              This cannot be of type intstr.IntOrString since kubebuilder doesn't support pattern
+                              checking for int nodes for IntOrString nodes.
+                              Ref: https://github.com/kubernetes-sigs/controller-tools/blob/55efe4be40394a288216dab63156b0a64fb82929/pkg/crd/markers/validation.go#L379-L388
+                            pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
+                            type: string
+                          schedule:
+                            description: |-
+                              Schedule specifies when a budget begins being active, following
+                              the upstream cronjob syntax. If omitted, the budget is always active.
+                              Timezones are not supported.
+                              This field is required if Duration is set.
+                            pattern: ^(@(annually|yearly|monthly|weekly|daily|midnight|hourly))|((.+)\s(.+)\s(.+)\s(.+)\s(.+))$
+                            type: string
+                        required:
+                          - nodes
+                        type: object
+                      maxItems: 50
+                      type: array
+                      x-kubernetes-validations:
+                        - message: '''schedule'' must be set with ''duration'''
+                          rule: self.all(x, has(x.schedule) == has(x.duration))
+                    consolidateAfter:
+                      description: |-
+                        ConsolidateAfter is the duration the controller will wait
+                        before attempting to terminate nodes that are underutilized.
+                        Refer to ConsolidationPolicy for how underutilization is considered.
+                      pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                      type: string
+                    consolidationPolicy:
+                      default: WhenUnderutilized
+                      description: |-
+                        ConsolidationPolicy describes which nodes Karpenter can disrupt through its consolidation
+                        algorithm. This policy defaults to "WhenUnderutilized" if not specified
+                      enum:
+                        - WhenEmpty
+                        - WhenUnderutilized
+                      type: string
+                    expireAfter:
+                      default: 720h
+                      description: |-
+                        ExpireAfter is the duration the controller will wait
+                        before terminating a node, measured from when the node is created. This
+                        is useful to implement features like eventually consistent node upgrade,
+                        memory leak protection, and disruption testing.
+                      pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                      type: string
+                  type: object
+                  x-kubernetes-validations:
+                    - message: consolidateAfter cannot be combined with consolidationPolicy=WhenUnderutilized
+                      rule: 'has(self.consolidateAfter) ? self.consolidationPolicy != ''WhenUnderutilized'' || self.consolidateAfter == ''Never'' : true'
+                    - message: consolidateAfter must be specified with consolidationPolicy=WhenEmpty
+                      rule: 'self.consolidationPolicy == ''WhenEmpty'' ? has(self.consolidateAfter) : true'
+                limits:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Limits define a set of bounds for provisioning capacity.
+                  type: object
+                template:
+                  description: |-
+                    Template contains the template of possibilities for the provisioning logic to launch a NodeClaim with.
+                    NodeClaims launched from this NodePool will often be further constrained than the template specifies.
+                  properties:
+                    metadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Annotations is an unstructured key value map stored with a resource that may be
+                            set by external tools to store and retrieve arbitrary metadata. They are not
+                            queryable and should be preserved when modifying objects.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                            maxLength: 63
+                            pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                          description: |-
+                            Map of string keys and values that can be used to organize and categorize
+                            (scope and select) objects. May match selectors of replication controllers
+                            and services.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
+                          type: object
+                          maxProperties: 100
+                          x-kubernetes-validations:
+                            - message: label domain "kubernetes.io" is restricted
+                              rule: self.all(x, x in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region",  "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || x.find("^([^/]+)").endsWith("node.kubernetes.io") || x.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !x.find("^([^/]+)").endsWith("kubernetes.io"))
+                            - message: label domain "k8s.io" is restricted
+                              rule: self.all(x, x.find("^([^/]+)").endsWith("kops.k8s.io") || !x.find("^([^/]+)").endsWith("k8s.io"))
+                            - message: label domain "karpenter.sh" is restricted
+                              rule: self.all(x, x in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !x.find("^([^/]+)").endsWith("karpenter.sh"))
+                            - message: label "karpenter.sh/nodepool" is restricted
+                              rule: self.all(x, x != "karpenter.sh/nodepool")
+                            - message: label "kubernetes.io/hostname" is restricted
+                              rule: self.all(x, x != "kubernetes.io/hostname")
+                            - message: label domain "karpenter.k8s.aws" is restricted
+                              rule: self.all(x, x in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !x.find("^([^/]+)").endsWith("karpenter.k8s.aws"))
+                      type: object
+                    spec:
+                      description: NodeClaimSpec describes the desired state of the NodeClaim
+                      properties:
+                        kubelet:
+                          description: |-
+                            Kubelet defines args to be used when configuring kubelet on provisioned nodes.
+                            They are a subset of the upstream types, recognizing not all options may be supported.
+                            Wherever possible, the types and names should reflect the upstream kubelet types.
+                          properties:
+                            clusterDNS:
+                              description: |-
+                                clusterDNS is a list of IP addresses for the cluster DNS server.
+                                Note that not all providers may use all addresses.
+                              items:
+                                type: string
+                              type: array
+                            cpuCFSQuota:
+                              description: CPUCFSQuota enables CPU CFS quota enforcement for containers that specify CPU limits.
+                              type: boolean
+                            evictionHard:
+                              additionalProperties:
+                                type: string
+                                pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                              description: EvictionHard is the map of signal names to quantities that define hard eviction thresholds
+                              type: object
+                              x-kubernetes-validations:
+                                - message: valid keys for evictionHard are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                                  rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                            evictionMaxPodGracePeriod:
+                              description: |-
+                                EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in
+                                response to soft eviction thresholds being met.
+                              format: int32
+                              type: integer
+                            evictionSoft:
+                              additionalProperties:
+                                type: string
+                                pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                              description: EvictionSoft is the map of signal names to quantities that define soft eviction thresholds
+                              type: object
+                              x-kubernetes-validations:
+                                - message: valid keys for evictionSoft are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                                  rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                            evictionSoftGracePeriod:
+                              additionalProperties:
+                                type: string
+                              description: EvictionSoftGracePeriod is the map of signal names to quantities that define grace periods for each eviction signal
+                              type: object
+                              x-kubernetes-validations:
+                                - message: valid keys for evictionSoftGracePeriod are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                                  rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                            imageGCHighThresholdPercent:
+                              description: |-
+                                ImageGCHighThresholdPercent is the percent of disk usage after which image
+                                garbage collection is always run. The percent is calculated by dividing this
+                                field value by 100, so this field must be between 0 and 100, inclusive.
+                                When specified, the value must be greater than ImageGCLowThresholdPercent.
+                              format: int32
+                              maximum: 100
+                              minimum: 0
+                              type: integer
+                            imageGCLowThresholdPercent:
+                              description: |-
+                                ImageGCLowThresholdPercent is the percent of disk usage before which image
+                                garbage collection is never run. Lowest disk usage to garbage collect to.
+                                The percent is calculated by dividing this field value by 100,
+                                so the field value must be between 0 and 100, inclusive.
+                                When specified, the value must be less than imageGCHighThresholdPercent
+                              format: int32
+                              maximum: 100
+                              minimum: 0
+                              type: integer
+                            kubeReserved:
+                              additionalProperties:
+                                type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              description: KubeReserved contains resources reserved for Kubernetes system components.
+                              type: object
+                              x-kubernetes-validations:
+                                - message: valid keys for kubeReserved are ['cpu','memory','ephemeral-storage','pid']
+                                  rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                                - message: kubeReserved value cannot be a negative resource quantity
+                                  rule: self.all(x, !self[x].startsWith('-'))
+                            maxPods:
+                              description: |-
+                                MaxPods is an override for the maximum number of pods that can run on
+                                a worker node instance.
+                              format: int32
+                              minimum: 0
+                              type: integer
+                            podsPerCore:
+                              description: |-
+                                PodsPerCore is an override for the number of pods that can run on a worker node
+                                instance based on the number of cpu cores. This value cannot exceed MaxPods, so, if
+                                MaxPods is a lower value, that value will be used.
+                              format: int32
+                              minimum: 0
+                              type: integer
+                            systemReserved:
+                              additionalProperties:
+                                type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              description: SystemReserved contains resources reserved for OS system daemons and kernel memory.
+                              type: object
+                              x-kubernetes-validations:
+                                - message: valid keys for systemReserved are ['cpu','memory','ephemeral-storage','pid']
+                                  rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                                - message: systemReserved value cannot be a negative resource quantity
+                                  rule: self.all(x, !self[x].startsWith('-'))
+                          type: object
+                          x-kubernetes-validations:
+                            - message: imageGCHighThresholdPercent must be greater than imageGCLowThresholdPercent
+                              rule: 'has(self.imageGCHighThresholdPercent) && has(self.imageGCLowThresholdPercent) ?  self.imageGCHighThresholdPercent > self.imageGCLowThresholdPercent  : true'
+                            - message: evictionSoft OwnerKey does not have a matching evictionSoftGracePeriod
+                              rule: has(self.evictionSoft) ? self.evictionSoft.all(e, (e in self.evictionSoftGracePeriod)):true
+                            - message: evictionSoftGracePeriod OwnerKey does not have a matching evictionSoft
+                              rule: has(self.evictionSoftGracePeriod) ? self.evictionSoftGracePeriod.all(e, (e in self.evictionSoft)):true
+                        nodeClassRef:
+                          description: NodeClassRef is a reference to an object that defines provider specific configuration
+                          properties:
+                            apiVersion:
+                              description: API version of the referent
+                              type: string
+                            kind:
+                              description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                              type: string
+                            name:
+                              description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        requirements:
+                          description: Requirements are layered with GetLabels and applied to every node.
+                          items:
+                            description: |-
+                              A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                              and minValues that represent the requirement to have at least that many values.
+                            properties:
+                              key:
+                                description: The label key that the selector applies to.
+                                type: string
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                                x-kubernetes-validations:
+                                  - message: label domain "kubernetes.io" is restricted
+                                    rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                                  - message: label domain "k8s.io" is restricted
+                                    rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                                  - message: label domain "karpenter.sh" is restricted
+                                    rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                                  - message: label "karpenter.sh/nodepool" is restricted
+                                    rule: self != "karpenter.sh/nodepool"
+                                  - message: label "kubernetes.io/hostname" is restricted
+                                    rule: self != "kubernetes.io/hostname"
+                                  - message: label domain "karpenter.k8s.aws" is restricted
+                                    rule: self in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                              minValues:
+                                description: |-
+                                  This field is ALPHA and can be dropped or replaced at any time
+                                  MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                                maximum: 50
+                                minimum: 1
+                                type: integer
+                              operator:
+                                description: |-
+                                  Represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                type: string
+                                enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  - Gt
+                                  - Lt
+                              values:
+                                description: |-
+                                  An array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                  array must have a single element, which will be interpreted as an integer.
+                                  This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          maxItems: 100
+                          type: array
+                          x-kubernetes-validations:
+                            - message: requirements with operator 'In' must have a value defined
+                              rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                            - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                              rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                            - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                              rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                        resources:
+                          description: Resources models the resource requirements for the NodeClaim to launch
+                          properties:
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: Requests describes the minimum required resources for the NodeClaim to launch
+                              type: object
+                          type: object
+                          maxProperties: 0
+                        startupTaints:
+                          description: |-
+                            StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                            within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                            daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                            purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        taints:
+                          description: Taints will be applied to the NodeClaim's node.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                      required:
+                        - nodeClassRef
+                        - requirements
+                      type: object
+                  required:
+                    - spec
+                  type: object
+                weight:
+                  description: |-
+                    Weight is the priority given to the nodepool during scheduling. A higher
+                    numerical weight indicates that this nodepool will be ordered
+                    ahead of other nodepools with lower weights. A nodepool with no weight
+                    will be treated as if it is a nodepool with a weight of 0.
+                  format: int32
+                  maximum: 100
+                  minimum: 1
+                  type: integer
+              required:
+                - template
+              type: object
+            status:
+              description: NodePoolStatus defines the observed state of NodePool
+              properties:
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                resources:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Resources is the list of resources that have been provisioned.
+                  type: object
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+        - v1
+      clientConfig:
+        service:
+          name: karpenter
+          namespace: kube-system
+          port: 8443

--- a/content/projects/karpenter/v1.0.5/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/content/projects/karpenter/v1.0.5/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -1,0 +1,1306 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.3
+  name: ec2nodeclasses.karpenter.k8s.aws
+spec:
+  group: karpenter.k8s.aws
+  names:
+    categories:
+      - karpenter
+    kind: EC2NodeClass
+    listKind: EC2NodeClassList
+    plural: ec2nodeclasses
+    shortNames:
+      - ec2nc
+      - ec2ncs
+    singular: ec2nodeclass
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.role
+          name: Role
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: EC2NodeClass is the Schema for the EC2NodeClass API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                EC2NodeClassSpec is the top level specification for the AWS Karpenter Provider.
+                This will contain configuration necessary to launch instances in AWS.
+              properties:
+                amiFamily:
+                  description: |-
+                    AMIFamily dictates the UserData format and default BlockDeviceMappings used when generating launch templates.
+                    This field is optional when using an alias amiSelectorTerm, and the value will be inferred from the alias'
+                    family. When an alias is specified, this field may only be set to its corresponding family or 'Custom'. If no
+                    alias is specified, this field is required.
+                    NOTE: We ignore the AMIFamily for hashing here because we hash the AMIFamily dynamically by using the alias using
+                    the AMIFamily() helper function
+                  enum:
+                    - AL2
+                    - AL2023
+                    - Bottlerocket
+                    - Custom
+                    - Windows2019
+                    - Windows2022
+                  type: string
+                amiSelectorTerms:
+                  description: AMISelectorTerms is a list of or ami selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      AMISelectorTerm defines selection logic for an ami used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      alias:
+                        description: |-
+                          Alias specifies which EKS optimized AMI to select.
+                          Each alias consists of a family and an AMI version, specified as "family@version".
+                          Valid families include: al2, al2023, bottlerocket, windows2019, and windows2022.
+                          The version can either be pinned to a specific AMI release, with that AMIs version format (ex: "al2023@v20240625" or "bottlerocket@v1.10.0").
+                          The version can also be set to "latest" for any family. Setting the version to latest will result in drift when a new AMI is released. This is **not** recommended for production environments.
+                          Note: The Windows families do **not** support version pinning, and only latest may be used.
+                        maxLength: 30
+                        type: string
+                        x-kubernetes-validations:
+                          - message: '''alias'' is improperly formatted, must match the format ''family@version'''
+                            rule: self.matches('^[a-zA-Z0-9]+@.+$')
+                          - message: 'family is not supported, must be one of the following: ''al2'', ''al2023'', ''bottlerocket'', ''windows2019'', ''windows2022'''
+                            rule: self.split('@')[0] in ['al2','al2023','bottlerocket','windows2019','windows2022']
+                          - message: windows families may only specify version 'latest'
+                            rule: 'self.split(''@'')[0] in [''windows2019'',''windows2022''] ? self.split(''@'')[1] == ''latest'' : true'
+                      id:
+                        description: ID is the ami id in EC2
+                        pattern: ami-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the ami name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      owner:
+                        description: |-
+                          Owner is the owner for the ami.
+                          You can specify a combination of AWS account IDs, "self", "amazon", and "aws-marketplace"
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  minItems: 1
+                  type: array
+                  x-kubernetes-validations:
+                    - message: expected at least one, got none, ['tags', 'id', 'name', 'alias']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name) || has(x.alias))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.exists(x, has(x.id) && (has(x.alias) || has(x.tags) || has(x.name) || has(x.owner)))'
+                    - message: '''alias'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.exists(x, has(x.alias) && (has(x.id) || has(x.tags) || has(x.name) || has(x.owner)))'
+                    - message: '''alias'' is mutually exclusive, cannot be set with a combination of other amiSelectorTerms'
+                      rule: '!(self.exists(x, has(x.alias)) && self.size() != 1)'
+                associatePublicIPAddress:
+                  description: AssociatePublicIPAddress controls if public IP addresses are assigned to instances that are launched with the nodeclass.
+                  type: boolean
+                blockDeviceMappings:
+                  description: BlockDeviceMappings to be applied to provisioned nodes.
+                  items:
+                    properties:
+                      deviceName:
+                        description: The device name (for example, /dev/sdh or xvdh).
+                        type: string
+                      ebs:
+                        description: EBS contains parameters used to automatically set up EBS volumes when an instance is launched.
+                        properties:
+                          deleteOnTermination:
+                            description: DeleteOnTermination indicates whether the EBS volume is deleted on instance termination.
+                            type: boolean
+                          encrypted:
+                            description: |-
+                              Encrypted indicates whether the EBS volume is encrypted. Encrypted volumes can only
+                              be attached to instances that support Amazon EBS encryption. If you are creating
+                              a volume from a snapshot, you can't specify an encryption value.
+                            type: boolean
+                          iops:
+                            description: |-
+                              IOPS is the number of I/O operations per second (IOPS). For gp3, io1, and io2 volumes,
+                              this represents the number of IOPS that are provisioned for the volume. For
+                              gp2 volumes, this represents the baseline performance of the volume and the
+                              rate at which the volume accumulates I/O credits for bursting.
+
+                              The following are the supported values for each volume type:
+
+                                 * gp3: 3,000-16,000 IOPS
+
+                                 * io1: 100-64,000 IOPS
+
+                                 * io2: 100-64,000 IOPS
+
+                              For io1 and io2 volumes, we guarantee 64,000 IOPS only for Instances built
+                              on the Nitro System (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances).
+                              Other instance families guarantee performance up to 32,000 IOPS.
+
+                              This parameter is supported for io1, io2, and gp3 volumes only. This parameter
+                              is not supported for gp2, st1, sc1, or standard volumes.
+                            format: int64
+                            type: integer
+                          kmsKeyID:
+                            description: KMSKeyID (ARN) of the symmetric Key Management Service (KMS) CMK used for encryption.
+                            type: string
+                          snapshotID:
+                            description: SnapshotID is the ID of an EBS snapshot
+                            type: string
+                          throughput:
+                            description: |-
+                              Throughput to provision for a gp3 volume, with a maximum of 1,000 MiB/s.
+                              Valid Range: Minimum value of 125. Maximum value of 1000.
+                            format: int64
+                            type: integer
+                          volumeSize:
+                            description: |-
+                              VolumeSize in `Gi`, `G`, `Ti`, or `T`. You must specify either a snapshot ID or
+                              a volume size. The following are the supported volumes sizes for each volume
+                              type:
+
+                                 * gp2 and gp3: 1-16,384
+
+                                 * io1 and io2: 4-16,384
+
+                                 * st1 and sc1: 125-16,384
+
+                                 * standard: 1-1,024
+                            pattern: ^((?:[1-9][0-9]{0,3}|[1-4][0-9]{4}|[5][0-8][0-9]{3}|59000)Gi|(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|[6][0-3][0-9]{3}|64000)G|([1-9]||[1-5][0-7]|58)Ti|([1-9]||[1-5][0-9]|6[0-3]|64)T)$
+                            type: string
+                          volumeType:
+                            description: |-
+                              VolumeType of the block device.
+                              For more information, see Amazon EBS volume types (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html)
+                              in the Amazon Elastic Compute Cloud User Guide.
+                            enum:
+                              - standard
+                              - io1
+                              - io2
+                              - gp2
+                              - sc1
+                              - st1
+                              - gp3
+                            type: string
+                        type: object
+                        x-kubernetes-validations:
+                          - message: snapshotID or volumeSize must be defined
+                            rule: has(self.snapshotID) || has(self.volumeSize)
+                      rootVolume:
+                        description: |-
+                          RootVolume is a flag indicating if this device is mounted as kubelet root dir. You can
+                          configure at most one root volume in BlockDeviceMappings.
+                        type: boolean
+                    type: object
+                  maxItems: 50
+                  type: array
+                  x-kubernetes-validations:
+                    - message: must have only one blockDeviceMappings with rootVolume
+                      rule: self.filter(x, has(x.rootVolume)?x.rootVolume==true:false).size() <= 1
+                context:
+                  description: |-
+                    Context is a Reserved field in EC2 APIs
+                    https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet.html
+                  type: string
+                detailedMonitoring:
+                  description: DetailedMonitoring controls if detailed monitoring is enabled for instances that are launched
+                  type: boolean
+                instanceProfile:
+                  description: |-
+                    InstanceProfile is the AWS entity that instances use.
+                    This field is mutually exclusive from role.
+                    The instance profile should already have a role assigned to it that Karpenter
+                     has PassRole permission on for instance launch using this instanceProfile to succeed.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: instanceProfile cannot be empty
+                      rule: self != ''
+                instanceStorePolicy:
+                  description: InstanceStorePolicy specifies how to handle instance-store disks.
+                  enum:
+                    - RAID0
+                  type: string
+                kubelet:
+                  description: |-
+                    Kubelet defines args to be used when configuring kubelet on provisioned nodes.
+                    They are a subset of the upstream types, recognizing not all options may be supported.
+                    Wherever possible, the types and names should reflect the upstream kubelet types.
+                  properties:
+                    clusterDNS:
+                      description: |-
+                        clusterDNS is a list of IP addresses for the cluster DNS server.
+                        Note that not all providers may use all addresses.
+                      items:
+                        type: string
+                      type: array
+                    cpuCFSQuota:
+                      description: CPUCFSQuota enables CPU CFS quota enforcement for containers that specify CPU limits.
+                      type: boolean
+                    evictionHard:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionHard is the map of signal names to quantities that define hard eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionHard are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionMaxPodGracePeriod:
+                      description: |-
+                        EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in
+                        response to soft eviction thresholds being met.
+                      format: int32
+                      type: integer
+                    evictionSoft:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionSoft is the map of signal names to quantities that define soft eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoft are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionSoftGracePeriod:
+                      additionalProperties:
+                        type: string
+                      description: EvictionSoftGracePeriod is the map of signal names to quantities that define grace periods for each eviction signal
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoftGracePeriod are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    imageGCHighThresholdPercent:
+                      description: |-
+                        ImageGCHighThresholdPercent is the percent of disk usage after which image
+                        garbage collection is always run. The percent is calculated by dividing this
+                        field value by 100, so this field must be between 0 and 100, inclusive.
+                        When specified, the value must be greater than ImageGCLowThresholdPercent.
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    imageGCLowThresholdPercent:
+                      description: |-
+                        ImageGCLowThresholdPercent is the percent of disk usage before which image
+                        garbage collection is never run. Lowest disk usage to garbage collect to.
+                        The percent is calculated by dividing this field value by 100,
+                        so the field value must be between 0 and 100, inclusive.
+                        When specified, the value must be less than imageGCHighThresholdPercent
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    kubeReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: KubeReserved contains resources reserved for Kubernetes system components.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for kubeReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: kubeReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                    maxPods:
+                      description: |-
+                        MaxPods is an override for the maximum number of pods that can run on
+                        a worker node instance.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    podsPerCore:
+                      description: |-
+                        PodsPerCore is an override for the number of pods that can run on a worker node
+                        instance based on the number of cpu cores. This value cannot exceed MaxPods, so, if
+                        MaxPods is a lower value, that value will be used.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    systemReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: SystemReserved contains resources reserved for OS system daemons and kernel memory.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for systemReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: systemReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                  type: object
+                  x-kubernetes-validations:
+                    - message: imageGCHighThresholdPercent must be greater than imageGCLowThresholdPercent
+                      rule: 'has(self.imageGCHighThresholdPercent) && has(self.imageGCLowThresholdPercent) ?  self.imageGCHighThresholdPercent > self.imageGCLowThresholdPercent  : true'
+                    - message: evictionSoft OwnerKey does not have a matching evictionSoftGracePeriod
+                      rule: has(self.evictionSoft) ? self.evictionSoft.all(e, (e in self.evictionSoftGracePeriod)):true
+                    - message: evictionSoftGracePeriod OwnerKey does not have a matching evictionSoft
+                      rule: has(self.evictionSoftGracePeriod) ? self.evictionSoftGracePeriod.all(e, (e in self.evictionSoft)):true
+                metadataOptions:
+                  default:
+                    httpEndpoint: enabled
+                    httpProtocolIPv6: disabled
+                    httpPutResponseHopLimit: 1
+                    httpTokens: required
+                  description: |-
+                    MetadataOptions for the generated launch template of provisioned nodes.
+
+                    This specifies the exposure of the Instance Metadata Service to
+                    provisioned EC2 nodes. For more information,
+                    see Instance Metadata and User Data
+                    (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
+                    in the Amazon Elastic Compute Cloud User Guide.
+
+                    Refer to recommended, security best practices
+                    (https://aws.github.io/aws-eks-best-practices/security/docs/iam/#restrict-access-to-the-instance-profile-assigned-to-the-worker-node)
+                    for limiting exposure of Instance Metadata and User Data to pods.
+                    If omitted, defaults to httpEndpoint enabled, with httpProtocolIPv6
+                    disabled, with httpPutResponseLimit of 1, and with httpTokens
+                    required.
+                  properties:
+                    httpEndpoint:
+                      default: enabled
+                      description: |-
+                        HTTPEndpoint enables or disables the HTTP metadata endpoint on provisioned
+                        nodes. If metadata options is non-nil, but this parameter is not specified,
+                        the default state is "enabled".
+
+                        If you specify a value of "disabled", instance metadata will not be accessible
+                        on the node.
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpProtocolIPv6:
+                      default: disabled
+                      description: |-
+                        HTTPProtocolIPv6 enables or disables the IPv6 endpoint for the instance metadata
+                        service on provisioned nodes. If metadata options is non-nil, but this parameter
+                        is not specified, the default state is "disabled".
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpPutResponseHopLimit:
+                      default: 1
+                      description: |-
+                        HTTPPutResponseHopLimit is the desired HTTP PUT response hop limit for
+                        instance metadata requests. The larger the number, the further instance
+                        metadata requests can travel. Possible values are integers from 1 to 64.
+                        If metadata options is non-nil, but this parameter is not specified, the
+                        default value is 1.
+                      format: int64
+                      maximum: 64
+                      minimum: 1
+                      type: integer
+                    httpTokens:
+                      default: required
+                      description: |-
+                        HTTPTokens determines the state of token usage for instance metadata
+                        requests. If metadata options is non-nil, but this parameter is not
+                        specified, the default state is "required".
+
+                        If the state is optional, one can choose to retrieve instance metadata with
+                        or without a signed token header on the request. If one retrieves the IAM
+                        role credentials without a token, the version 1.0 role credentials are
+                        returned. If one retrieves the IAM role credentials using a valid signed
+                        token, the version 2.0 role credentials are returned.
+
+                        If the state is "required", one must send a signed token header with any
+                        instance metadata retrieval requests. In this state, retrieving the IAM
+                        role credentials always returns the version 2.0 credentials; the version
+                        1.0 credentials are not available.
+                      enum:
+                        - required
+                        - optional
+                      type: string
+                  type: object
+                role:
+                  description: |-
+                    Role is the AWS identity that nodes use. This field is immutable.
+                    This field is mutually exclusive from instanceProfile.
+                    Marking this field as immutable avoids concerns around terminating managed instance profiles from running instances.
+                    This field may be made mutable in the future, assuming the correct garbage collection and drift handling is implemented
+                    for the old instance profiles on an update.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: role cannot be empty
+                      rule: self != ''
+                    - message: immutable field changed
+                      rule: self == oldSelf
+                securityGroupSelectorTerms:
+                  description: SecurityGroupSelectorTerms is a list of or security group selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SecurityGroupSelectorTerm defines selection logic for a security group used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the security group id in EC2
+                        pattern: sg-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the security group name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: securityGroupSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id', 'name']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && (has(x.tags) || has(x.name)))'
+                    - message: '''name'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.name) && (has(x.tags) || has(x.id)))'
+                subnetSelectorTerms:
+                  description: SubnetSelectorTerms is a list of or subnet selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SubnetSelectorTerm defines selection logic for a subnet used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the subnet id in EC2
+                        pattern: subnet-[0-9a-z]+
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: subnetSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id']
+                      rule: self.all(x, has(x.tags) || has(x.id))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in subnetSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && has(x.tags))'
+                tags:
+                  additionalProperties:
+                    type: string
+                  description: Tags to be applied on ec2 resources like instances and launch templates.
+                  type: object
+                  x-kubernetes-validations:
+                    - message: empty tag keys aren't supported
+                      rule: self.all(k, k != '')
+                    - message: tag contains a restricted tag matching eks:eks-cluster-name
+                      rule: self.all(k, k !='eks:eks-cluster-name')
+                    - message: tag contains a restricted tag matching kubernetes.io/cluster/
+                      rule: self.all(k, !k.startsWith('kubernetes.io/cluster') )
+                    - message: tag contains a restricted tag matching karpenter.sh/nodepool
+                      rule: self.all(k, k != 'karpenter.sh/nodepool')
+                    - message: tag contains a restricted tag matching karpenter.sh/nodeclaim
+                      rule: self.all(k, k !='karpenter.sh/nodeclaim')
+                    - message: tag contains a restricted tag matching karpenter.k8s.aws/ec2nodeclass
+                      rule: self.all(k, k !='karpenter.k8s.aws/ec2nodeclass')
+                userData:
+                  description: |-
+                    UserData to be applied to the provisioned nodes.
+                    It must be in the appropriate format based on the AMIFamily in use. Karpenter will merge certain fields into
+                    this UserData to ensure nodes are being provisioned with the correct configuration.
+                  type: string
+              required:
+                - amiSelectorTerms
+                - securityGroupSelectorTerms
+                - subnetSelectorTerms
+              type: object
+              x-kubernetes-validations:
+                - message: must specify exactly one of ['role', 'instanceProfile']
+                  rule: (has(self.role) && !has(self.instanceProfile)) || (!has(self.role) && has(self.instanceProfile))
+                - message: changing from 'instanceProfile' to 'role' is not supported. You must delete and recreate this node class if you want to change this.
+                  rule: (has(oldSelf.role) && has(self.role)) || (has(oldSelf.instanceProfile) && has(self.instanceProfile))
+                - message: if set, amiFamily must be 'AL2' or 'Custom' when using an AL2 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''al2'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''AL2'') : true)'
+                - message: if set, amiFamily must be 'AL2023' or 'Custom' when using an AL2023 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''al2023'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''AL2023'') : true)'
+                - message: if set, amiFamily must be 'Bottlerocket' or 'Custom' when using a Bottlerocket alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''bottlerocket'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Bottlerocket'') : true)'
+                - message: if set, amiFamily must be 'Windows2019' or 'Custom' when using a Windows2019 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''windows2019'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Windows2019'') : true)'
+                - message: if set, amiFamily must be 'Windows2022' or 'Custom' when using a Windows2022 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''windows2022'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Windows2022'') : true)'
+                - message: must specify amiFamily if amiSelectorTerms does not contain an alias
+                  rule: 'self.amiSelectorTerms.exists(x, has(x.alias)) ? true : has(self.amiFamily)'
+            status:
+              description: EC2NodeClassStatus contains the resolved state of the EC2NodeClass
+              properties:
+                amis:
+                  description: |-
+                    AMI contains the current AMI values that are available to the
+                    cluster under the AMI selectors.
+                  items:
+                    description: AMI contains resolved AMI selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the AMI
+                        type: string
+                      name:
+                        description: Name of the AMI
+                        type: string
+                      requirements:
+                        description: Requirements of the AMI to be utilized on an instance type
+                        items:
+                          description: |-
+                            A node selector requirement is a selector that contains values, a key, and an operator
+                            that relates the key and values.
+                          properties:
+                            key:
+                              description: The label key that the selector applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                Represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                              type: string
+                            values:
+                              description: |-
+                                An array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. If the operator is Gt or Lt, the values
+                                array must have a single element, which will be interpreted as an integer.
+                                This array is replaced during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                            - key
+                            - operator
+                          type: object
+                        type: array
+                    required:
+                      - id
+                      - requirements
+                    type: object
+                  type: array
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                instanceProfile:
+                  description: InstanceProfile contains the resolved instance profile for the role
+                  type: string
+                securityGroups:
+                  description: |-
+                    SecurityGroups contains the current Security Groups values that are available to the
+                    cluster under the SecurityGroups selectors.
+                  items:
+                    description: SecurityGroup contains resolved SecurityGroup selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the security group
+                        type: string
+                      name:
+                        description: Name of the security group
+                        type: string
+                    required:
+                      - id
+                    type: object
+                  type: array
+                subnets:
+                  description: |-
+                    Subnets contains the current Subnet values that are available to the
+                    cluster under the subnet selectors.
+                  items:
+                    description: Subnet contains resolved Subnet selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the subnet
+                        type: string
+                      zone:
+                        description: The associated availability zone
+                        type: string
+                      zoneID:
+                        description: The associated availability zone ID
+                        type: string
+                    required:
+                      - id
+                      - zone
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: EC2NodeClass is the Schema for the EC2NodeClass API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                EC2NodeClassSpec is the top level specification for the AWS Karpenter Provider.
+                This will contain configuration necessary to launch instances in AWS.
+              properties:
+                amiFamily:
+                  description: AMIFamily is the AMI family that instances use.
+                  enum:
+                    - AL2
+                    - AL2023
+                    - Bottlerocket
+                    - Ubuntu
+                    - Custom
+                    - Windows2019
+                    - Windows2022
+                  type: string
+                amiSelectorTerms:
+                  description: AMISelectorTerms is a list of or ami selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      AMISelectorTerm defines selection logic for an ami used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the ami id in EC2
+                        pattern: ami-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the ami name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      owner:
+                        description: |-
+                          Owner is the owner for the ami.
+                          You can specify a combination of AWS account IDs, "self", "amazon", and "aws-marketplace"
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: expected at least one, got none, ['tags', 'id', 'name']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && (has(x.tags) || has(x.name) || has(x.owner)))'
+                associatePublicIPAddress:
+                  description: AssociatePublicIPAddress controls if public IP addresses are assigned to instances that are launched with the nodeclass.
+                  type: boolean
+                blockDeviceMappings:
+                  description: BlockDeviceMappings to be applied to provisioned nodes.
+                  items:
+                    properties:
+                      deviceName:
+                        description: The device name (for example, /dev/sdh or xvdh).
+                        type: string
+                      ebs:
+                        description: EBS contains parameters used to automatically set up EBS volumes when an instance is launched.
+                        properties:
+                          deleteOnTermination:
+                            description: DeleteOnTermination indicates whether the EBS volume is deleted on instance termination.
+                            type: boolean
+                          encrypted:
+                            description: |-
+                              Encrypted indicates whether the EBS volume is encrypted. Encrypted volumes can only
+                              be attached to instances that support Amazon EBS encryption. If you are creating
+                              a volume from a snapshot, you can't specify an encryption value.
+                            type: boolean
+                          iops:
+                            description: |-
+                              IOPS is the number of I/O operations per second (IOPS). For gp3, io1, and io2 volumes,
+                              this represents the number of IOPS that are provisioned for the volume. For
+                              gp2 volumes, this represents the baseline performance of the volume and the
+                              rate at which the volume accumulates I/O credits for bursting.
+
+                              The following are the supported values for each volume type:
+
+                                 * gp3: 3,000-16,000 IOPS
+
+                                 * io1: 100-64,000 IOPS
+
+                                 * io2: 100-64,000 IOPS
+
+                              For io1 and io2 volumes, we guarantee 64,000 IOPS only for Instances built
+                              on the Nitro System (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances).
+                              Other instance families guarantee performance up to 32,000 IOPS.
+
+                              This parameter is supported for io1, io2, and gp3 volumes only. This parameter
+                              is not supported for gp2, st1, sc1, or standard volumes.
+                            format: int64
+                            type: integer
+                          kmsKeyID:
+                            description: KMSKeyID (ARN) of the symmetric Key Management Service (KMS) CMK used for encryption.
+                            type: string
+                          snapshotID:
+                            description: SnapshotID is the ID of an EBS snapshot
+                            type: string
+                          throughput:
+                            description: |-
+                              Throughput to provision for a gp3 volume, with a maximum of 1,000 MiB/s.
+                              Valid Range: Minimum value of 125. Maximum value of 1000.
+                            format: int64
+                            type: integer
+                          volumeSize:
+                            description: |-
+                              VolumeSize in `Gi`, `G`, `Ti`, or `T`. You must specify either a snapshot ID or
+                              a volume size. The following are the supported volumes sizes for each volume
+                              type:
+
+                                 * gp2 and gp3: 1-16,384
+
+                                 * io1 and io2: 4-16,384
+
+                                 * st1 and sc1: 125-16,384
+
+                                 * standard: 1-1,024
+                            pattern: ^((?:[1-9][0-9]{0,3}|[1-4][0-9]{4}|[5][0-8][0-9]{3}|59000)Gi|(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|[6][0-3][0-9]{3}|64000)G|([1-9]||[1-5][0-7]|58)Ti|([1-9]||[1-5][0-9]|6[0-3]|64)T)$
+                            type: string
+                          volumeType:
+                            description: |-
+                              VolumeType of the block device.
+                              For more information, see Amazon EBS volume types (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html)
+                              in the Amazon Elastic Compute Cloud User Guide.
+                            enum:
+                              - standard
+                              - io1
+                              - io2
+                              - gp2
+                              - sc1
+                              - st1
+                              - gp3
+                            type: string
+                        type: object
+                        x-kubernetes-validations:
+                          - message: snapshotID or volumeSize must be defined
+                            rule: has(self.snapshotID) || has(self.volumeSize)
+                      rootVolume:
+                        description: |-
+                          RootVolume is a flag indicating if this device is mounted as kubelet root dir. You can
+                          configure at most one root volume in BlockDeviceMappings.
+                        type: boolean
+                    type: object
+                  maxItems: 50
+                  type: array
+                  x-kubernetes-validations:
+                    - message: must have only one blockDeviceMappings with rootVolume
+                      rule: self.filter(x, has(x.rootVolume)?x.rootVolume==true:false).size() <= 1
+                context:
+                  description: |-
+                    Context is a Reserved field in EC2 APIs
+                    https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet.html
+                  type: string
+                detailedMonitoring:
+                  description: DetailedMonitoring controls if detailed monitoring is enabled for instances that are launched
+                  type: boolean
+                instanceProfile:
+                  description: |-
+                    InstanceProfile is the AWS entity that instances use.
+                    This field is mutually exclusive from role.
+                    The instance profile should already have a role assigned to it that Karpenter
+                     has PassRole permission on for instance launch using this instanceProfile to succeed.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: instanceProfile cannot be empty
+                      rule: self != ''
+                instanceStorePolicy:
+                  description: InstanceStorePolicy specifies how to handle instance-store disks.
+                  enum:
+                    - RAID0
+                  type: string
+                metadataOptions:
+                  default:
+                    httpEndpoint: enabled
+                    httpProtocolIPv6: disabled
+                    httpPutResponseHopLimit: 1
+                    httpTokens: required
+                  description: |-
+                    MetadataOptions for the generated launch template of provisioned nodes.
+
+                    This specifies the exposure of the Instance Metadata Service to
+                    provisioned EC2 nodes. For more information,
+                    see Instance Metadata and User Data
+                    (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
+                    in the Amazon Elastic Compute Cloud User Guide.
+
+                    Refer to recommended, security best practices
+                    (https://aws.github.io/aws-eks-best-practices/security/docs/iam/#restrict-access-to-the-instance-profile-assigned-to-the-worker-node)
+                    for limiting exposure of Instance Metadata and User Data to pods.
+                    If omitted, defaults to httpEndpoint enabled, with httpProtocolIPv6
+                    disabled, with httpPutResponseLimit of 1, and with httpTokens
+                    required.
+                  properties:
+                    httpEndpoint:
+                      default: enabled
+                      description: |-
+                        HTTPEndpoint enables or disables the HTTP metadata endpoint on provisioned
+                        nodes. If metadata options is non-nil, but this parameter is not specified,
+                        the default state is "enabled".
+
+                        If you specify a value of "disabled", instance metadata will not be accessible
+                        on the node.
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpProtocolIPv6:
+                      default: disabled
+                      description: |-
+                        HTTPProtocolIPv6 enables or disables the IPv6 endpoint for the instance metadata
+                        service on provisioned nodes. If metadata options is non-nil, but this parameter
+                        is not specified, the default state is "disabled".
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpPutResponseHopLimit:
+                      default: 2
+                      description: |-
+                        HTTPPutResponseHopLimit is the desired HTTP PUT response hop limit for
+                        instance metadata requests. The larger the number, the further instance
+                        metadata requests can travel. Possible values are integers from 1 to 64.
+                        If metadata options is non-nil, but this parameter is not specified, the
+                        default value is 2.
+                      format: int64
+                      maximum: 64
+                      minimum: 1
+                      type: integer
+                    httpTokens:
+                      default: required
+                      description: |-
+                        HTTPTokens determines the state of token usage for instance metadata
+                        requests. If metadata options is non-nil, but this parameter is not
+                        specified, the default state is "required".
+
+                        If the state is optional, one can choose to retrieve instance metadata with
+                        or without a signed token header on the request. If one retrieves the IAM
+                        role credentials without a token, the version 1.0 role credentials are
+                        returned. If one retrieves the IAM role credentials using a valid signed
+                        token, the version 2.0 role credentials are returned.
+
+                        If the state is "required", one must send a signed token header with any
+                        instance metadata retrieval requests. In this state, retrieving the IAM
+                        role credentials always returns the version 2.0 credentials; the version
+                        1.0 credentials are not available.
+                      enum:
+                        - required
+                        - optional
+                      type: string
+                  type: object
+                role:
+                  description: |-
+                    Role is the AWS identity that nodes use. This field is immutable.
+                    This field is mutually exclusive from instanceProfile.
+                    Marking this field as immutable avoids concerns around terminating managed instance profiles from running instances.
+                    This field may be made mutable in the future, assuming the correct garbage collection and drift handling is implemented
+                    for the old instance profiles on an update.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: role cannot be empty
+                      rule: self != ''
+                    - message: immutable field changed
+                      rule: self == oldSelf
+                securityGroupSelectorTerms:
+                  description: SecurityGroupSelectorTerms is a list of or security group selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SecurityGroupSelectorTerm defines selection logic for a security group used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the security group id in EC2
+                        pattern: sg-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the security group name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: securityGroupSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id', 'name']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && (has(x.tags) || has(x.name)))'
+                    - message: '''name'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.name) && (has(x.tags) || has(x.id)))'
+                subnetSelectorTerms:
+                  description: SubnetSelectorTerms is a list of or subnet selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SubnetSelectorTerm defines selection logic for a subnet used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the subnet id in EC2
+                        pattern: subnet-[0-9a-z]+
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: subnetSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id']
+                      rule: self.all(x, has(x.tags) || has(x.id))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in subnetSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && has(x.tags))'
+                tags:
+                  additionalProperties:
+                    type: string
+                  description: Tags to be applied on ec2 resources like instances and launch templates.
+                  type: object
+                  x-kubernetes-validations:
+                    - message: empty tag keys aren't supported
+                      rule: self.all(k, k != '')
+                    - message: tag contains a restricted tag matching kubernetes.io/cluster/
+                      rule: self.all(k, !k.startsWith('kubernetes.io/cluster') )
+                    - message: tag contains a restricted tag matching karpenter.sh/nodepool
+                      rule: self.all(k, k != 'karpenter.sh/nodepool')
+                    - message: tag contains a restricted tag matching karpenter.sh/managed-by
+                      rule: self.all(k, k !='karpenter.sh/managed-by')
+                    - message: tag contains a restricted tag matching karpenter.sh/nodeclaim
+                      rule: self.all(k, k !='karpenter.sh/nodeclaim')
+                    - message: tag contains a restricted tag matching karpenter.k8s.aws/ec2nodeclass
+                      rule: self.all(k, k !='karpenter.k8s.aws/ec2nodeclass')
+                userData:
+                  description: |-
+                    UserData to be applied to the provisioned nodes.
+                    It must be in the appropriate format based on the AMIFamily in use. Karpenter will merge certain fields into
+                    this UserData to ensure nodes are being provisioned with the correct configuration.
+                  type: string
+              required:
+                - amiFamily
+                - securityGroupSelectorTerms
+                - subnetSelectorTerms
+              type: object
+              x-kubernetes-validations:
+                - message: amiSelectorTerms is required when amiFamily == 'Custom'
+                  rule: 'self.amiFamily == ''Custom'' ? self.amiSelectorTerms.size() != 0 : true'
+                - message: must specify exactly one of ['role', 'instanceProfile']
+                  rule: (has(self.role) && !has(self.instanceProfile)) || (!has(self.role) && has(self.instanceProfile))
+                - message: changing from 'instanceProfile' to 'role' is not supported. You must delete and recreate this node class if you want to change this.
+                  rule: (has(oldSelf.role) && has(self.role)) || (has(oldSelf.instanceProfile) && has(self.instanceProfile))
+            status:
+              description: EC2NodeClassStatus contains the resolved state of the EC2NodeClass
+              properties:
+                amis:
+                  description: |-
+                    AMI contains the current AMI values that are available to the
+                    cluster under the AMI selectors.
+                  items:
+                    description: AMI contains resolved AMI selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the AMI
+                        type: string
+                      name:
+                        description: Name of the AMI
+                        type: string
+                      requirements:
+                        description: Requirements of the AMI to be utilized on an instance type
+                        items:
+                          description: |-
+                            A node selector requirement is a selector that contains values, a key, and an operator
+                            that relates the key and values.
+                          properties:
+                            key:
+                              description: The label key that the selector applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                Represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                              type: string
+                            values:
+                              description: |-
+                                An array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. If the operator is Gt or Lt, the values
+                                array must have a single element, which will be interpreted as an integer.
+                                This array is replaced during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                            - key
+                            - operator
+                          type: object
+                        type: array
+                    required:
+                      - id
+                      - requirements
+                    type: object
+                  type: array
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                instanceProfile:
+                  description: InstanceProfile contains the resolved instance profile for the role
+                  type: string
+                securityGroups:
+                  description: |-
+                    SecurityGroups contains the current Security Groups values that are available to the
+                    cluster under the SecurityGroups selectors.
+                  items:
+                    description: SecurityGroup contains resolved SecurityGroup selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the security group
+                        type: string
+                      name:
+                        description: Name of the security group
+                        type: string
+                    required:
+                      - id
+                    type: object
+                  type: array
+                subnets:
+                  description: |-
+                    Subnets contains the current Subnet values that are available to the
+                    cluster under the subnet selectors.
+                  items:
+                    description: Subnet contains resolved Subnet selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the subnet
+                        type: string
+                      zone:
+                        description: The associated availability zone
+                        type: string
+                      zoneID:
+                        description: The associated availability zone ID
+                        type: string
+                    required:
+                      - id
+                      - zone
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+        - v1
+      clientConfig:
+        service:
+          name: karpenter
+          namespace: kube-system
+          port: 8443

--- a/content/projects/karpenter/v1.0.5/karpenter.sh_nodeclaims.yaml
+++ b/content/projects/karpenter/v1.0.5/karpenter.sh_nodeclaims.yaml
@@ -1,0 +1,829 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.3
+  name: nodeclaims.karpenter.sh
+spec:
+  group: karpenter.sh
+  names:
+    categories:
+      - karpenter
+    kind: NodeClaim
+    listKind: NodeClaimList
+    plural: nodeclaims
+    singular: nodeclaim
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.labels.node\.kubernetes\.io/instance-type
+          name: Type
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/capacity-type
+          name: Capacity
+          type: string
+        - jsonPath: .metadata.labels.topology\.kubernetes\.io/zone
+          name: Zone
+          type: string
+        - jsonPath: .status.nodeName
+          name: Node
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .status.providerID
+          name: ID
+          priority: 1
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/nodepool
+          name: NodePool
+          priority: 1
+          type: string
+        - jsonPath: .spec.nodeClassRef.name
+          name: NodeClass
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: NodeClaim is the Schema for the NodeClaims API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: NodeClaimSpec describes the desired state of the NodeClaim
+              properties:
+                expireAfter:
+                  default: 720h
+                  description: |-
+                    ExpireAfter is the duration the controller will wait
+                    before terminating a node, measured from when the node is created. This
+                    is useful to implement features like eventually consistent node upgrade,
+                    memory leak protection, and disruption testing.
+                  pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                  type: string
+                nodeClassRef:
+                  description: NodeClassRef is a reference to an object that defines provider specific configuration
+                  properties:
+                    group:
+                      description: API version of the referent
+                      pattern: ^[^/]*$
+                      type: string
+                    kind:
+                      description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                      type: string
+                    name:
+                      description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                      type: string
+                  required:
+                    - group
+                    - kind
+                    - name
+                  type: object
+                requirements:
+                  description: Requirements are layered with GetLabels and applied to every node.
+                  items:
+                    description: |-
+                      A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                      and minValues that represent the requirement to have at least that many values.
+                    properties:
+                      key:
+                        description: The label key that the selector applies to.
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                        x-kubernetes-validations:
+                          - message: label domain "kubernetes.io" is restricted
+                            rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                          - message: label domain "k8s.io" is restricted
+                            rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                          - message: label domain "karpenter.sh" is restricted
+                            rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                          - message: label "kubernetes.io/hostname" is restricted
+                            rule: self != "kubernetes.io/hostname"
+                          - message: label domain "karpenter.k8s.aws" is restricted
+                            rule: self in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                      minValues:
+                        description: |-
+                          This field is ALPHA and can be dropped or replaced at any time
+                          MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                        maximum: 50
+                        minimum: 1
+                        type: integer
+                      operator:
+                        description: |-
+                          Represents a key's relationship to a set of values.
+                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                        type: string
+                        enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          - Gt
+                          - Lt
+                      values:
+                        description: |-
+                          An array of string values. If the operator is In or NotIn,
+                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                          the values array must be empty. If the operator is Gt or Lt, the values
+                          array must have a single element, which will be interpreted as an integer.
+                          This array is replaced during a strategic merge patch.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                        maxLength: 63
+                        pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                    required:
+                      - key
+                      - operator
+                    type: object
+                  maxItems: 100
+                  type: array
+                  x-kubernetes-validations:
+                    - message: requirements with operator 'In' must have a value defined
+                      rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                    - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                      rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                    - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                      rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                resources:
+                  description: Resources models the resource requirements for the NodeClaim to launch
+                  properties:
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: Requests describes the minimum required resources for the NodeClaim to launch
+                      type: object
+                  type: object
+                startupTaints:
+                  description: |-
+                    StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                    within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                    daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                    purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                taints:
+                  description: Taints will be applied to the NodeClaim's node.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                terminationGracePeriod:
+                  description: |-
+                    TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
+
+                    Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
+
+                    This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
+                    When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
+
+                    Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
+                    If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
+                    that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
+
+                    The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
+                    If left undefined, the controller will wait indefinitely for pods to be drained.
+                  pattern: ^([0-9]+(s|m|h))+$
+                  type: string
+              required:
+                - nodeClassRef
+                - requirements
+              type: object
+              x-kubernetes-validations:
+                - message: spec is immutable
+                  rule: self == oldSelf
+            status:
+              description: NodeClaimStatus defines the observed state of NodeClaim
+              properties:
+                allocatable:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Allocatable is the estimated allocatable capacity of the node
+                  type: object
+                capacity:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Capacity is the estimated full capacity of the node
+                  type: object
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        pattern: ^([A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?|)$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - status
+                      - type
+                    type: object
+                  type: array
+                imageID:
+                  description: ImageID is an identifier for the image that runs on the node
+                  type: string
+                lastPodEventTime:
+                  description: |-
+                    LastPodEventTime is updated with the last time a pod was scheduled
+                    or removed from the node. A pod going terminal or terminating
+                    is also considered as removed.
+                  format: date-time
+                  type: string
+                nodeName:
+                  description: NodeName is the name of the corresponding node object
+                  type: string
+                providerID:
+                  description: ProviderID of the corresponding node object
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.labels.node\.kubernetes\.io/instance-type
+          name: Type
+          type: string
+        - jsonPath: .metadata.labels.topology\.kubernetes\.io/zone
+          name: Zone
+          type: string
+        - jsonPath: .status.nodeName
+          name: Node
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .metadata.labels.karpenter\.sh/capacity-type
+          name: Capacity
+          priority: 1
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/nodepool
+          name: NodePool
+          priority: 1
+          type: string
+        - jsonPath: .spec.nodeClassRef.name
+          name: NodeClass
+          priority: 1
+          type: string
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: NodeClaim is the Schema for the NodeClaims API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: NodeClaimSpec describes the desired state of the NodeClaim
+              properties:
+                kubelet:
+                  description: |-
+                    Kubelet defines args to be used when configuring kubelet on provisioned nodes.
+                    They are a subset of the upstream types, recognizing not all options may be supported.
+                    Wherever possible, the types and names should reflect the upstream kubelet types.
+                  properties:
+                    clusterDNS:
+                      description: |-
+                        clusterDNS is a list of IP addresses for the cluster DNS server.
+                        Note that not all providers may use all addresses.
+                      items:
+                        type: string
+                      type: array
+                    cpuCFSQuota:
+                      description: CPUCFSQuota enables CPU CFS quota enforcement for containers that specify CPU limits.
+                      type: boolean
+                    evictionHard:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionHard is the map of signal names to quantities that define hard eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionHard are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionMaxPodGracePeriod:
+                      description: |-
+                        EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in
+                        response to soft eviction thresholds being met.
+                      format: int32
+                      type: integer
+                    evictionSoft:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionSoft is the map of signal names to quantities that define soft eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoft are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionSoftGracePeriod:
+                      additionalProperties:
+                        type: string
+                      description: EvictionSoftGracePeriod is the map of signal names to quantities that define grace periods for each eviction signal
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoftGracePeriod are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    imageGCHighThresholdPercent:
+                      description: |-
+                        ImageGCHighThresholdPercent is the percent of disk usage after which image
+                        garbage collection is always run. The percent is calculated by dividing this
+                        field value by 100, so this field must be between 0 and 100, inclusive.
+                        When specified, the value must be greater than ImageGCLowThresholdPercent.
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    imageGCLowThresholdPercent:
+                      description: |-
+                        ImageGCLowThresholdPercent is the percent of disk usage before which image
+                        garbage collection is never run. Lowest disk usage to garbage collect to.
+                        The percent is calculated by dividing this field value by 100,
+                        so the field value must be between 0 and 100, inclusive.
+                        When specified, the value must be less than imageGCHighThresholdPercent
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    kubeReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: KubeReserved contains resources reserved for Kubernetes system components.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for kubeReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: kubeReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                    maxPods:
+                      description: |-
+                        MaxPods is an override for the maximum number of pods that can run on
+                        a worker node instance.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    podsPerCore:
+                      description: |-
+                        PodsPerCore is an override for the number of pods that can run on a worker node
+                        instance based on the number of cpu cores. This value cannot exceed MaxPods, so, if
+                        MaxPods is a lower value, that value will be used.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    systemReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: SystemReserved contains resources reserved for OS system daemons and kernel memory.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for systemReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: systemReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                  type: object
+                  x-kubernetes-validations:
+                    - message: imageGCHighThresholdPercent must be greater than imageGCLowThresholdPercent
+                      rule: 'has(self.imageGCHighThresholdPercent) && has(self.imageGCLowThresholdPercent) ?  self.imageGCHighThresholdPercent > self.imageGCLowThresholdPercent  : true'
+                    - message: evictionSoft OwnerKey does not have a matching evictionSoftGracePeriod
+                      rule: has(self.evictionSoft) ? self.evictionSoft.all(e, (e in self.evictionSoftGracePeriod)):true
+                    - message: evictionSoftGracePeriod OwnerKey does not have a matching evictionSoft
+                      rule: has(self.evictionSoftGracePeriod) ? self.evictionSoftGracePeriod.all(e, (e in self.evictionSoft)):true
+                nodeClassRef:
+                  description: NodeClassRef is a reference to an object that defines provider specific configuration
+                  properties:
+                    apiVersion:
+                      description: API version of the referent
+                      type: string
+                    kind:
+                      description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                      type: string
+                    name:
+                      description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                      type: string
+                  required:
+                    - name
+                  type: object
+                requirements:
+                  description: Requirements are layered with GetLabels and applied to every node.
+                  items:
+                    description: |-
+                      A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                      and minValues that represent the requirement to have at least that many values.
+                    properties:
+                      key:
+                        description: The label key that the selector applies to.
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                        x-kubernetes-validations:
+                          - message: label domain "kubernetes.io" is restricted
+                            rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                          - message: label domain "k8s.io" is restricted
+                            rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                          - message: label domain "karpenter.sh" is restricted
+                            rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                          - message: label "kubernetes.io/hostname" is restricted
+                            rule: self != "kubernetes.io/hostname"
+                          - message: label domain "karpenter.k8s.aws" is restricted
+                            rule: self in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                      minValues:
+                        description: |-
+                          This field is ALPHA and can be dropped or replaced at any time
+                          MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                        maximum: 50
+                        minimum: 1
+                        type: integer
+                      operator:
+                        description: |-
+                          Represents a key's relationship to a set of values.
+                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                        type: string
+                        enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          - Gt
+                          - Lt
+                      values:
+                        description: |-
+                          An array of string values. If the operator is In or NotIn,
+                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                          the values array must be empty. If the operator is Gt or Lt, the values
+                          array must have a single element, which will be interpreted as an integer.
+                          This array is replaced during a strategic merge patch.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                        maxLength: 63
+                        pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                    required:
+                      - key
+                      - operator
+                    type: object
+                  maxItems: 100
+                  type: array
+                  x-kubernetes-validations:
+                    - message: requirements with operator 'In' must have a value defined
+                      rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                    - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                      rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                    - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                      rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                resources:
+                  description: Resources models the resource requirements for the NodeClaim to launch
+                  properties:
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: Requests describes the minimum required resources for the NodeClaim to launch
+                      type: object
+                  type: object
+                startupTaints:
+                  description: |-
+                    StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                    within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                    daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                    purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                taints:
+                  description: Taints will be applied to the NodeClaim's node.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+              required:
+                - nodeClassRef
+                - requirements
+              type: object
+            status:
+              description: NodeClaimStatus defines the observed state of NodeClaim
+              properties:
+                allocatable:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Allocatable is the estimated allocatable capacity of the node
+                  type: object
+                capacity:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Capacity is the estimated full capacity of the node
+                  type: object
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        pattern: ^([A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?|)$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - status
+                      - type
+                    type: object
+                  type: array
+                imageID:
+                  description: ImageID is an identifier for the image that runs on the node
+                  type: string
+                nodeName:
+                  description: NodeName is the name of the corresponding node object
+                  type: string
+                providerID:
+                  description: ProviderID of the corresponding node object
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+        - v1
+      clientConfig:
+        service:
+          name: karpenter
+          namespace: kube-system
+          port: 8443

--- a/content/projects/karpenter/v1.0.5/karpenter.sh_nodepools.yaml
+++ b/content/projects/karpenter/v1.0.5/karpenter.sh_nodepools.yaml
@@ -1,0 +1,1082 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.3
+  name: nodepools.karpenter.sh
+spec:
+  group: karpenter.sh
+  names:
+    categories:
+      - karpenter
+    kind: NodePool
+    listKind: NodePoolList
+    plural: nodepools
+    singular: nodepool
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.template.spec.nodeClassRef.name
+          name: NodeClass
+          type: string
+        - jsonPath: .status.resources.nodes
+          name: Nodes
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.weight
+          name: Weight
+          priority: 1
+          type: integer
+        - jsonPath: .status.resources.cpu
+          name: CPU
+          priority: 1
+          type: string
+        - jsonPath: .status.resources.memory
+          name: Memory
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: NodePool is the Schema for the NodePools API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                NodePoolSpec is the top level nodepool specification. Nodepools
+                launch nodes in response to pods that are unschedulable. A single nodepool
+                is capable of managing a diverse set of nodes. Node properties are determined
+                from a combination of nodepool and pod scheduling constraints.
+              properties:
+                disruption:
+                  default:
+                    consolidateAfter: 0s
+                  description: Disruption contains the parameters that relate to Karpenter's disruption logic
+                  properties:
+                    budgets:
+                      default:
+                        - nodes: 10%
+                      description: |-
+                        Budgets is a list of Budgets.
+                        If there are multiple active budgets, Karpenter uses
+                        the most restrictive value. If left undefined,
+                        this will default to one budget with a value to 10%.
+                      items:
+                        description: |-
+                          Budget defines when Karpenter will restrict the
+                          number of Node Claims that can be terminating simultaneously.
+                        properties:
+                          duration:
+                            description: |-
+                              Duration determines how long a Budget is active since each Schedule hit.
+                              Only minutes and hours are accepted, as cron does not work in seconds.
+                              If omitted, the budget is always active.
+                              This is required if Schedule is set.
+                              This regex has an optional 0s at the end since the duration.String() always adds
+                              a 0s at the end.
+                            pattern: ^((([0-9]+(h|m))|([0-9]+h[0-9]+m))(0s)?)$
+                            type: string
+                          nodes:
+                            default: 10%
+                            description: |-
+                              Nodes dictates the maximum number of NodeClaims owned by this NodePool
+                              that can be terminating at once. This is calculated by counting nodes that
+                              have a deletion timestamp set, or are actively being deleted by Karpenter.
+                              This field is required when specifying a budget.
+                              This cannot be of type intstr.IntOrString since kubebuilder doesn't support pattern
+                              checking for int nodes for IntOrString nodes.
+                              Ref: https://github.com/kubernetes-sigs/controller-tools/blob/55efe4be40394a288216dab63156b0a64fb82929/pkg/crd/markers/validation.go#L379-L388
+                            pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
+                            type: string
+                          reasons:
+                            description: |-
+                              Reasons is a list of disruption methods that this budget applies to. If Reasons is not set, this budget applies to all methods.
+                              Otherwise, this will apply to each reason defined.
+                              allowed reasons are Underutilized, Empty, and Drifted.
+                            items:
+                              description: DisruptionReason defines valid reasons for disruption budgets.
+                              enum:
+                                - Underutilized
+                                - Empty
+                                - Drifted
+                              type: string
+                            type: array
+                          schedule:
+                            description: |-
+                              Schedule specifies when a budget begins being active, following
+                              the upstream cronjob syntax. If omitted, the budget is always active.
+                              Timezones are not supported.
+                              This field is required if Duration is set.
+                            pattern: ^(@(annually|yearly|monthly|weekly|daily|midnight|hourly))|((.+)\s(.+)\s(.+)\s(.+)\s(.+))$
+                            type: string
+                        required:
+                          - nodes
+                        type: object
+                      maxItems: 50
+                      type: array
+                      x-kubernetes-validations:
+                        - message: '''schedule'' must be set with ''duration'''
+                          rule: self.all(x, has(x.schedule) == has(x.duration))
+                    consolidateAfter:
+                      description: |-
+                        ConsolidateAfter is the duration the controller will wait
+                        before attempting to terminate nodes that are underutilized.
+                        Refer to ConsolidationPolicy for how underutilization is considered.
+                      pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                      type: string
+                    consolidationPolicy:
+                      default: WhenEmptyOrUnderutilized
+                      description: |-
+                        ConsolidationPolicy describes which nodes Karpenter can disrupt through its consolidation
+                        algorithm. This policy defaults to "WhenEmptyOrUnderutilized" if not specified
+                      enum:
+                        - WhenEmpty
+                        - WhenEmptyOrUnderutilized
+                      type: string
+                  required:
+                    - consolidateAfter
+                  type: object
+                limits:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Limits define a set of bounds for provisioning capacity.
+                  type: object
+                template:
+                  description: |-
+                    Template contains the template of possibilities for the provisioning logic to launch a NodeClaim with.
+                    NodeClaims launched from this NodePool will often be further constrained than the template specifies.
+                  properties:
+                    metadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Annotations is an unstructured key value map stored with a resource that may be
+                            set by external tools to store and retrieve arbitrary metadata. They are not
+                            queryable and should be preserved when modifying objects.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                            maxLength: 63
+                            pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                          description: |-
+                            Map of string keys and values that can be used to organize and categorize
+                            (scope and select) objects. May match selectors of replication controllers
+                            and services.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
+                          type: object
+                          maxProperties: 100
+                          x-kubernetes-validations:
+                            - message: label domain "kubernetes.io" is restricted
+                              rule: self.all(x, x in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region",  "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || x.find("^([^/]+)").endsWith("node.kubernetes.io") || x.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !x.find("^([^/]+)").endsWith("kubernetes.io"))
+                            - message: label domain "k8s.io" is restricted
+                              rule: self.all(x, x.find("^([^/]+)").endsWith("kops.k8s.io") || !x.find("^([^/]+)").endsWith("k8s.io"))
+                            - message: label domain "karpenter.sh" is restricted
+                              rule: self.all(x, x in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !x.find("^([^/]+)").endsWith("karpenter.sh"))
+                            - message: label "karpenter.sh/nodepool" is restricted
+                              rule: self.all(x, x != "karpenter.sh/nodepool")
+                            - message: label "kubernetes.io/hostname" is restricted
+                              rule: self.all(x, x != "kubernetes.io/hostname")
+                            - message: label domain "karpenter.k8s.aws" is restricted
+                              rule: self.all(x, x in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !x.find("^([^/]+)").endsWith("karpenter.k8s.aws"))
+                      type: object
+                    spec:
+                      description: |-
+                        NodeClaimTemplateSpec describes the desired state of the NodeClaim in the Nodepool
+                        NodeClaimTemplateSpec is used in the NodePool's NodeClaimTemplate, with the resource requests omitted since
+                        users are not able to set resource requests in the NodePool.
+                      properties:
+                        expireAfter:
+                          default: 720h
+                          description: |-
+                            ExpireAfter is the duration the controller will wait
+                            before terminating a node, measured from when the node is created. This
+                            is useful to implement features like eventually consistent node upgrade,
+                            memory leak protection, and disruption testing.
+                          pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                          type: string
+                        nodeClassRef:
+                          description: NodeClassRef is a reference to an object that defines provider specific configuration
+                          properties:
+                            group:
+                              description: API version of the referent
+                              pattern: ^[^/]*$
+                              type: string
+                            kind:
+                              description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                              type: string
+                            name:
+                              description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                          required:
+                            - group
+                            - kind
+                            - name
+                          type: object
+                        requirements:
+                          description: Requirements are layered with GetLabels and applied to every node.
+                          items:
+                            description: |-
+                              A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                              and minValues that represent the requirement to have at least that many values.
+                            properties:
+                              key:
+                                description: The label key that the selector applies to.
+                                type: string
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                                x-kubernetes-validations:
+                                  - message: label domain "kubernetes.io" is restricted
+                                    rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                                  - message: label domain "k8s.io" is restricted
+                                    rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                                  - message: label domain "karpenter.sh" is restricted
+                                    rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                                  - message: label "karpenter.sh/nodepool" is restricted
+                                    rule: self != "karpenter.sh/nodepool"
+                                  - message: label "kubernetes.io/hostname" is restricted
+                                    rule: self != "kubernetes.io/hostname"
+                                  - message: label domain "karpenter.k8s.aws" is restricted
+                                    rule: self in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                              minValues:
+                                description: |-
+                                  This field is ALPHA and can be dropped or replaced at any time
+                                  MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                                maximum: 50
+                                minimum: 1
+                                type: integer
+                              operator:
+                                description: |-
+                                  Represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                type: string
+                                enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  - Gt
+                                  - Lt
+                              values:
+                                description: |-
+                                  An array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                  array must have a single element, which will be interpreted as an integer.
+                                  This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          maxItems: 100
+                          type: array
+                          x-kubernetes-validations:
+                            - message: requirements with operator 'In' must have a value defined
+                              rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                            - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                              rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                            - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                              rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                        startupTaints:
+                          description: |-
+                            StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                            within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                            daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                            purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        taints:
+                          description: Taints will be applied to the NodeClaim's node.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        terminationGracePeriod:
+                          description: |-
+                            TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
+
+                            Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
+
+                            This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
+                            When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
+
+                            Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
+                            If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
+                            that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
+
+                            The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
+                            If left undefined, the controller will wait indefinitely for pods to be drained.
+                          pattern: ^([0-9]+(s|m|h))+$
+                          type: string
+                      required:
+                        - nodeClassRef
+                        - requirements
+                      type: object
+                  required:
+                    - spec
+                  type: object
+                weight:
+                  description: |-
+                    Weight is the priority given to the nodepool during scheduling. A higher
+                    numerical weight indicates that this nodepool will be ordered
+                    ahead of other nodepools with lower weights. A nodepool with no weight
+                    will be treated as if it is a nodepool with a weight of 0.
+                  format: int32
+                  maximum: 100
+                  minimum: 1
+                  type: integer
+              required:
+                - template
+              type: object
+            status:
+              description: NodePoolStatus defines the observed state of NodePool
+              properties:
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                resources:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Resources is the list of resources that have been provisioned.
+                  type: object
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .spec.template.spec.nodeClassRef.name
+          name: NodeClass
+          type: string
+        - jsonPath: .spec.weight
+          name: Weight
+          priority: 1
+          type: string
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: NodePool is the Schema for the NodePools API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                NodePoolSpec is the top level nodepool specification. Nodepools
+                launch nodes in response to pods that are unschedulable. A single nodepool
+                is capable of managing a diverse set of nodes. Node properties are determined
+                from a combination of nodepool and pod scheduling constraints.
+              properties:
+                disruption:
+                  default:
+                    consolidationPolicy: WhenUnderutilized
+                    expireAfter: 720h
+                  description: Disruption contains the parameters that relate to Karpenter's disruption logic
+                  properties:
+                    budgets:
+                      default:
+                        - nodes: 10%
+                      description: |-
+                        Budgets is a list of Budgets.
+                        If there are multiple active budgets, Karpenter uses
+                        the most restrictive value. If left undefined,
+                        this will default to one budget with a value to 10%.
+                      items:
+                        description: |-
+                          Budget defines when Karpenter will restrict the
+                          number of Node Claims that can be terminating simultaneously.
+                        properties:
+                          duration:
+                            description: |-
+                              Duration determines how long a Budget is active since each Schedule hit.
+                              Only minutes and hours are accepted, as cron does not work in seconds.
+                              If omitted, the budget is always active.
+                              This is required if Schedule is set.
+                              This regex has an optional 0s at the end since the duration.String() always adds
+                              a 0s at the end.
+                            pattern: ^((([0-9]+(h|m))|([0-9]+h[0-9]+m))(0s)?)$
+                            type: string
+                          nodes:
+                            default: 10%
+                            description: |-
+                              Nodes dictates the maximum number of NodeClaims owned by this NodePool
+                              that can be terminating at once. This is calculated by counting nodes that
+                              have a deletion timestamp set, or are actively being deleted by Karpenter.
+                              This field is required when specifying a budget.
+                              This cannot be of type intstr.IntOrString since kubebuilder doesn't support pattern
+                              checking for int nodes for IntOrString nodes.
+                              Ref: https://github.com/kubernetes-sigs/controller-tools/blob/55efe4be40394a288216dab63156b0a64fb82929/pkg/crd/markers/validation.go#L379-L388
+                            pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
+                            type: string
+                          schedule:
+                            description: |-
+                              Schedule specifies when a budget begins being active, following
+                              the upstream cronjob syntax. If omitted, the budget is always active.
+                              Timezones are not supported.
+                              This field is required if Duration is set.
+                            pattern: ^(@(annually|yearly|monthly|weekly|daily|midnight|hourly))|((.+)\s(.+)\s(.+)\s(.+)\s(.+))$
+                            type: string
+                        required:
+                          - nodes
+                        type: object
+                      maxItems: 50
+                      type: array
+                      x-kubernetes-validations:
+                        - message: '''schedule'' must be set with ''duration'''
+                          rule: self.all(x, has(x.schedule) == has(x.duration))
+                    consolidateAfter:
+                      description: |-
+                        ConsolidateAfter is the duration the controller will wait
+                        before attempting to terminate nodes that are underutilized.
+                        Refer to ConsolidationPolicy for how underutilization is considered.
+                      pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                      type: string
+                    consolidationPolicy:
+                      default: WhenUnderutilized
+                      description: |-
+                        ConsolidationPolicy describes which nodes Karpenter can disrupt through its consolidation
+                        algorithm. This policy defaults to "WhenUnderutilized" if not specified
+                      enum:
+                        - WhenEmpty
+                        - WhenUnderutilized
+                      type: string
+                    expireAfter:
+                      default: 720h
+                      description: |-
+                        ExpireAfter is the duration the controller will wait
+                        before terminating a node, measured from when the node is created. This
+                        is useful to implement features like eventually consistent node upgrade,
+                        memory leak protection, and disruption testing.
+                      pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                      type: string
+                  type: object
+                  x-kubernetes-validations:
+                    - message: consolidateAfter cannot be combined with consolidationPolicy=WhenUnderutilized
+                      rule: 'has(self.consolidateAfter) ? self.consolidationPolicy != ''WhenUnderutilized'' || self.consolidateAfter == ''Never'' : true'
+                    - message: consolidateAfter must be specified with consolidationPolicy=WhenEmpty
+                      rule: 'self.consolidationPolicy == ''WhenEmpty'' ? has(self.consolidateAfter) : true'
+                limits:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Limits define a set of bounds for provisioning capacity.
+                  type: object
+                template:
+                  description: |-
+                    Template contains the template of possibilities for the provisioning logic to launch a NodeClaim with.
+                    NodeClaims launched from this NodePool will often be further constrained than the template specifies.
+                  properties:
+                    metadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Annotations is an unstructured key value map stored with a resource that may be
+                            set by external tools to store and retrieve arbitrary metadata. They are not
+                            queryable and should be preserved when modifying objects.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                            maxLength: 63
+                            pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                          description: |-
+                            Map of string keys and values that can be used to organize and categorize
+                            (scope and select) objects. May match selectors of replication controllers
+                            and services.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
+                          type: object
+                          maxProperties: 100
+                          x-kubernetes-validations:
+                            - message: label domain "kubernetes.io" is restricted
+                              rule: self.all(x, x in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region",  "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || x.find("^([^/]+)").endsWith("node.kubernetes.io") || x.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !x.find("^([^/]+)").endsWith("kubernetes.io"))
+                            - message: label domain "k8s.io" is restricted
+                              rule: self.all(x, x.find("^([^/]+)").endsWith("kops.k8s.io") || !x.find("^([^/]+)").endsWith("k8s.io"))
+                            - message: label domain "karpenter.sh" is restricted
+                              rule: self.all(x, x in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !x.find("^([^/]+)").endsWith("karpenter.sh"))
+                            - message: label "karpenter.sh/nodepool" is restricted
+                              rule: self.all(x, x != "karpenter.sh/nodepool")
+                            - message: label "kubernetes.io/hostname" is restricted
+                              rule: self.all(x, x != "kubernetes.io/hostname")
+                            - message: label domain "karpenter.k8s.aws" is restricted
+                              rule: self.all(x, x in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !x.find("^([^/]+)").endsWith("karpenter.k8s.aws"))
+                      type: object
+                    spec:
+                      description: NodeClaimSpec describes the desired state of the NodeClaim
+                      properties:
+                        kubelet:
+                          description: |-
+                            Kubelet defines args to be used when configuring kubelet on provisioned nodes.
+                            They are a subset of the upstream types, recognizing not all options may be supported.
+                            Wherever possible, the types and names should reflect the upstream kubelet types.
+                          properties:
+                            clusterDNS:
+                              description: |-
+                                clusterDNS is a list of IP addresses for the cluster DNS server.
+                                Note that not all providers may use all addresses.
+                              items:
+                                type: string
+                              type: array
+                            cpuCFSQuota:
+                              description: CPUCFSQuota enables CPU CFS quota enforcement for containers that specify CPU limits.
+                              type: boolean
+                            evictionHard:
+                              additionalProperties:
+                                type: string
+                                pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                              description: EvictionHard is the map of signal names to quantities that define hard eviction thresholds
+                              type: object
+                              x-kubernetes-validations:
+                                - message: valid keys for evictionHard are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                                  rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                            evictionMaxPodGracePeriod:
+                              description: |-
+                                EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in
+                                response to soft eviction thresholds being met.
+                              format: int32
+                              type: integer
+                            evictionSoft:
+                              additionalProperties:
+                                type: string
+                                pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                              description: EvictionSoft is the map of signal names to quantities that define soft eviction thresholds
+                              type: object
+                              x-kubernetes-validations:
+                                - message: valid keys for evictionSoft are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                                  rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                            evictionSoftGracePeriod:
+                              additionalProperties:
+                                type: string
+                              description: EvictionSoftGracePeriod is the map of signal names to quantities that define grace periods for each eviction signal
+                              type: object
+                              x-kubernetes-validations:
+                                - message: valid keys for evictionSoftGracePeriod are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                                  rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                            imageGCHighThresholdPercent:
+                              description: |-
+                                ImageGCHighThresholdPercent is the percent of disk usage after which image
+                                garbage collection is always run. The percent is calculated by dividing this
+                                field value by 100, so this field must be between 0 and 100, inclusive.
+                                When specified, the value must be greater than ImageGCLowThresholdPercent.
+                              format: int32
+                              maximum: 100
+                              minimum: 0
+                              type: integer
+                            imageGCLowThresholdPercent:
+                              description: |-
+                                ImageGCLowThresholdPercent is the percent of disk usage before which image
+                                garbage collection is never run. Lowest disk usage to garbage collect to.
+                                The percent is calculated by dividing this field value by 100,
+                                so the field value must be between 0 and 100, inclusive.
+                                When specified, the value must be less than imageGCHighThresholdPercent
+                              format: int32
+                              maximum: 100
+                              minimum: 0
+                              type: integer
+                            kubeReserved:
+                              additionalProperties:
+                                type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              description: KubeReserved contains resources reserved for Kubernetes system components.
+                              type: object
+                              x-kubernetes-validations:
+                                - message: valid keys for kubeReserved are ['cpu','memory','ephemeral-storage','pid']
+                                  rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                                - message: kubeReserved value cannot be a negative resource quantity
+                                  rule: self.all(x, !self[x].startsWith('-'))
+                            maxPods:
+                              description: |-
+                                MaxPods is an override for the maximum number of pods that can run on
+                                a worker node instance.
+                              format: int32
+                              minimum: 0
+                              type: integer
+                            podsPerCore:
+                              description: |-
+                                PodsPerCore is an override for the number of pods that can run on a worker node
+                                instance based on the number of cpu cores. This value cannot exceed MaxPods, so, if
+                                MaxPods is a lower value, that value will be used.
+                              format: int32
+                              minimum: 0
+                              type: integer
+                            systemReserved:
+                              additionalProperties:
+                                type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              description: SystemReserved contains resources reserved for OS system daemons and kernel memory.
+                              type: object
+                              x-kubernetes-validations:
+                                - message: valid keys for systemReserved are ['cpu','memory','ephemeral-storage','pid']
+                                  rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                                - message: systemReserved value cannot be a negative resource quantity
+                                  rule: self.all(x, !self[x].startsWith('-'))
+                          type: object
+                          x-kubernetes-validations:
+                            - message: imageGCHighThresholdPercent must be greater than imageGCLowThresholdPercent
+                              rule: 'has(self.imageGCHighThresholdPercent) && has(self.imageGCLowThresholdPercent) ?  self.imageGCHighThresholdPercent > self.imageGCLowThresholdPercent  : true'
+                            - message: evictionSoft OwnerKey does not have a matching evictionSoftGracePeriod
+                              rule: has(self.evictionSoft) ? self.evictionSoft.all(e, (e in self.evictionSoftGracePeriod)):true
+                            - message: evictionSoftGracePeriod OwnerKey does not have a matching evictionSoft
+                              rule: has(self.evictionSoftGracePeriod) ? self.evictionSoftGracePeriod.all(e, (e in self.evictionSoft)):true
+                        nodeClassRef:
+                          description: NodeClassRef is a reference to an object that defines provider specific configuration
+                          properties:
+                            apiVersion:
+                              description: API version of the referent
+                              type: string
+                            kind:
+                              description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                              type: string
+                            name:
+                              description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        requirements:
+                          description: Requirements are layered with GetLabels and applied to every node.
+                          items:
+                            description: |-
+                              A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                              and minValues that represent the requirement to have at least that many values.
+                            properties:
+                              key:
+                                description: The label key that the selector applies to.
+                                type: string
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                                x-kubernetes-validations:
+                                  - message: label domain "kubernetes.io" is restricted
+                                    rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                                  - message: label domain "k8s.io" is restricted
+                                    rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                                  - message: label domain "karpenter.sh" is restricted
+                                    rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                                  - message: label "karpenter.sh/nodepool" is restricted
+                                    rule: self != "karpenter.sh/nodepool"
+                                  - message: label "kubernetes.io/hostname" is restricted
+                                    rule: self != "kubernetes.io/hostname"
+                                  - message: label domain "karpenter.k8s.aws" is restricted
+                                    rule: self in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                              minValues:
+                                description: |-
+                                  This field is ALPHA and can be dropped or replaced at any time
+                                  MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                                maximum: 50
+                                minimum: 1
+                                type: integer
+                              operator:
+                                description: |-
+                                  Represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                type: string
+                                enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  - Gt
+                                  - Lt
+                              values:
+                                description: |-
+                                  An array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                  array must have a single element, which will be interpreted as an integer.
+                                  This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          maxItems: 100
+                          type: array
+                          x-kubernetes-validations:
+                            - message: requirements with operator 'In' must have a value defined
+                              rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                            - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                              rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                            - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                              rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                        resources:
+                          description: Resources models the resource requirements for the NodeClaim to launch
+                          properties:
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: Requests describes the minimum required resources for the NodeClaim to launch
+                              type: object
+                          type: object
+                          maxProperties: 0
+                        startupTaints:
+                          description: |-
+                            StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                            within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                            daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                            purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        taints:
+                          description: Taints will be applied to the NodeClaim's node.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                      required:
+                        - nodeClassRef
+                        - requirements
+                      type: object
+                  required:
+                    - spec
+                  type: object
+                weight:
+                  description: |-
+                    Weight is the priority given to the nodepool during scheduling. A higher
+                    numerical weight indicates that this nodepool will be ordered
+                    ahead of other nodepools with lower weights. A nodepool with no weight
+                    will be treated as if it is a nodepool with a weight of 0.
+                  format: int32
+                  maximum: 100
+                  minimum: 1
+                  type: integer
+              required:
+                - template
+              type: object
+            status:
+              description: NodePoolStatus defines the observed state of NodePool
+              properties:
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                resources:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Resources is the list of resources that have been provisioned.
+                  type: object
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+        - v1
+      clientConfig:
+        service:
+          name: karpenter
+          namespace: kube-system
+          port: 8443

--- a/content/projects/karpenter/v1.0.6/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/content/projects/karpenter/v1.0.6/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -1,0 +1,1306 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.3
+  name: ec2nodeclasses.karpenter.k8s.aws
+spec:
+  group: karpenter.k8s.aws
+  names:
+    categories:
+      - karpenter
+    kind: EC2NodeClass
+    listKind: EC2NodeClassList
+    plural: ec2nodeclasses
+    shortNames:
+      - ec2nc
+      - ec2ncs
+    singular: ec2nodeclass
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.role
+          name: Role
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: EC2NodeClass is the Schema for the EC2NodeClass API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                EC2NodeClassSpec is the top level specification for the AWS Karpenter Provider.
+                This will contain configuration necessary to launch instances in AWS.
+              properties:
+                amiFamily:
+                  description: |-
+                    AMIFamily dictates the UserData format and default BlockDeviceMappings used when generating launch templates.
+                    This field is optional when using an alias amiSelectorTerm, and the value will be inferred from the alias'
+                    family. When an alias is specified, this field may only be set to its corresponding family or 'Custom'. If no
+                    alias is specified, this field is required.
+                    NOTE: We ignore the AMIFamily for hashing here because we hash the AMIFamily dynamically by using the alias using
+                    the AMIFamily() helper function
+                  enum:
+                    - AL2
+                    - AL2023
+                    - Bottlerocket
+                    - Custom
+                    - Windows2019
+                    - Windows2022
+                  type: string
+                amiSelectorTerms:
+                  description: AMISelectorTerms is a list of or ami selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      AMISelectorTerm defines selection logic for an ami used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      alias:
+                        description: |-
+                          Alias specifies which EKS optimized AMI to select.
+                          Each alias consists of a family and an AMI version, specified as "family@version".
+                          Valid families include: al2, al2023, bottlerocket, windows2019, and windows2022.
+                          The version can either be pinned to a specific AMI release, with that AMIs version format (ex: "al2023@v20240625" or "bottlerocket@v1.10.0").
+                          The version can also be set to "latest" for any family. Setting the version to latest will result in drift when a new AMI is released. This is **not** recommended for production environments.
+                          Note: The Windows families do **not** support version pinning, and only latest may be used.
+                        maxLength: 30
+                        type: string
+                        x-kubernetes-validations:
+                          - message: '''alias'' is improperly formatted, must match the format ''family@version'''
+                            rule: self.matches('^[a-zA-Z0-9]+@.+$')
+                          - message: 'family is not supported, must be one of the following: ''al2'', ''al2023'', ''bottlerocket'', ''windows2019'', ''windows2022'''
+                            rule: self.split('@')[0] in ['al2','al2023','bottlerocket','windows2019','windows2022']
+                          - message: windows families may only specify version 'latest'
+                            rule: 'self.split(''@'')[0] in [''windows2019'',''windows2022''] ? self.split(''@'')[1] == ''latest'' : true'
+                      id:
+                        description: ID is the ami id in EC2
+                        pattern: ami-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the ami name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      owner:
+                        description: |-
+                          Owner is the owner for the ami.
+                          You can specify a combination of AWS account IDs, "self", "amazon", and "aws-marketplace"
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  minItems: 1
+                  type: array
+                  x-kubernetes-validations:
+                    - message: expected at least one, got none, ['tags', 'id', 'name', 'alias']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name) || has(x.alias))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.exists(x, has(x.id) && (has(x.alias) || has(x.tags) || has(x.name) || has(x.owner)))'
+                    - message: '''alias'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.exists(x, has(x.alias) && (has(x.id) || has(x.tags) || has(x.name) || has(x.owner)))'
+                    - message: '''alias'' is mutually exclusive, cannot be set with a combination of other amiSelectorTerms'
+                      rule: '!(self.exists(x, has(x.alias)) && self.size() != 1)'
+                associatePublicIPAddress:
+                  description: AssociatePublicIPAddress controls if public IP addresses are assigned to instances that are launched with the nodeclass.
+                  type: boolean
+                blockDeviceMappings:
+                  description: BlockDeviceMappings to be applied to provisioned nodes.
+                  items:
+                    properties:
+                      deviceName:
+                        description: The device name (for example, /dev/sdh or xvdh).
+                        type: string
+                      ebs:
+                        description: EBS contains parameters used to automatically set up EBS volumes when an instance is launched.
+                        properties:
+                          deleteOnTermination:
+                            description: DeleteOnTermination indicates whether the EBS volume is deleted on instance termination.
+                            type: boolean
+                          encrypted:
+                            description: |-
+                              Encrypted indicates whether the EBS volume is encrypted. Encrypted volumes can only
+                              be attached to instances that support Amazon EBS encryption. If you are creating
+                              a volume from a snapshot, you can't specify an encryption value.
+                            type: boolean
+                          iops:
+                            description: |-
+                              IOPS is the number of I/O operations per second (IOPS). For gp3, io1, and io2 volumes,
+                              this represents the number of IOPS that are provisioned for the volume. For
+                              gp2 volumes, this represents the baseline performance of the volume and the
+                              rate at which the volume accumulates I/O credits for bursting.
+
+                              The following are the supported values for each volume type:
+
+                                 * gp3: 3,000-16,000 IOPS
+
+                                 * io1: 100-64,000 IOPS
+
+                                 * io2: 100-64,000 IOPS
+
+                              For io1 and io2 volumes, we guarantee 64,000 IOPS only for Instances built
+                              on the Nitro System (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances).
+                              Other instance families guarantee performance up to 32,000 IOPS.
+
+                              This parameter is supported for io1, io2, and gp3 volumes only. This parameter
+                              is not supported for gp2, st1, sc1, or standard volumes.
+                            format: int64
+                            type: integer
+                          kmsKeyID:
+                            description: KMSKeyID (ARN) of the symmetric Key Management Service (KMS) CMK used for encryption.
+                            type: string
+                          snapshotID:
+                            description: SnapshotID is the ID of an EBS snapshot
+                            type: string
+                          throughput:
+                            description: |-
+                              Throughput to provision for a gp3 volume, with a maximum of 1,000 MiB/s.
+                              Valid Range: Minimum value of 125. Maximum value of 1000.
+                            format: int64
+                            type: integer
+                          volumeSize:
+                            description: |-
+                              VolumeSize in `Gi`, `G`, `Ti`, or `T`. You must specify either a snapshot ID or
+                              a volume size. The following are the supported volumes sizes for each volume
+                              type:
+
+                                 * gp2 and gp3: 1-16,384
+
+                                 * io1 and io2: 4-16,384
+
+                                 * st1 and sc1: 125-16,384
+
+                                 * standard: 1-1,024
+                            pattern: ^((?:[1-9][0-9]{0,3}|[1-4][0-9]{4}|[5][0-8][0-9]{3}|59000)Gi|(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|[6][0-3][0-9]{3}|64000)G|([1-9]||[1-5][0-7]|58)Ti|([1-9]||[1-5][0-9]|6[0-3]|64)T)$
+                            type: string
+                          volumeType:
+                            description: |-
+                              VolumeType of the block device.
+                              For more information, see Amazon EBS volume types (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html)
+                              in the Amazon Elastic Compute Cloud User Guide.
+                            enum:
+                              - standard
+                              - io1
+                              - io2
+                              - gp2
+                              - sc1
+                              - st1
+                              - gp3
+                            type: string
+                        type: object
+                        x-kubernetes-validations:
+                          - message: snapshotID or volumeSize must be defined
+                            rule: has(self.snapshotID) || has(self.volumeSize)
+                      rootVolume:
+                        description: |-
+                          RootVolume is a flag indicating if this device is mounted as kubelet root dir. You can
+                          configure at most one root volume in BlockDeviceMappings.
+                        type: boolean
+                    type: object
+                  maxItems: 50
+                  type: array
+                  x-kubernetes-validations:
+                    - message: must have only one blockDeviceMappings with rootVolume
+                      rule: self.filter(x, has(x.rootVolume)?x.rootVolume==true:false).size() <= 1
+                context:
+                  description: |-
+                    Context is a Reserved field in EC2 APIs
+                    https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet.html
+                  type: string
+                detailedMonitoring:
+                  description: DetailedMonitoring controls if detailed monitoring is enabled for instances that are launched
+                  type: boolean
+                instanceProfile:
+                  description: |-
+                    InstanceProfile is the AWS entity that instances use.
+                    This field is mutually exclusive from role.
+                    The instance profile should already have a role assigned to it that Karpenter
+                     has PassRole permission on for instance launch using this instanceProfile to succeed.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: instanceProfile cannot be empty
+                      rule: self != ''
+                instanceStorePolicy:
+                  description: InstanceStorePolicy specifies how to handle instance-store disks.
+                  enum:
+                    - RAID0
+                  type: string
+                kubelet:
+                  description: |-
+                    Kubelet defines args to be used when configuring kubelet on provisioned nodes.
+                    They are a subset of the upstream types, recognizing not all options may be supported.
+                    Wherever possible, the types and names should reflect the upstream kubelet types.
+                  properties:
+                    clusterDNS:
+                      description: |-
+                        clusterDNS is a list of IP addresses for the cluster DNS server.
+                        Note that not all providers may use all addresses.
+                      items:
+                        type: string
+                      type: array
+                    cpuCFSQuota:
+                      description: CPUCFSQuota enables CPU CFS quota enforcement for containers that specify CPU limits.
+                      type: boolean
+                    evictionHard:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionHard is the map of signal names to quantities that define hard eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionHard are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionMaxPodGracePeriod:
+                      description: |-
+                        EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in
+                        response to soft eviction thresholds being met.
+                      format: int32
+                      type: integer
+                    evictionSoft:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionSoft is the map of signal names to quantities that define soft eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoft are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionSoftGracePeriod:
+                      additionalProperties:
+                        type: string
+                      description: EvictionSoftGracePeriod is the map of signal names to quantities that define grace periods for each eviction signal
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoftGracePeriod are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    imageGCHighThresholdPercent:
+                      description: |-
+                        ImageGCHighThresholdPercent is the percent of disk usage after which image
+                        garbage collection is always run. The percent is calculated by dividing this
+                        field value by 100, so this field must be between 0 and 100, inclusive.
+                        When specified, the value must be greater than ImageGCLowThresholdPercent.
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    imageGCLowThresholdPercent:
+                      description: |-
+                        ImageGCLowThresholdPercent is the percent of disk usage before which image
+                        garbage collection is never run. Lowest disk usage to garbage collect to.
+                        The percent is calculated by dividing this field value by 100,
+                        so the field value must be between 0 and 100, inclusive.
+                        When specified, the value must be less than imageGCHighThresholdPercent
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    kubeReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: KubeReserved contains resources reserved for Kubernetes system components.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for kubeReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: kubeReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                    maxPods:
+                      description: |-
+                        MaxPods is an override for the maximum number of pods that can run on
+                        a worker node instance.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    podsPerCore:
+                      description: |-
+                        PodsPerCore is an override for the number of pods that can run on a worker node
+                        instance based on the number of cpu cores. This value cannot exceed MaxPods, so, if
+                        MaxPods is a lower value, that value will be used.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    systemReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: SystemReserved contains resources reserved for OS system daemons and kernel memory.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for systemReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: systemReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                  type: object
+                  x-kubernetes-validations:
+                    - message: imageGCHighThresholdPercent must be greater than imageGCLowThresholdPercent
+                      rule: 'has(self.imageGCHighThresholdPercent) && has(self.imageGCLowThresholdPercent) ?  self.imageGCHighThresholdPercent > self.imageGCLowThresholdPercent  : true'
+                    - message: evictionSoft OwnerKey does not have a matching evictionSoftGracePeriod
+                      rule: has(self.evictionSoft) ? self.evictionSoft.all(e, (e in self.evictionSoftGracePeriod)):true
+                    - message: evictionSoftGracePeriod OwnerKey does not have a matching evictionSoft
+                      rule: has(self.evictionSoftGracePeriod) ? self.evictionSoftGracePeriod.all(e, (e in self.evictionSoft)):true
+                metadataOptions:
+                  default:
+                    httpEndpoint: enabled
+                    httpProtocolIPv6: disabled
+                    httpPutResponseHopLimit: 1
+                    httpTokens: required
+                  description: |-
+                    MetadataOptions for the generated launch template of provisioned nodes.
+
+                    This specifies the exposure of the Instance Metadata Service to
+                    provisioned EC2 nodes. For more information,
+                    see Instance Metadata and User Data
+                    (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
+                    in the Amazon Elastic Compute Cloud User Guide.
+
+                    Refer to recommended, security best practices
+                    (https://aws.github.io/aws-eks-best-practices/security/docs/iam/#restrict-access-to-the-instance-profile-assigned-to-the-worker-node)
+                    for limiting exposure of Instance Metadata and User Data to pods.
+                    If omitted, defaults to httpEndpoint enabled, with httpProtocolIPv6
+                    disabled, with httpPutResponseLimit of 1, and with httpTokens
+                    required.
+                  properties:
+                    httpEndpoint:
+                      default: enabled
+                      description: |-
+                        HTTPEndpoint enables or disables the HTTP metadata endpoint on provisioned
+                        nodes. If metadata options is non-nil, but this parameter is not specified,
+                        the default state is "enabled".
+
+                        If you specify a value of "disabled", instance metadata will not be accessible
+                        on the node.
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpProtocolIPv6:
+                      default: disabled
+                      description: |-
+                        HTTPProtocolIPv6 enables or disables the IPv6 endpoint for the instance metadata
+                        service on provisioned nodes. If metadata options is non-nil, but this parameter
+                        is not specified, the default state is "disabled".
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpPutResponseHopLimit:
+                      default: 1
+                      description: |-
+                        HTTPPutResponseHopLimit is the desired HTTP PUT response hop limit for
+                        instance metadata requests. The larger the number, the further instance
+                        metadata requests can travel. Possible values are integers from 1 to 64.
+                        If metadata options is non-nil, but this parameter is not specified, the
+                        default value is 1.
+                      format: int64
+                      maximum: 64
+                      minimum: 1
+                      type: integer
+                    httpTokens:
+                      default: required
+                      description: |-
+                        HTTPTokens determines the state of token usage for instance metadata
+                        requests. If metadata options is non-nil, but this parameter is not
+                        specified, the default state is "required".
+
+                        If the state is optional, one can choose to retrieve instance metadata with
+                        or without a signed token header on the request. If one retrieves the IAM
+                        role credentials without a token, the version 1.0 role credentials are
+                        returned. If one retrieves the IAM role credentials using a valid signed
+                        token, the version 2.0 role credentials are returned.
+
+                        If the state is "required", one must send a signed token header with any
+                        instance metadata retrieval requests. In this state, retrieving the IAM
+                        role credentials always returns the version 2.0 credentials; the version
+                        1.0 credentials are not available.
+                      enum:
+                        - required
+                        - optional
+                      type: string
+                  type: object
+                role:
+                  description: |-
+                    Role is the AWS identity that nodes use. This field is immutable.
+                    This field is mutually exclusive from instanceProfile.
+                    Marking this field as immutable avoids concerns around terminating managed instance profiles from running instances.
+                    This field may be made mutable in the future, assuming the correct garbage collection and drift handling is implemented
+                    for the old instance profiles on an update.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: role cannot be empty
+                      rule: self != ''
+                    - message: immutable field changed
+                      rule: self == oldSelf
+                securityGroupSelectorTerms:
+                  description: SecurityGroupSelectorTerms is a list of or security group selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SecurityGroupSelectorTerm defines selection logic for a security group used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the security group id in EC2
+                        pattern: sg-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the security group name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: securityGroupSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id', 'name']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && (has(x.tags) || has(x.name)))'
+                    - message: '''name'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.name) && (has(x.tags) || has(x.id)))'
+                subnetSelectorTerms:
+                  description: SubnetSelectorTerms is a list of or subnet selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SubnetSelectorTerm defines selection logic for a subnet used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the subnet id in EC2
+                        pattern: subnet-[0-9a-z]+
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: subnetSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id']
+                      rule: self.all(x, has(x.tags) || has(x.id))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in subnetSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && has(x.tags))'
+                tags:
+                  additionalProperties:
+                    type: string
+                  description: Tags to be applied on ec2 resources like instances and launch templates.
+                  type: object
+                  x-kubernetes-validations:
+                    - message: empty tag keys aren't supported
+                      rule: self.all(k, k != '')
+                    - message: tag contains a restricted tag matching eks:eks-cluster-name
+                      rule: self.all(k, k !='eks:eks-cluster-name')
+                    - message: tag contains a restricted tag matching kubernetes.io/cluster/
+                      rule: self.all(k, !k.startsWith('kubernetes.io/cluster') )
+                    - message: tag contains a restricted tag matching karpenter.sh/nodepool
+                      rule: self.all(k, k != 'karpenter.sh/nodepool')
+                    - message: tag contains a restricted tag matching karpenter.sh/nodeclaim
+                      rule: self.all(k, k !='karpenter.sh/nodeclaim')
+                    - message: tag contains a restricted tag matching karpenter.k8s.aws/ec2nodeclass
+                      rule: self.all(k, k !='karpenter.k8s.aws/ec2nodeclass')
+                userData:
+                  description: |-
+                    UserData to be applied to the provisioned nodes.
+                    It must be in the appropriate format based on the AMIFamily in use. Karpenter will merge certain fields into
+                    this UserData to ensure nodes are being provisioned with the correct configuration.
+                  type: string
+              required:
+                - amiSelectorTerms
+                - securityGroupSelectorTerms
+                - subnetSelectorTerms
+              type: object
+              x-kubernetes-validations:
+                - message: must specify exactly one of ['role', 'instanceProfile']
+                  rule: (has(self.role) && !has(self.instanceProfile)) || (!has(self.role) && has(self.instanceProfile))
+                - message: changing from 'instanceProfile' to 'role' is not supported. You must delete and recreate this node class if you want to change this.
+                  rule: (has(oldSelf.role) && has(self.role)) || (has(oldSelf.instanceProfile) && has(self.instanceProfile))
+                - message: if set, amiFamily must be 'AL2' or 'Custom' when using an AL2 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''al2'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''AL2'') : true)'
+                - message: if set, amiFamily must be 'AL2023' or 'Custom' when using an AL2023 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''al2023'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''AL2023'') : true)'
+                - message: if set, amiFamily must be 'Bottlerocket' or 'Custom' when using a Bottlerocket alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''bottlerocket'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Bottlerocket'') : true)'
+                - message: if set, amiFamily must be 'Windows2019' or 'Custom' when using a Windows2019 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''windows2019'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Windows2019'') : true)'
+                - message: if set, amiFamily must be 'Windows2022' or 'Custom' when using a Windows2022 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''windows2022'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Windows2022'') : true)'
+                - message: must specify amiFamily if amiSelectorTerms does not contain an alias
+                  rule: 'self.amiSelectorTerms.exists(x, has(x.alias)) ? true : has(self.amiFamily)'
+            status:
+              description: EC2NodeClassStatus contains the resolved state of the EC2NodeClass
+              properties:
+                amis:
+                  description: |-
+                    AMI contains the current AMI values that are available to the
+                    cluster under the AMI selectors.
+                  items:
+                    description: AMI contains resolved AMI selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the AMI
+                        type: string
+                      name:
+                        description: Name of the AMI
+                        type: string
+                      requirements:
+                        description: Requirements of the AMI to be utilized on an instance type
+                        items:
+                          description: |-
+                            A node selector requirement is a selector that contains values, a key, and an operator
+                            that relates the key and values.
+                          properties:
+                            key:
+                              description: The label key that the selector applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                Represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                              type: string
+                            values:
+                              description: |-
+                                An array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. If the operator is Gt or Lt, the values
+                                array must have a single element, which will be interpreted as an integer.
+                                This array is replaced during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                            - key
+                            - operator
+                          type: object
+                        type: array
+                    required:
+                      - id
+                      - requirements
+                    type: object
+                  type: array
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                instanceProfile:
+                  description: InstanceProfile contains the resolved instance profile for the role
+                  type: string
+                securityGroups:
+                  description: |-
+                    SecurityGroups contains the current Security Groups values that are available to the
+                    cluster under the SecurityGroups selectors.
+                  items:
+                    description: SecurityGroup contains resolved SecurityGroup selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the security group
+                        type: string
+                      name:
+                        description: Name of the security group
+                        type: string
+                    required:
+                      - id
+                    type: object
+                  type: array
+                subnets:
+                  description: |-
+                    Subnets contains the current Subnet values that are available to the
+                    cluster under the subnet selectors.
+                  items:
+                    description: Subnet contains resolved Subnet selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the subnet
+                        type: string
+                      zone:
+                        description: The associated availability zone
+                        type: string
+                      zoneID:
+                        description: The associated availability zone ID
+                        type: string
+                    required:
+                      - id
+                      - zone
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: EC2NodeClass is the Schema for the EC2NodeClass API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                EC2NodeClassSpec is the top level specification for the AWS Karpenter Provider.
+                This will contain configuration necessary to launch instances in AWS.
+              properties:
+                amiFamily:
+                  description: AMIFamily is the AMI family that instances use.
+                  enum:
+                    - AL2
+                    - AL2023
+                    - Bottlerocket
+                    - Ubuntu
+                    - Custom
+                    - Windows2019
+                    - Windows2022
+                  type: string
+                amiSelectorTerms:
+                  description: AMISelectorTerms is a list of or ami selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      AMISelectorTerm defines selection logic for an ami used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the ami id in EC2
+                        pattern: ami-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the ami name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      owner:
+                        description: |-
+                          Owner is the owner for the ami.
+                          You can specify a combination of AWS account IDs, "self", "amazon", and "aws-marketplace"
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: expected at least one, got none, ['tags', 'id', 'name']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && (has(x.tags) || has(x.name) || has(x.owner)))'
+                associatePublicIPAddress:
+                  description: AssociatePublicIPAddress controls if public IP addresses are assigned to instances that are launched with the nodeclass.
+                  type: boolean
+                blockDeviceMappings:
+                  description: BlockDeviceMappings to be applied to provisioned nodes.
+                  items:
+                    properties:
+                      deviceName:
+                        description: The device name (for example, /dev/sdh or xvdh).
+                        type: string
+                      ebs:
+                        description: EBS contains parameters used to automatically set up EBS volumes when an instance is launched.
+                        properties:
+                          deleteOnTermination:
+                            description: DeleteOnTermination indicates whether the EBS volume is deleted on instance termination.
+                            type: boolean
+                          encrypted:
+                            description: |-
+                              Encrypted indicates whether the EBS volume is encrypted. Encrypted volumes can only
+                              be attached to instances that support Amazon EBS encryption. If you are creating
+                              a volume from a snapshot, you can't specify an encryption value.
+                            type: boolean
+                          iops:
+                            description: |-
+                              IOPS is the number of I/O operations per second (IOPS). For gp3, io1, and io2 volumes,
+                              this represents the number of IOPS that are provisioned for the volume. For
+                              gp2 volumes, this represents the baseline performance of the volume and the
+                              rate at which the volume accumulates I/O credits for bursting.
+
+                              The following are the supported values for each volume type:
+
+                                 * gp3: 3,000-16,000 IOPS
+
+                                 * io1: 100-64,000 IOPS
+
+                                 * io2: 100-64,000 IOPS
+
+                              For io1 and io2 volumes, we guarantee 64,000 IOPS only for Instances built
+                              on the Nitro System (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances).
+                              Other instance families guarantee performance up to 32,000 IOPS.
+
+                              This parameter is supported for io1, io2, and gp3 volumes only. This parameter
+                              is not supported for gp2, st1, sc1, or standard volumes.
+                            format: int64
+                            type: integer
+                          kmsKeyID:
+                            description: KMSKeyID (ARN) of the symmetric Key Management Service (KMS) CMK used for encryption.
+                            type: string
+                          snapshotID:
+                            description: SnapshotID is the ID of an EBS snapshot
+                            type: string
+                          throughput:
+                            description: |-
+                              Throughput to provision for a gp3 volume, with a maximum of 1,000 MiB/s.
+                              Valid Range: Minimum value of 125. Maximum value of 1000.
+                            format: int64
+                            type: integer
+                          volumeSize:
+                            description: |-
+                              VolumeSize in `Gi`, `G`, `Ti`, or `T`. You must specify either a snapshot ID or
+                              a volume size. The following are the supported volumes sizes for each volume
+                              type:
+
+                                 * gp2 and gp3: 1-16,384
+
+                                 * io1 and io2: 4-16,384
+
+                                 * st1 and sc1: 125-16,384
+
+                                 * standard: 1-1,024
+                            pattern: ^((?:[1-9][0-9]{0,3}|[1-4][0-9]{4}|[5][0-8][0-9]{3}|59000)Gi|(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|[6][0-3][0-9]{3}|64000)G|([1-9]||[1-5][0-7]|58)Ti|([1-9]||[1-5][0-9]|6[0-3]|64)T)$
+                            type: string
+                          volumeType:
+                            description: |-
+                              VolumeType of the block device.
+                              For more information, see Amazon EBS volume types (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html)
+                              in the Amazon Elastic Compute Cloud User Guide.
+                            enum:
+                              - standard
+                              - io1
+                              - io2
+                              - gp2
+                              - sc1
+                              - st1
+                              - gp3
+                            type: string
+                        type: object
+                        x-kubernetes-validations:
+                          - message: snapshotID or volumeSize must be defined
+                            rule: has(self.snapshotID) || has(self.volumeSize)
+                      rootVolume:
+                        description: |-
+                          RootVolume is a flag indicating if this device is mounted as kubelet root dir. You can
+                          configure at most one root volume in BlockDeviceMappings.
+                        type: boolean
+                    type: object
+                  maxItems: 50
+                  type: array
+                  x-kubernetes-validations:
+                    - message: must have only one blockDeviceMappings with rootVolume
+                      rule: self.filter(x, has(x.rootVolume)?x.rootVolume==true:false).size() <= 1
+                context:
+                  description: |-
+                    Context is a Reserved field in EC2 APIs
+                    https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet.html
+                  type: string
+                detailedMonitoring:
+                  description: DetailedMonitoring controls if detailed monitoring is enabled for instances that are launched
+                  type: boolean
+                instanceProfile:
+                  description: |-
+                    InstanceProfile is the AWS entity that instances use.
+                    This field is mutually exclusive from role.
+                    The instance profile should already have a role assigned to it that Karpenter
+                     has PassRole permission on for instance launch using this instanceProfile to succeed.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: instanceProfile cannot be empty
+                      rule: self != ''
+                instanceStorePolicy:
+                  description: InstanceStorePolicy specifies how to handle instance-store disks.
+                  enum:
+                    - RAID0
+                  type: string
+                metadataOptions:
+                  default:
+                    httpEndpoint: enabled
+                    httpProtocolIPv6: disabled
+                    httpPutResponseHopLimit: 1
+                    httpTokens: required
+                  description: |-
+                    MetadataOptions for the generated launch template of provisioned nodes.
+
+                    This specifies the exposure of the Instance Metadata Service to
+                    provisioned EC2 nodes. For more information,
+                    see Instance Metadata and User Data
+                    (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
+                    in the Amazon Elastic Compute Cloud User Guide.
+
+                    Refer to recommended, security best practices
+                    (https://aws.github.io/aws-eks-best-practices/security/docs/iam/#restrict-access-to-the-instance-profile-assigned-to-the-worker-node)
+                    for limiting exposure of Instance Metadata and User Data to pods.
+                    If omitted, defaults to httpEndpoint enabled, with httpProtocolIPv6
+                    disabled, with httpPutResponseLimit of 1, and with httpTokens
+                    required.
+                  properties:
+                    httpEndpoint:
+                      default: enabled
+                      description: |-
+                        HTTPEndpoint enables or disables the HTTP metadata endpoint on provisioned
+                        nodes. If metadata options is non-nil, but this parameter is not specified,
+                        the default state is "enabled".
+
+                        If you specify a value of "disabled", instance metadata will not be accessible
+                        on the node.
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpProtocolIPv6:
+                      default: disabled
+                      description: |-
+                        HTTPProtocolIPv6 enables or disables the IPv6 endpoint for the instance metadata
+                        service on provisioned nodes. If metadata options is non-nil, but this parameter
+                        is not specified, the default state is "disabled".
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpPutResponseHopLimit:
+                      default: 2
+                      description: |-
+                        HTTPPutResponseHopLimit is the desired HTTP PUT response hop limit for
+                        instance metadata requests. The larger the number, the further instance
+                        metadata requests can travel. Possible values are integers from 1 to 64.
+                        If metadata options is non-nil, but this parameter is not specified, the
+                        default value is 2.
+                      format: int64
+                      maximum: 64
+                      minimum: 1
+                      type: integer
+                    httpTokens:
+                      default: required
+                      description: |-
+                        HTTPTokens determines the state of token usage for instance metadata
+                        requests. If metadata options is non-nil, but this parameter is not
+                        specified, the default state is "required".
+
+                        If the state is optional, one can choose to retrieve instance metadata with
+                        or without a signed token header on the request. If one retrieves the IAM
+                        role credentials without a token, the version 1.0 role credentials are
+                        returned. If one retrieves the IAM role credentials using a valid signed
+                        token, the version 2.0 role credentials are returned.
+
+                        If the state is "required", one must send a signed token header with any
+                        instance metadata retrieval requests. In this state, retrieving the IAM
+                        role credentials always returns the version 2.0 credentials; the version
+                        1.0 credentials are not available.
+                      enum:
+                        - required
+                        - optional
+                      type: string
+                  type: object
+                role:
+                  description: |-
+                    Role is the AWS identity that nodes use. This field is immutable.
+                    This field is mutually exclusive from instanceProfile.
+                    Marking this field as immutable avoids concerns around terminating managed instance profiles from running instances.
+                    This field may be made mutable in the future, assuming the correct garbage collection and drift handling is implemented
+                    for the old instance profiles on an update.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: role cannot be empty
+                      rule: self != ''
+                    - message: immutable field changed
+                      rule: self == oldSelf
+                securityGroupSelectorTerms:
+                  description: SecurityGroupSelectorTerms is a list of or security group selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SecurityGroupSelectorTerm defines selection logic for a security group used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the security group id in EC2
+                        pattern: sg-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the security group name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: securityGroupSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id', 'name']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && (has(x.tags) || has(x.name)))'
+                    - message: '''name'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.name) && (has(x.tags) || has(x.id)))'
+                subnetSelectorTerms:
+                  description: SubnetSelectorTerms is a list of or subnet selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SubnetSelectorTerm defines selection logic for a subnet used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the subnet id in EC2
+                        pattern: subnet-[0-9a-z]+
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: subnetSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id']
+                      rule: self.all(x, has(x.tags) || has(x.id))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in subnetSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && has(x.tags))'
+                tags:
+                  additionalProperties:
+                    type: string
+                  description: Tags to be applied on ec2 resources like instances and launch templates.
+                  type: object
+                  x-kubernetes-validations:
+                    - message: empty tag keys aren't supported
+                      rule: self.all(k, k != '')
+                    - message: tag contains a restricted tag matching kubernetes.io/cluster/
+                      rule: self.all(k, !k.startsWith('kubernetes.io/cluster') )
+                    - message: tag contains a restricted tag matching karpenter.sh/nodepool
+                      rule: self.all(k, k != 'karpenter.sh/nodepool')
+                    - message: tag contains a restricted tag matching karpenter.sh/managed-by
+                      rule: self.all(k, k !='karpenter.sh/managed-by')
+                    - message: tag contains a restricted tag matching karpenter.sh/nodeclaim
+                      rule: self.all(k, k !='karpenter.sh/nodeclaim')
+                    - message: tag contains a restricted tag matching karpenter.k8s.aws/ec2nodeclass
+                      rule: self.all(k, k !='karpenter.k8s.aws/ec2nodeclass')
+                userData:
+                  description: |-
+                    UserData to be applied to the provisioned nodes.
+                    It must be in the appropriate format based on the AMIFamily in use. Karpenter will merge certain fields into
+                    this UserData to ensure nodes are being provisioned with the correct configuration.
+                  type: string
+              required:
+                - amiFamily
+                - securityGroupSelectorTerms
+                - subnetSelectorTerms
+              type: object
+              x-kubernetes-validations:
+                - message: amiSelectorTerms is required when amiFamily == 'Custom'
+                  rule: 'self.amiFamily == ''Custom'' ? self.amiSelectorTerms.size() != 0 : true'
+                - message: must specify exactly one of ['role', 'instanceProfile']
+                  rule: (has(self.role) && !has(self.instanceProfile)) || (!has(self.role) && has(self.instanceProfile))
+                - message: changing from 'instanceProfile' to 'role' is not supported. You must delete and recreate this node class if you want to change this.
+                  rule: (has(oldSelf.role) && has(self.role)) || (has(oldSelf.instanceProfile) && has(self.instanceProfile))
+            status:
+              description: EC2NodeClassStatus contains the resolved state of the EC2NodeClass
+              properties:
+                amis:
+                  description: |-
+                    AMI contains the current AMI values that are available to the
+                    cluster under the AMI selectors.
+                  items:
+                    description: AMI contains resolved AMI selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the AMI
+                        type: string
+                      name:
+                        description: Name of the AMI
+                        type: string
+                      requirements:
+                        description: Requirements of the AMI to be utilized on an instance type
+                        items:
+                          description: |-
+                            A node selector requirement is a selector that contains values, a key, and an operator
+                            that relates the key and values.
+                          properties:
+                            key:
+                              description: The label key that the selector applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                Represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                              type: string
+                            values:
+                              description: |-
+                                An array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. If the operator is Gt or Lt, the values
+                                array must have a single element, which will be interpreted as an integer.
+                                This array is replaced during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                            - key
+                            - operator
+                          type: object
+                        type: array
+                    required:
+                      - id
+                      - requirements
+                    type: object
+                  type: array
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                instanceProfile:
+                  description: InstanceProfile contains the resolved instance profile for the role
+                  type: string
+                securityGroups:
+                  description: |-
+                    SecurityGroups contains the current Security Groups values that are available to the
+                    cluster under the SecurityGroups selectors.
+                  items:
+                    description: SecurityGroup contains resolved SecurityGroup selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the security group
+                        type: string
+                      name:
+                        description: Name of the security group
+                        type: string
+                    required:
+                      - id
+                    type: object
+                  type: array
+                subnets:
+                  description: |-
+                    Subnets contains the current Subnet values that are available to the
+                    cluster under the subnet selectors.
+                  items:
+                    description: Subnet contains resolved Subnet selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the subnet
+                        type: string
+                      zone:
+                        description: The associated availability zone
+                        type: string
+                      zoneID:
+                        description: The associated availability zone ID
+                        type: string
+                    required:
+                      - id
+                      - zone
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+        - v1
+      clientConfig:
+        service:
+          name: karpenter
+          namespace: kube-system
+          port: 8443

--- a/content/projects/karpenter/v1.0.6/karpenter.sh_nodeclaims.yaml
+++ b/content/projects/karpenter/v1.0.6/karpenter.sh_nodeclaims.yaml
@@ -1,0 +1,829 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.3
+  name: nodeclaims.karpenter.sh
+spec:
+  group: karpenter.sh
+  names:
+    categories:
+      - karpenter
+    kind: NodeClaim
+    listKind: NodeClaimList
+    plural: nodeclaims
+    singular: nodeclaim
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.labels.node\.kubernetes\.io/instance-type
+          name: Type
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/capacity-type
+          name: Capacity
+          type: string
+        - jsonPath: .metadata.labels.topology\.kubernetes\.io/zone
+          name: Zone
+          type: string
+        - jsonPath: .status.nodeName
+          name: Node
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .status.providerID
+          name: ID
+          priority: 1
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/nodepool
+          name: NodePool
+          priority: 1
+          type: string
+        - jsonPath: .spec.nodeClassRef.name
+          name: NodeClass
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: NodeClaim is the Schema for the NodeClaims API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: NodeClaimSpec describes the desired state of the NodeClaim
+              properties:
+                expireAfter:
+                  default: 720h
+                  description: |-
+                    ExpireAfter is the duration the controller will wait
+                    before terminating a node, measured from when the node is created. This
+                    is useful to implement features like eventually consistent node upgrade,
+                    memory leak protection, and disruption testing.
+                  pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                  type: string
+                nodeClassRef:
+                  description: NodeClassRef is a reference to an object that defines provider specific configuration
+                  properties:
+                    group:
+                      description: API version of the referent
+                      pattern: ^[^/]*$
+                      type: string
+                    kind:
+                      description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                      type: string
+                    name:
+                      description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                      type: string
+                  required:
+                    - group
+                    - kind
+                    - name
+                  type: object
+                requirements:
+                  description: Requirements are layered with GetLabels and applied to every node.
+                  items:
+                    description: |-
+                      A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                      and minValues that represent the requirement to have at least that many values.
+                    properties:
+                      key:
+                        description: The label key that the selector applies to.
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                        x-kubernetes-validations:
+                          - message: label domain "kubernetes.io" is restricted
+                            rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                          - message: label domain "k8s.io" is restricted
+                            rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                          - message: label domain "karpenter.sh" is restricted
+                            rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                          - message: label "kubernetes.io/hostname" is restricted
+                            rule: self != "kubernetes.io/hostname"
+                          - message: label domain "karpenter.k8s.aws" is restricted
+                            rule: self in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                      minValues:
+                        description: |-
+                          This field is ALPHA and can be dropped or replaced at any time
+                          MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                        maximum: 50
+                        minimum: 1
+                        type: integer
+                      operator:
+                        description: |-
+                          Represents a key's relationship to a set of values.
+                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                        type: string
+                        enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          - Gt
+                          - Lt
+                      values:
+                        description: |-
+                          An array of string values. If the operator is In or NotIn,
+                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                          the values array must be empty. If the operator is Gt or Lt, the values
+                          array must have a single element, which will be interpreted as an integer.
+                          This array is replaced during a strategic merge patch.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                        maxLength: 63
+                        pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                    required:
+                      - key
+                      - operator
+                    type: object
+                  maxItems: 100
+                  type: array
+                  x-kubernetes-validations:
+                    - message: requirements with operator 'In' must have a value defined
+                      rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                    - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                      rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                    - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                      rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                resources:
+                  description: Resources models the resource requirements for the NodeClaim to launch
+                  properties:
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: Requests describes the minimum required resources for the NodeClaim to launch
+                      type: object
+                  type: object
+                startupTaints:
+                  description: |-
+                    StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                    within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                    daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                    purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                taints:
+                  description: Taints will be applied to the NodeClaim's node.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                terminationGracePeriod:
+                  description: |-
+                    TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
+
+                    Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
+
+                    This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
+                    When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
+
+                    Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
+                    If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
+                    that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
+
+                    The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
+                    If left undefined, the controller will wait indefinitely for pods to be drained.
+                  pattern: ^([0-9]+(s|m|h))+$
+                  type: string
+              required:
+                - nodeClassRef
+                - requirements
+              type: object
+              x-kubernetes-validations:
+                - message: spec is immutable
+                  rule: self == oldSelf
+            status:
+              description: NodeClaimStatus defines the observed state of NodeClaim
+              properties:
+                allocatable:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Allocatable is the estimated allocatable capacity of the node
+                  type: object
+                capacity:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Capacity is the estimated full capacity of the node
+                  type: object
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        pattern: ^([A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?|)$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - status
+                      - type
+                    type: object
+                  type: array
+                imageID:
+                  description: ImageID is an identifier for the image that runs on the node
+                  type: string
+                lastPodEventTime:
+                  description: |-
+                    LastPodEventTime is updated with the last time a pod was scheduled
+                    or removed from the node. A pod going terminal or terminating
+                    is also considered as removed.
+                  format: date-time
+                  type: string
+                nodeName:
+                  description: NodeName is the name of the corresponding node object
+                  type: string
+                providerID:
+                  description: ProviderID of the corresponding node object
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.labels.node\.kubernetes\.io/instance-type
+          name: Type
+          type: string
+        - jsonPath: .metadata.labels.topology\.kubernetes\.io/zone
+          name: Zone
+          type: string
+        - jsonPath: .status.nodeName
+          name: Node
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .metadata.labels.karpenter\.sh/capacity-type
+          name: Capacity
+          priority: 1
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/nodepool
+          name: NodePool
+          priority: 1
+          type: string
+        - jsonPath: .spec.nodeClassRef.name
+          name: NodeClass
+          priority: 1
+          type: string
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: NodeClaim is the Schema for the NodeClaims API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: NodeClaimSpec describes the desired state of the NodeClaim
+              properties:
+                kubelet:
+                  description: |-
+                    Kubelet defines args to be used when configuring kubelet on provisioned nodes.
+                    They are a subset of the upstream types, recognizing not all options may be supported.
+                    Wherever possible, the types and names should reflect the upstream kubelet types.
+                  properties:
+                    clusterDNS:
+                      description: |-
+                        clusterDNS is a list of IP addresses for the cluster DNS server.
+                        Note that not all providers may use all addresses.
+                      items:
+                        type: string
+                      type: array
+                    cpuCFSQuota:
+                      description: CPUCFSQuota enables CPU CFS quota enforcement for containers that specify CPU limits.
+                      type: boolean
+                    evictionHard:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionHard is the map of signal names to quantities that define hard eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionHard are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionMaxPodGracePeriod:
+                      description: |-
+                        EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in
+                        response to soft eviction thresholds being met.
+                      format: int32
+                      type: integer
+                    evictionSoft:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionSoft is the map of signal names to quantities that define soft eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoft are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionSoftGracePeriod:
+                      additionalProperties:
+                        type: string
+                      description: EvictionSoftGracePeriod is the map of signal names to quantities that define grace periods for each eviction signal
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoftGracePeriod are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    imageGCHighThresholdPercent:
+                      description: |-
+                        ImageGCHighThresholdPercent is the percent of disk usage after which image
+                        garbage collection is always run. The percent is calculated by dividing this
+                        field value by 100, so this field must be between 0 and 100, inclusive.
+                        When specified, the value must be greater than ImageGCLowThresholdPercent.
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    imageGCLowThresholdPercent:
+                      description: |-
+                        ImageGCLowThresholdPercent is the percent of disk usage before which image
+                        garbage collection is never run. Lowest disk usage to garbage collect to.
+                        The percent is calculated by dividing this field value by 100,
+                        so the field value must be between 0 and 100, inclusive.
+                        When specified, the value must be less than imageGCHighThresholdPercent
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    kubeReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: KubeReserved contains resources reserved for Kubernetes system components.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for kubeReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: kubeReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                    maxPods:
+                      description: |-
+                        MaxPods is an override for the maximum number of pods that can run on
+                        a worker node instance.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    podsPerCore:
+                      description: |-
+                        PodsPerCore is an override for the number of pods that can run on a worker node
+                        instance based on the number of cpu cores. This value cannot exceed MaxPods, so, if
+                        MaxPods is a lower value, that value will be used.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    systemReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: SystemReserved contains resources reserved for OS system daemons and kernel memory.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for systemReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: systemReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                  type: object
+                  x-kubernetes-validations:
+                    - message: imageGCHighThresholdPercent must be greater than imageGCLowThresholdPercent
+                      rule: 'has(self.imageGCHighThresholdPercent) && has(self.imageGCLowThresholdPercent) ?  self.imageGCHighThresholdPercent > self.imageGCLowThresholdPercent  : true'
+                    - message: evictionSoft OwnerKey does not have a matching evictionSoftGracePeriod
+                      rule: has(self.evictionSoft) ? self.evictionSoft.all(e, (e in self.evictionSoftGracePeriod)):true
+                    - message: evictionSoftGracePeriod OwnerKey does not have a matching evictionSoft
+                      rule: has(self.evictionSoftGracePeriod) ? self.evictionSoftGracePeriod.all(e, (e in self.evictionSoft)):true
+                nodeClassRef:
+                  description: NodeClassRef is a reference to an object that defines provider specific configuration
+                  properties:
+                    apiVersion:
+                      description: API version of the referent
+                      type: string
+                    kind:
+                      description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                      type: string
+                    name:
+                      description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                      type: string
+                  required:
+                    - name
+                  type: object
+                requirements:
+                  description: Requirements are layered with GetLabels and applied to every node.
+                  items:
+                    description: |-
+                      A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                      and minValues that represent the requirement to have at least that many values.
+                    properties:
+                      key:
+                        description: The label key that the selector applies to.
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                        x-kubernetes-validations:
+                          - message: label domain "kubernetes.io" is restricted
+                            rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                          - message: label domain "k8s.io" is restricted
+                            rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                          - message: label domain "karpenter.sh" is restricted
+                            rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                          - message: label "kubernetes.io/hostname" is restricted
+                            rule: self != "kubernetes.io/hostname"
+                          - message: label domain "karpenter.k8s.aws" is restricted
+                            rule: self in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                      minValues:
+                        description: |-
+                          This field is ALPHA and can be dropped or replaced at any time
+                          MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                        maximum: 50
+                        minimum: 1
+                        type: integer
+                      operator:
+                        description: |-
+                          Represents a key's relationship to a set of values.
+                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                        type: string
+                        enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          - Gt
+                          - Lt
+                      values:
+                        description: |-
+                          An array of string values. If the operator is In or NotIn,
+                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                          the values array must be empty. If the operator is Gt or Lt, the values
+                          array must have a single element, which will be interpreted as an integer.
+                          This array is replaced during a strategic merge patch.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                        maxLength: 63
+                        pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                    required:
+                      - key
+                      - operator
+                    type: object
+                  maxItems: 100
+                  type: array
+                  x-kubernetes-validations:
+                    - message: requirements with operator 'In' must have a value defined
+                      rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                    - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                      rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                    - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                      rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                resources:
+                  description: Resources models the resource requirements for the NodeClaim to launch
+                  properties:
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: Requests describes the minimum required resources for the NodeClaim to launch
+                      type: object
+                  type: object
+                startupTaints:
+                  description: |-
+                    StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                    within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                    daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                    purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                taints:
+                  description: Taints will be applied to the NodeClaim's node.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+              required:
+                - nodeClassRef
+                - requirements
+              type: object
+            status:
+              description: NodeClaimStatus defines the observed state of NodeClaim
+              properties:
+                allocatable:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Allocatable is the estimated allocatable capacity of the node
+                  type: object
+                capacity:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Capacity is the estimated full capacity of the node
+                  type: object
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        pattern: ^([A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?|)$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - status
+                      - type
+                    type: object
+                  type: array
+                imageID:
+                  description: ImageID is an identifier for the image that runs on the node
+                  type: string
+                nodeName:
+                  description: NodeName is the name of the corresponding node object
+                  type: string
+                providerID:
+                  description: ProviderID of the corresponding node object
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+        - v1
+      clientConfig:
+        service:
+          name: karpenter
+          namespace: kube-system
+          port: 8443

--- a/content/projects/karpenter/v1.0.6/karpenter.sh_nodepools.yaml
+++ b/content/projects/karpenter/v1.0.6/karpenter.sh_nodepools.yaml
@@ -1,0 +1,1082 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.3
+  name: nodepools.karpenter.sh
+spec:
+  group: karpenter.sh
+  names:
+    categories:
+      - karpenter
+    kind: NodePool
+    listKind: NodePoolList
+    plural: nodepools
+    singular: nodepool
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.template.spec.nodeClassRef.name
+          name: NodeClass
+          type: string
+        - jsonPath: .status.resources.nodes
+          name: Nodes
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.weight
+          name: Weight
+          priority: 1
+          type: integer
+        - jsonPath: .status.resources.cpu
+          name: CPU
+          priority: 1
+          type: string
+        - jsonPath: .status.resources.memory
+          name: Memory
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: NodePool is the Schema for the NodePools API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                NodePoolSpec is the top level nodepool specification. Nodepools
+                launch nodes in response to pods that are unschedulable. A single nodepool
+                is capable of managing a diverse set of nodes. Node properties are determined
+                from a combination of nodepool and pod scheduling constraints.
+              properties:
+                disruption:
+                  default:
+                    consolidateAfter: 0s
+                  description: Disruption contains the parameters that relate to Karpenter's disruption logic
+                  properties:
+                    budgets:
+                      default:
+                        - nodes: 10%
+                      description: |-
+                        Budgets is a list of Budgets.
+                        If there are multiple active budgets, Karpenter uses
+                        the most restrictive value. If left undefined,
+                        this will default to one budget with a value to 10%.
+                      items:
+                        description: |-
+                          Budget defines when Karpenter will restrict the
+                          number of Node Claims that can be terminating simultaneously.
+                        properties:
+                          duration:
+                            description: |-
+                              Duration determines how long a Budget is active since each Schedule hit.
+                              Only minutes and hours are accepted, as cron does not work in seconds.
+                              If omitted, the budget is always active.
+                              This is required if Schedule is set.
+                              This regex has an optional 0s at the end since the duration.String() always adds
+                              a 0s at the end.
+                            pattern: ^((([0-9]+(h|m))|([0-9]+h[0-9]+m))(0s)?)$
+                            type: string
+                          nodes:
+                            default: 10%
+                            description: |-
+                              Nodes dictates the maximum number of NodeClaims owned by this NodePool
+                              that can be terminating at once. This is calculated by counting nodes that
+                              have a deletion timestamp set, or are actively being deleted by Karpenter.
+                              This field is required when specifying a budget.
+                              This cannot be of type intstr.IntOrString since kubebuilder doesn't support pattern
+                              checking for int nodes for IntOrString nodes.
+                              Ref: https://github.com/kubernetes-sigs/controller-tools/blob/55efe4be40394a288216dab63156b0a64fb82929/pkg/crd/markers/validation.go#L379-L388
+                            pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
+                            type: string
+                          reasons:
+                            description: |-
+                              Reasons is a list of disruption methods that this budget applies to. If Reasons is not set, this budget applies to all methods.
+                              Otherwise, this will apply to each reason defined.
+                              allowed reasons are Underutilized, Empty, and Drifted.
+                            items:
+                              description: DisruptionReason defines valid reasons for disruption budgets.
+                              enum:
+                                - Underutilized
+                                - Empty
+                                - Drifted
+                              type: string
+                            type: array
+                          schedule:
+                            description: |-
+                              Schedule specifies when a budget begins being active, following
+                              the upstream cronjob syntax. If omitted, the budget is always active.
+                              Timezones are not supported.
+                              This field is required if Duration is set.
+                            pattern: ^(@(annually|yearly|monthly|weekly|daily|midnight|hourly))|((.+)\s(.+)\s(.+)\s(.+)\s(.+))$
+                            type: string
+                        required:
+                          - nodes
+                        type: object
+                      maxItems: 50
+                      type: array
+                      x-kubernetes-validations:
+                        - message: '''schedule'' must be set with ''duration'''
+                          rule: self.all(x, has(x.schedule) == has(x.duration))
+                    consolidateAfter:
+                      description: |-
+                        ConsolidateAfter is the duration the controller will wait
+                        before attempting to terminate nodes that are underutilized.
+                        Refer to ConsolidationPolicy for how underutilization is considered.
+                      pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                      type: string
+                    consolidationPolicy:
+                      default: WhenEmptyOrUnderutilized
+                      description: |-
+                        ConsolidationPolicy describes which nodes Karpenter can disrupt through its consolidation
+                        algorithm. This policy defaults to "WhenEmptyOrUnderutilized" if not specified
+                      enum:
+                        - WhenEmpty
+                        - WhenEmptyOrUnderutilized
+                      type: string
+                  required:
+                    - consolidateAfter
+                  type: object
+                limits:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Limits define a set of bounds for provisioning capacity.
+                  type: object
+                template:
+                  description: |-
+                    Template contains the template of possibilities for the provisioning logic to launch a NodeClaim with.
+                    NodeClaims launched from this NodePool will often be further constrained than the template specifies.
+                  properties:
+                    metadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Annotations is an unstructured key value map stored with a resource that may be
+                            set by external tools to store and retrieve arbitrary metadata. They are not
+                            queryable and should be preserved when modifying objects.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                            maxLength: 63
+                            pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                          description: |-
+                            Map of string keys and values that can be used to organize and categorize
+                            (scope and select) objects. May match selectors of replication controllers
+                            and services.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
+                          type: object
+                          maxProperties: 100
+                          x-kubernetes-validations:
+                            - message: label domain "kubernetes.io" is restricted
+                              rule: self.all(x, x in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region",  "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || x.find("^([^/]+)").endsWith("node.kubernetes.io") || x.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !x.find("^([^/]+)").endsWith("kubernetes.io"))
+                            - message: label domain "k8s.io" is restricted
+                              rule: self.all(x, x.find("^([^/]+)").endsWith("kops.k8s.io") || !x.find("^([^/]+)").endsWith("k8s.io"))
+                            - message: label domain "karpenter.sh" is restricted
+                              rule: self.all(x, x in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !x.find("^([^/]+)").endsWith("karpenter.sh"))
+                            - message: label "karpenter.sh/nodepool" is restricted
+                              rule: self.all(x, x != "karpenter.sh/nodepool")
+                            - message: label "kubernetes.io/hostname" is restricted
+                              rule: self.all(x, x != "kubernetes.io/hostname")
+                            - message: label domain "karpenter.k8s.aws" is restricted
+                              rule: self.all(x, x in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !x.find("^([^/]+)").endsWith("karpenter.k8s.aws"))
+                      type: object
+                    spec:
+                      description: |-
+                        NodeClaimTemplateSpec describes the desired state of the NodeClaim in the Nodepool
+                        NodeClaimTemplateSpec is used in the NodePool's NodeClaimTemplate, with the resource requests omitted since
+                        users are not able to set resource requests in the NodePool.
+                      properties:
+                        expireAfter:
+                          default: 720h
+                          description: |-
+                            ExpireAfter is the duration the controller will wait
+                            before terminating a node, measured from when the node is created. This
+                            is useful to implement features like eventually consistent node upgrade,
+                            memory leak protection, and disruption testing.
+                          pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                          type: string
+                        nodeClassRef:
+                          description: NodeClassRef is a reference to an object that defines provider specific configuration
+                          properties:
+                            group:
+                              description: API version of the referent
+                              pattern: ^[^/]*$
+                              type: string
+                            kind:
+                              description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                              type: string
+                            name:
+                              description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                          required:
+                            - group
+                            - kind
+                            - name
+                          type: object
+                        requirements:
+                          description: Requirements are layered with GetLabels and applied to every node.
+                          items:
+                            description: |-
+                              A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                              and minValues that represent the requirement to have at least that many values.
+                            properties:
+                              key:
+                                description: The label key that the selector applies to.
+                                type: string
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                                x-kubernetes-validations:
+                                  - message: label domain "kubernetes.io" is restricted
+                                    rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                                  - message: label domain "k8s.io" is restricted
+                                    rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                                  - message: label domain "karpenter.sh" is restricted
+                                    rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                                  - message: label "karpenter.sh/nodepool" is restricted
+                                    rule: self != "karpenter.sh/nodepool"
+                                  - message: label "kubernetes.io/hostname" is restricted
+                                    rule: self != "kubernetes.io/hostname"
+                                  - message: label domain "karpenter.k8s.aws" is restricted
+                                    rule: self in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                              minValues:
+                                description: |-
+                                  This field is ALPHA and can be dropped or replaced at any time
+                                  MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                                maximum: 50
+                                minimum: 1
+                                type: integer
+                              operator:
+                                description: |-
+                                  Represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                type: string
+                                enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  - Gt
+                                  - Lt
+                              values:
+                                description: |-
+                                  An array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                  array must have a single element, which will be interpreted as an integer.
+                                  This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          maxItems: 100
+                          type: array
+                          x-kubernetes-validations:
+                            - message: requirements with operator 'In' must have a value defined
+                              rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                            - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                              rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                            - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                              rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                        startupTaints:
+                          description: |-
+                            StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                            within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                            daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                            purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        taints:
+                          description: Taints will be applied to the NodeClaim's node.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        terminationGracePeriod:
+                          description: |-
+                            TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
+
+                            Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
+
+                            This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
+                            When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
+
+                            Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
+                            If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
+                            that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
+
+                            The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
+                            If left undefined, the controller will wait indefinitely for pods to be drained.
+                          pattern: ^([0-9]+(s|m|h))+$
+                          type: string
+                      required:
+                        - nodeClassRef
+                        - requirements
+                      type: object
+                  required:
+                    - spec
+                  type: object
+                weight:
+                  description: |-
+                    Weight is the priority given to the nodepool during scheduling. A higher
+                    numerical weight indicates that this nodepool will be ordered
+                    ahead of other nodepools with lower weights. A nodepool with no weight
+                    will be treated as if it is a nodepool with a weight of 0.
+                  format: int32
+                  maximum: 100
+                  minimum: 1
+                  type: integer
+              required:
+                - template
+              type: object
+            status:
+              description: NodePoolStatus defines the observed state of NodePool
+              properties:
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                resources:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Resources is the list of resources that have been provisioned.
+                  type: object
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .spec.template.spec.nodeClassRef.name
+          name: NodeClass
+          type: string
+        - jsonPath: .spec.weight
+          name: Weight
+          priority: 1
+          type: string
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: NodePool is the Schema for the NodePools API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                NodePoolSpec is the top level nodepool specification. Nodepools
+                launch nodes in response to pods that are unschedulable. A single nodepool
+                is capable of managing a diverse set of nodes. Node properties are determined
+                from a combination of nodepool and pod scheduling constraints.
+              properties:
+                disruption:
+                  default:
+                    consolidationPolicy: WhenUnderutilized
+                    expireAfter: 720h
+                  description: Disruption contains the parameters that relate to Karpenter's disruption logic
+                  properties:
+                    budgets:
+                      default:
+                        - nodes: 10%
+                      description: |-
+                        Budgets is a list of Budgets.
+                        If there are multiple active budgets, Karpenter uses
+                        the most restrictive value. If left undefined,
+                        this will default to one budget with a value to 10%.
+                      items:
+                        description: |-
+                          Budget defines when Karpenter will restrict the
+                          number of Node Claims that can be terminating simultaneously.
+                        properties:
+                          duration:
+                            description: |-
+                              Duration determines how long a Budget is active since each Schedule hit.
+                              Only minutes and hours are accepted, as cron does not work in seconds.
+                              If omitted, the budget is always active.
+                              This is required if Schedule is set.
+                              This regex has an optional 0s at the end since the duration.String() always adds
+                              a 0s at the end.
+                            pattern: ^((([0-9]+(h|m))|([0-9]+h[0-9]+m))(0s)?)$
+                            type: string
+                          nodes:
+                            default: 10%
+                            description: |-
+                              Nodes dictates the maximum number of NodeClaims owned by this NodePool
+                              that can be terminating at once. This is calculated by counting nodes that
+                              have a deletion timestamp set, or are actively being deleted by Karpenter.
+                              This field is required when specifying a budget.
+                              This cannot be of type intstr.IntOrString since kubebuilder doesn't support pattern
+                              checking for int nodes for IntOrString nodes.
+                              Ref: https://github.com/kubernetes-sigs/controller-tools/blob/55efe4be40394a288216dab63156b0a64fb82929/pkg/crd/markers/validation.go#L379-L388
+                            pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
+                            type: string
+                          schedule:
+                            description: |-
+                              Schedule specifies when a budget begins being active, following
+                              the upstream cronjob syntax. If omitted, the budget is always active.
+                              Timezones are not supported.
+                              This field is required if Duration is set.
+                            pattern: ^(@(annually|yearly|monthly|weekly|daily|midnight|hourly))|((.+)\s(.+)\s(.+)\s(.+)\s(.+))$
+                            type: string
+                        required:
+                          - nodes
+                        type: object
+                      maxItems: 50
+                      type: array
+                      x-kubernetes-validations:
+                        - message: '''schedule'' must be set with ''duration'''
+                          rule: self.all(x, has(x.schedule) == has(x.duration))
+                    consolidateAfter:
+                      description: |-
+                        ConsolidateAfter is the duration the controller will wait
+                        before attempting to terminate nodes that are underutilized.
+                        Refer to ConsolidationPolicy for how underutilization is considered.
+                      pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                      type: string
+                    consolidationPolicy:
+                      default: WhenUnderutilized
+                      description: |-
+                        ConsolidationPolicy describes which nodes Karpenter can disrupt through its consolidation
+                        algorithm. This policy defaults to "WhenUnderutilized" if not specified
+                      enum:
+                        - WhenEmpty
+                        - WhenUnderutilized
+                      type: string
+                    expireAfter:
+                      default: 720h
+                      description: |-
+                        ExpireAfter is the duration the controller will wait
+                        before terminating a node, measured from when the node is created. This
+                        is useful to implement features like eventually consistent node upgrade,
+                        memory leak protection, and disruption testing.
+                      pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                      type: string
+                  type: object
+                  x-kubernetes-validations:
+                    - message: consolidateAfter cannot be combined with consolidationPolicy=WhenUnderutilized
+                      rule: 'has(self.consolidateAfter) ? self.consolidationPolicy != ''WhenUnderutilized'' || self.consolidateAfter == ''Never'' : true'
+                    - message: consolidateAfter must be specified with consolidationPolicy=WhenEmpty
+                      rule: 'self.consolidationPolicy == ''WhenEmpty'' ? has(self.consolidateAfter) : true'
+                limits:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Limits define a set of bounds for provisioning capacity.
+                  type: object
+                template:
+                  description: |-
+                    Template contains the template of possibilities for the provisioning logic to launch a NodeClaim with.
+                    NodeClaims launched from this NodePool will often be further constrained than the template specifies.
+                  properties:
+                    metadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Annotations is an unstructured key value map stored with a resource that may be
+                            set by external tools to store and retrieve arbitrary metadata. They are not
+                            queryable and should be preserved when modifying objects.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                            maxLength: 63
+                            pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                          description: |-
+                            Map of string keys and values that can be used to organize and categorize
+                            (scope and select) objects. May match selectors of replication controllers
+                            and services.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
+                          type: object
+                          maxProperties: 100
+                          x-kubernetes-validations:
+                            - message: label domain "kubernetes.io" is restricted
+                              rule: self.all(x, x in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region",  "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || x.find("^([^/]+)").endsWith("node.kubernetes.io") || x.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !x.find("^([^/]+)").endsWith("kubernetes.io"))
+                            - message: label domain "k8s.io" is restricted
+                              rule: self.all(x, x.find("^([^/]+)").endsWith("kops.k8s.io") || !x.find("^([^/]+)").endsWith("k8s.io"))
+                            - message: label domain "karpenter.sh" is restricted
+                              rule: self.all(x, x in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !x.find("^([^/]+)").endsWith("karpenter.sh"))
+                            - message: label "karpenter.sh/nodepool" is restricted
+                              rule: self.all(x, x != "karpenter.sh/nodepool")
+                            - message: label "kubernetes.io/hostname" is restricted
+                              rule: self.all(x, x != "kubernetes.io/hostname")
+                            - message: label domain "karpenter.k8s.aws" is restricted
+                              rule: self.all(x, x in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !x.find("^([^/]+)").endsWith("karpenter.k8s.aws"))
+                      type: object
+                    spec:
+                      description: NodeClaimSpec describes the desired state of the NodeClaim
+                      properties:
+                        kubelet:
+                          description: |-
+                            Kubelet defines args to be used when configuring kubelet on provisioned nodes.
+                            They are a subset of the upstream types, recognizing not all options may be supported.
+                            Wherever possible, the types and names should reflect the upstream kubelet types.
+                          properties:
+                            clusterDNS:
+                              description: |-
+                                clusterDNS is a list of IP addresses for the cluster DNS server.
+                                Note that not all providers may use all addresses.
+                              items:
+                                type: string
+                              type: array
+                            cpuCFSQuota:
+                              description: CPUCFSQuota enables CPU CFS quota enforcement for containers that specify CPU limits.
+                              type: boolean
+                            evictionHard:
+                              additionalProperties:
+                                type: string
+                                pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                              description: EvictionHard is the map of signal names to quantities that define hard eviction thresholds
+                              type: object
+                              x-kubernetes-validations:
+                                - message: valid keys for evictionHard are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                                  rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                            evictionMaxPodGracePeriod:
+                              description: |-
+                                EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in
+                                response to soft eviction thresholds being met.
+                              format: int32
+                              type: integer
+                            evictionSoft:
+                              additionalProperties:
+                                type: string
+                                pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                              description: EvictionSoft is the map of signal names to quantities that define soft eviction thresholds
+                              type: object
+                              x-kubernetes-validations:
+                                - message: valid keys for evictionSoft are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                                  rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                            evictionSoftGracePeriod:
+                              additionalProperties:
+                                type: string
+                              description: EvictionSoftGracePeriod is the map of signal names to quantities that define grace periods for each eviction signal
+                              type: object
+                              x-kubernetes-validations:
+                                - message: valid keys for evictionSoftGracePeriod are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                                  rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                            imageGCHighThresholdPercent:
+                              description: |-
+                                ImageGCHighThresholdPercent is the percent of disk usage after which image
+                                garbage collection is always run. The percent is calculated by dividing this
+                                field value by 100, so this field must be between 0 and 100, inclusive.
+                                When specified, the value must be greater than ImageGCLowThresholdPercent.
+                              format: int32
+                              maximum: 100
+                              minimum: 0
+                              type: integer
+                            imageGCLowThresholdPercent:
+                              description: |-
+                                ImageGCLowThresholdPercent is the percent of disk usage before which image
+                                garbage collection is never run. Lowest disk usage to garbage collect to.
+                                The percent is calculated by dividing this field value by 100,
+                                so the field value must be between 0 and 100, inclusive.
+                                When specified, the value must be less than imageGCHighThresholdPercent
+                              format: int32
+                              maximum: 100
+                              minimum: 0
+                              type: integer
+                            kubeReserved:
+                              additionalProperties:
+                                type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              description: KubeReserved contains resources reserved for Kubernetes system components.
+                              type: object
+                              x-kubernetes-validations:
+                                - message: valid keys for kubeReserved are ['cpu','memory','ephemeral-storage','pid']
+                                  rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                                - message: kubeReserved value cannot be a negative resource quantity
+                                  rule: self.all(x, !self[x].startsWith('-'))
+                            maxPods:
+                              description: |-
+                                MaxPods is an override for the maximum number of pods that can run on
+                                a worker node instance.
+                              format: int32
+                              minimum: 0
+                              type: integer
+                            podsPerCore:
+                              description: |-
+                                PodsPerCore is an override for the number of pods that can run on a worker node
+                                instance based on the number of cpu cores. This value cannot exceed MaxPods, so, if
+                                MaxPods is a lower value, that value will be used.
+                              format: int32
+                              minimum: 0
+                              type: integer
+                            systemReserved:
+                              additionalProperties:
+                                type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              description: SystemReserved contains resources reserved for OS system daemons and kernel memory.
+                              type: object
+                              x-kubernetes-validations:
+                                - message: valid keys for systemReserved are ['cpu','memory','ephemeral-storage','pid']
+                                  rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                                - message: systemReserved value cannot be a negative resource quantity
+                                  rule: self.all(x, !self[x].startsWith('-'))
+                          type: object
+                          x-kubernetes-validations:
+                            - message: imageGCHighThresholdPercent must be greater than imageGCLowThresholdPercent
+                              rule: 'has(self.imageGCHighThresholdPercent) && has(self.imageGCLowThresholdPercent) ?  self.imageGCHighThresholdPercent > self.imageGCLowThresholdPercent  : true'
+                            - message: evictionSoft OwnerKey does not have a matching evictionSoftGracePeriod
+                              rule: has(self.evictionSoft) ? self.evictionSoft.all(e, (e in self.evictionSoftGracePeriod)):true
+                            - message: evictionSoftGracePeriod OwnerKey does not have a matching evictionSoft
+                              rule: has(self.evictionSoftGracePeriod) ? self.evictionSoftGracePeriod.all(e, (e in self.evictionSoft)):true
+                        nodeClassRef:
+                          description: NodeClassRef is a reference to an object that defines provider specific configuration
+                          properties:
+                            apiVersion:
+                              description: API version of the referent
+                              type: string
+                            kind:
+                              description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                              type: string
+                            name:
+                              description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        requirements:
+                          description: Requirements are layered with GetLabels and applied to every node.
+                          items:
+                            description: |-
+                              A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                              and minValues that represent the requirement to have at least that many values.
+                            properties:
+                              key:
+                                description: The label key that the selector applies to.
+                                type: string
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                                x-kubernetes-validations:
+                                  - message: label domain "kubernetes.io" is restricted
+                                    rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                                  - message: label domain "k8s.io" is restricted
+                                    rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                                  - message: label domain "karpenter.sh" is restricted
+                                    rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                                  - message: label "karpenter.sh/nodepool" is restricted
+                                    rule: self != "karpenter.sh/nodepool"
+                                  - message: label "kubernetes.io/hostname" is restricted
+                                    rule: self != "kubernetes.io/hostname"
+                                  - message: label domain "karpenter.k8s.aws" is restricted
+                                    rule: self in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                              minValues:
+                                description: |-
+                                  This field is ALPHA and can be dropped or replaced at any time
+                                  MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                                maximum: 50
+                                minimum: 1
+                                type: integer
+                              operator:
+                                description: |-
+                                  Represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                type: string
+                                enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  - Gt
+                                  - Lt
+                              values:
+                                description: |-
+                                  An array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                  array must have a single element, which will be interpreted as an integer.
+                                  This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          maxItems: 100
+                          type: array
+                          x-kubernetes-validations:
+                            - message: requirements with operator 'In' must have a value defined
+                              rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                            - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                              rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                            - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                              rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                        resources:
+                          description: Resources models the resource requirements for the NodeClaim to launch
+                          properties:
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: Requests describes the minimum required resources for the NodeClaim to launch
+                              type: object
+                          type: object
+                          maxProperties: 0
+                        startupTaints:
+                          description: |-
+                            StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                            within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                            daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                            purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        taints:
+                          description: Taints will be applied to the NodeClaim's node.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                      required:
+                        - nodeClassRef
+                        - requirements
+                      type: object
+                  required:
+                    - spec
+                  type: object
+                weight:
+                  description: |-
+                    Weight is the priority given to the nodepool during scheduling. A higher
+                    numerical weight indicates that this nodepool will be ordered
+                    ahead of other nodepools with lower weights. A nodepool with no weight
+                    will be treated as if it is a nodepool with a weight of 0.
+                  format: int32
+                  maximum: 100
+                  minimum: 1
+                  type: integer
+              required:
+                - template
+              type: object
+            status:
+              description: NodePoolStatus defines the observed state of NodePool
+              properties:
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                resources:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Resources is the list of resources that have been provisioned.
+                  type: object
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+        - v1
+      clientConfig:
+        service:
+          name: karpenter
+          namespace: kube-system
+          port: 8443

--- a/content/projects/karpenter/v1.0.7/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/content/projects/karpenter/v1.0.7/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -1,0 +1,1306 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: ec2nodeclasses.karpenter.k8s.aws
+spec:
+  group: karpenter.k8s.aws
+  names:
+    categories:
+      - karpenter
+    kind: EC2NodeClass
+    listKind: EC2NodeClassList
+    plural: ec2nodeclasses
+    shortNames:
+      - ec2nc
+      - ec2ncs
+    singular: ec2nodeclass
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.role
+          name: Role
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: EC2NodeClass is the Schema for the EC2NodeClass API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                EC2NodeClassSpec is the top level specification for the AWS Karpenter Provider.
+                This will contain configuration necessary to launch instances in AWS.
+              properties:
+                amiFamily:
+                  description: |-
+                    AMIFamily dictates the UserData format and default BlockDeviceMappings used when generating launch templates.
+                    This field is optional when using an alias amiSelectorTerm, and the value will be inferred from the alias'
+                    family. When an alias is specified, this field may only be set to its corresponding family or 'Custom'. If no
+                    alias is specified, this field is required.
+                    NOTE: We ignore the AMIFamily for hashing here because we hash the AMIFamily dynamically by using the alias using
+                    the AMIFamily() helper function
+                  enum:
+                    - AL2
+                    - AL2023
+                    - Bottlerocket
+                    - Custom
+                    - Windows2019
+                    - Windows2022
+                  type: string
+                amiSelectorTerms:
+                  description: AMISelectorTerms is a list of or ami selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      AMISelectorTerm defines selection logic for an ami used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      alias:
+                        description: |-
+                          Alias specifies which EKS optimized AMI to select.
+                          Each alias consists of a family and an AMI version, specified as "family@version".
+                          Valid families include: al2, al2023, bottlerocket, windows2019, and windows2022.
+                          The version can either be pinned to a specific AMI release, with that AMIs version format (ex: "al2023@v20240625" or "bottlerocket@v1.10.0").
+                          The version can also be set to "latest" for any family. Setting the version to latest will result in drift when a new AMI is released. This is **not** recommended for production environments.
+                          Note: The Windows families do **not** support version pinning, and only latest may be used.
+                        maxLength: 30
+                        type: string
+                        x-kubernetes-validations:
+                          - message: '''alias'' is improperly formatted, must match the format ''family@version'''
+                            rule: self.matches('^[a-zA-Z0-9]+@.+$')
+                          - message: 'family is not supported, must be one of the following: ''al2'', ''al2023'', ''bottlerocket'', ''windows2019'', ''windows2022'''
+                            rule: self.split('@')[0] in ['al2','al2023','bottlerocket','windows2019','windows2022']
+                          - message: windows families may only specify version 'latest'
+                            rule: 'self.split(''@'')[0] in [''windows2019'',''windows2022''] ? self.split(''@'')[1] == ''latest'' : true'
+                      id:
+                        description: ID is the ami id in EC2
+                        pattern: ami-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the ami name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      owner:
+                        description: |-
+                          Owner is the owner for the ami.
+                          You can specify a combination of AWS account IDs, "self", "amazon", and "aws-marketplace"
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  minItems: 1
+                  type: array
+                  x-kubernetes-validations:
+                    - message: expected at least one, got none, ['tags', 'id', 'name', 'alias']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name) || has(x.alias))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.exists(x, has(x.id) && (has(x.alias) || has(x.tags) || has(x.name) || has(x.owner)))'
+                    - message: '''alias'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.exists(x, has(x.alias) && (has(x.id) || has(x.tags) || has(x.name) || has(x.owner)))'
+                    - message: '''alias'' is mutually exclusive, cannot be set with a combination of other amiSelectorTerms'
+                      rule: '!(self.exists(x, has(x.alias)) && self.size() != 1)'
+                associatePublicIPAddress:
+                  description: AssociatePublicIPAddress controls if public IP addresses are assigned to instances that are launched with the nodeclass.
+                  type: boolean
+                blockDeviceMappings:
+                  description: BlockDeviceMappings to be applied to provisioned nodes.
+                  items:
+                    properties:
+                      deviceName:
+                        description: The device name (for example, /dev/sdh or xvdh).
+                        type: string
+                      ebs:
+                        description: EBS contains parameters used to automatically set up EBS volumes when an instance is launched.
+                        properties:
+                          deleteOnTermination:
+                            description: DeleteOnTermination indicates whether the EBS volume is deleted on instance termination.
+                            type: boolean
+                          encrypted:
+                            description: |-
+                              Encrypted indicates whether the EBS volume is encrypted. Encrypted volumes can only
+                              be attached to instances that support Amazon EBS encryption. If you are creating
+                              a volume from a snapshot, you can't specify an encryption value.
+                            type: boolean
+                          iops:
+                            description: |-
+                              IOPS is the number of I/O operations per second (IOPS). For gp3, io1, and io2 volumes,
+                              this represents the number of IOPS that are provisioned for the volume. For
+                              gp2 volumes, this represents the baseline performance of the volume and the
+                              rate at which the volume accumulates I/O credits for bursting.
+
+                              The following are the supported values for each volume type:
+
+                                 * gp3: 3,000-16,000 IOPS
+
+                                 * io1: 100-64,000 IOPS
+
+                                 * io2: 100-64,000 IOPS
+
+                              For io1 and io2 volumes, we guarantee 64,000 IOPS only for Instances built
+                              on the Nitro System (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances).
+                              Other instance families guarantee performance up to 32,000 IOPS.
+
+                              This parameter is supported for io1, io2, and gp3 volumes only. This parameter
+                              is not supported for gp2, st1, sc1, or standard volumes.
+                            format: int64
+                            type: integer
+                          kmsKeyID:
+                            description: KMSKeyID (ARN) of the symmetric Key Management Service (KMS) CMK used for encryption.
+                            type: string
+                          snapshotID:
+                            description: SnapshotID is the ID of an EBS snapshot
+                            type: string
+                          throughput:
+                            description: |-
+                              Throughput to provision for a gp3 volume, with a maximum of 1,000 MiB/s.
+                              Valid Range: Minimum value of 125. Maximum value of 1000.
+                            format: int64
+                            type: integer
+                          volumeSize:
+                            description: |-
+                              VolumeSize in `Gi`, `G`, `Ti`, or `T`. You must specify either a snapshot ID or
+                              a volume size. The following are the supported volumes sizes for each volume
+                              type:
+
+                                 * gp2 and gp3: 1-16,384
+
+                                 * io1 and io2: 4-16,384
+
+                                 * st1 and sc1: 125-16,384
+
+                                 * standard: 1-1,024
+                            pattern: ^((?:[1-9][0-9]{0,3}|[1-4][0-9]{4}|[5][0-8][0-9]{3}|59000)Gi|(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|[6][0-3][0-9]{3}|64000)G|([1-9]||[1-5][0-7]|58)Ti|([1-9]||[1-5][0-9]|6[0-3]|64)T)$
+                            type: string
+                          volumeType:
+                            description: |-
+                              VolumeType of the block device.
+                              For more information, see Amazon EBS volume types (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html)
+                              in the Amazon Elastic Compute Cloud User Guide.
+                            enum:
+                              - standard
+                              - io1
+                              - io2
+                              - gp2
+                              - sc1
+                              - st1
+                              - gp3
+                            type: string
+                        type: object
+                        x-kubernetes-validations:
+                          - message: snapshotID or volumeSize must be defined
+                            rule: has(self.snapshotID) || has(self.volumeSize)
+                      rootVolume:
+                        description: |-
+                          RootVolume is a flag indicating if this device is mounted as kubelet root dir. You can
+                          configure at most one root volume in BlockDeviceMappings.
+                        type: boolean
+                    type: object
+                  maxItems: 50
+                  type: array
+                  x-kubernetes-validations:
+                    - message: must have only one blockDeviceMappings with rootVolume
+                      rule: self.filter(x, has(x.rootVolume)?x.rootVolume==true:false).size() <= 1
+                context:
+                  description: |-
+                    Context is a Reserved field in EC2 APIs
+                    https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet.html
+                  type: string
+                detailedMonitoring:
+                  description: DetailedMonitoring controls if detailed monitoring is enabled for instances that are launched
+                  type: boolean
+                instanceProfile:
+                  description: |-
+                    InstanceProfile is the AWS entity that instances use.
+                    This field is mutually exclusive from role.
+                    The instance profile should already have a role assigned to it that Karpenter
+                     has PassRole permission on for instance launch using this instanceProfile to succeed.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: instanceProfile cannot be empty
+                      rule: self != ''
+                instanceStorePolicy:
+                  description: InstanceStorePolicy specifies how to handle instance-store disks.
+                  enum:
+                    - RAID0
+                  type: string
+                kubelet:
+                  description: |-
+                    Kubelet defines args to be used when configuring kubelet on provisioned nodes.
+                    They are a subset of the upstream types, recognizing not all options may be supported.
+                    Wherever possible, the types and names should reflect the upstream kubelet types.
+                  properties:
+                    clusterDNS:
+                      description: |-
+                        clusterDNS is a list of IP addresses for the cluster DNS server.
+                        Note that not all providers may use all addresses.
+                      items:
+                        type: string
+                      type: array
+                    cpuCFSQuota:
+                      description: CPUCFSQuota enables CPU CFS quota enforcement for containers that specify CPU limits.
+                      type: boolean
+                    evictionHard:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionHard is the map of signal names to quantities that define hard eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionHard are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionMaxPodGracePeriod:
+                      description: |-
+                        EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in
+                        response to soft eviction thresholds being met.
+                      format: int32
+                      type: integer
+                    evictionSoft:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionSoft is the map of signal names to quantities that define soft eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoft are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionSoftGracePeriod:
+                      additionalProperties:
+                        type: string
+                      description: EvictionSoftGracePeriod is the map of signal names to quantities that define grace periods for each eviction signal
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoftGracePeriod are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    imageGCHighThresholdPercent:
+                      description: |-
+                        ImageGCHighThresholdPercent is the percent of disk usage after which image
+                        garbage collection is always run. The percent is calculated by dividing this
+                        field value by 100, so this field must be between 0 and 100, inclusive.
+                        When specified, the value must be greater than ImageGCLowThresholdPercent.
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    imageGCLowThresholdPercent:
+                      description: |-
+                        ImageGCLowThresholdPercent is the percent of disk usage before which image
+                        garbage collection is never run. Lowest disk usage to garbage collect to.
+                        The percent is calculated by dividing this field value by 100,
+                        so the field value must be between 0 and 100, inclusive.
+                        When specified, the value must be less than imageGCHighThresholdPercent
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    kubeReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: KubeReserved contains resources reserved for Kubernetes system components.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for kubeReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: kubeReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                    maxPods:
+                      description: |-
+                        MaxPods is an override for the maximum number of pods that can run on
+                        a worker node instance.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    podsPerCore:
+                      description: |-
+                        PodsPerCore is an override for the number of pods that can run on a worker node
+                        instance based on the number of cpu cores. This value cannot exceed MaxPods, so, if
+                        MaxPods is a lower value, that value will be used.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    systemReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: SystemReserved contains resources reserved for OS system daemons and kernel memory.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for systemReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: systemReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                  type: object
+                  x-kubernetes-validations:
+                    - message: imageGCHighThresholdPercent must be greater than imageGCLowThresholdPercent
+                      rule: 'has(self.imageGCHighThresholdPercent) && has(self.imageGCLowThresholdPercent) ?  self.imageGCHighThresholdPercent > self.imageGCLowThresholdPercent  : true'
+                    - message: evictionSoft OwnerKey does not have a matching evictionSoftGracePeriod
+                      rule: has(self.evictionSoft) ? self.evictionSoft.all(e, (e in self.evictionSoftGracePeriod)):true
+                    - message: evictionSoftGracePeriod OwnerKey does not have a matching evictionSoft
+                      rule: has(self.evictionSoftGracePeriod) ? self.evictionSoftGracePeriod.all(e, (e in self.evictionSoft)):true
+                metadataOptions:
+                  default:
+                    httpEndpoint: enabled
+                    httpProtocolIPv6: disabled
+                    httpPutResponseHopLimit: 1
+                    httpTokens: required
+                  description: |-
+                    MetadataOptions for the generated launch template of provisioned nodes.
+
+                    This specifies the exposure of the Instance Metadata Service to
+                    provisioned EC2 nodes. For more information,
+                    see Instance Metadata and User Data
+                    (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
+                    in the Amazon Elastic Compute Cloud User Guide.
+
+                    Refer to recommended, security best practices
+                    (https://aws.github.io/aws-eks-best-practices/security/docs/iam/#restrict-access-to-the-instance-profile-assigned-to-the-worker-node)
+                    for limiting exposure of Instance Metadata and User Data to pods.
+                    If omitted, defaults to httpEndpoint enabled, with httpProtocolIPv6
+                    disabled, with httpPutResponseLimit of 1, and with httpTokens
+                    required.
+                  properties:
+                    httpEndpoint:
+                      default: enabled
+                      description: |-
+                        HTTPEndpoint enables or disables the HTTP metadata endpoint on provisioned
+                        nodes. If metadata options is non-nil, but this parameter is not specified,
+                        the default state is "enabled".
+
+                        If you specify a value of "disabled", instance metadata will not be accessible
+                        on the node.
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpProtocolIPv6:
+                      default: disabled
+                      description: |-
+                        HTTPProtocolIPv6 enables or disables the IPv6 endpoint for the instance metadata
+                        service on provisioned nodes. If metadata options is non-nil, but this parameter
+                        is not specified, the default state is "disabled".
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpPutResponseHopLimit:
+                      default: 1
+                      description: |-
+                        HTTPPutResponseHopLimit is the desired HTTP PUT response hop limit for
+                        instance metadata requests. The larger the number, the further instance
+                        metadata requests can travel. Possible values are integers from 1 to 64.
+                        If metadata options is non-nil, but this parameter is not specified, the
+                        default value is 1.
+                      format: int64
+                      maximum: 64
+                      minimum: 1
+                      type: integer
+                    httpTokens:
+                      default: required
+                      description: |-
+                        HTTPTokens determines the state of token usage for instance metadata
+                        requests. If metadata options is non-nil, but this parameter is not
+                        specified, the default state is "required".
+
+                        If the state is optional, one can choose to retrieve instance metadata with
+                        or without a signed token header on the request. If one retrieves the IAM
+                        role credentials without a token, the version 1.0 role credentials are
+                        returned. If one retrieves the IAM role credentials using a valid signed
+                        token, the version 2.0 role credentials are returned.
+
+                        If the state is "required", one must send a signed token header with any
+                        instance metadata retrieval requests. In this state, retrieving the IAM
+                        role credentials always returns the version 2.0 credentials; the version
+                        1.0 credentials are not available.
+                      enum:
+                        - required
+                        - optional
+                      type: string
+                  type: object
+                role:
+                  description: |-
+                    Role is the AWS identity that nodes use. This field is immutable.
+                    This field is mutually exclusive from instanceProfile.
+                    Marking this field as immutable avoids concerns around terminating managed instance profiles from running instances.
+                    This field may be made mutable in the future, assuming the correct garbage collection and drift handling is implemented
+                    for the old instance profiles on an update.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: role cannot be empty
+                      rule: self != ''
+                    - message: immutable field changed
+                      rule: self == oldSelf
+                securityGroupSelectorTerms:
+                  description: SecurityGroupSelectorTerms is a list of or security group selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SecurityGroupSelectorTerm defines selection logic for a security group used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the security group id in EC2
+                        pattern: sg-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the security group name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: securityGroupSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id', 'name']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && (has(x.tags) || has(x.name)))'
+                    - message: '''name'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.name) && (has(x.tags) || has(x.id)))'
+                subnetSelectorTerms:
+                  description: SubnetSelectorTerms is a list of or subnet selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SubnetSelectorTerm defines selection logic for a subnet used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the subnet id in EC2
+                        pattern: subnet-[0-9a-z]+
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: subnetSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id']
+                      rule: self.all(x, has(x.tags) || has(x.id))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in subnetSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && has(x.tags))'
+                tags:
+                  additionalProperties:
+                    type: string
+                  description: Tags to be applied on ec2 resources like instances and launch templates.
+                  type: object
+                  x-kubernetes-validations:
+                    - message: empty tag keys aren't supported
+                      rule: self.all(k, k != '')
+                    - message: tag contains a restricted tag matching eks:eks-cluster-name
+                      rule: self.all(k, k !='eks:eks-cluster-name')
+                    - message: tag contains a restricted tag matching kubernetes.io/cluster/
+                      rule: self.all(k, !k.startsWith('kubernetes.io/cluster') )
+                    - message: tag contains a restricted tag matching karpenter.sh/nodepool
+                      rule: self.all(k, k != 'karpenter.sh/nodepool')
+                    - message: tag contains a restricted tag matching karpenter.sh/nodeclaim
+                      rule: self.all(k, k !='karpenter.sh/nodeclaim')
+                    - message: tag contains a restricted tag matching karpenter.k8s.aws/ec2nodeclass
+                      rule: self.all(k, k !='karpenter.k8s.aws/ec2nodeclass')
+                userData:
+                  description: |-
+                    UserData to be applied to the provisioned nodes.
+                    It must be in the appropriate format based on the AMIFamily in use. Karpenter will merge certain fields into
+                    this UserData to ensure nodes are being provisioned with the correct configuration.
+                  type: string
+              required:
+                - amiSelectorTerms
+                - securityGroupSelectorTerms
+                - subnetSelectorTerms
+              type: object
+              x-kubernetes-validations:
+                - message: must specify exactly one of ['role', 'instanceProfile']
+                  rule: (has(self.role) && !has(self.instanceProfile)) || (!has(self.role) && has(self.instanceProfile))
+                - message: changing from 'instanceProfile' to 'role' is not supported. You must delete and recreate this node class if you want to change this.
+                  rule: (has(oldSelf.role) && has(self.role)) || (has(oldSelf.instanceProfile) && has(self.instanceProfile))
+                - message: if set, amiFamily must be 'AL2' or 'Custom' when using an AL2 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''al2'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''AL2'') : true)'
+                - message: if set, amiFamily must be 'AL2023' or 'Custom' when using an AL2023 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''al2023'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''AL2023'') : true)'
+                - message: if set, amiFamily must be 'Bottlerocket' or 'Custom' when using a Bottlerocket alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''bottlerocket'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Bottlerocket'') : true)'
+                - message: if set, amiFamily must be 'Windows2019' or 'Custom' when using a Windows2019 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''windows2019'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Windows2019'') : true)'
+                - message: if set, amiFamily must be 'Windows2022' or 'Custom' when using a Windows2022 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''windows2022'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Windows2022'') : true)'
+                - message: must specify amiFamily if amiSelectorTerms does not contain an alias
+                  rule: 'self.amiSelectorTerms.exists(x, has(x.alias)) ? true : has(self.amiFamily)'
+            status:
+              description: EC2NodeClassStatus contains the resolved state of the EC2NodeClass
+              properties:
+                amis:
+                  description: |-
+                    AMI contains the current AMI values that are available to the
+                    cluster under the AMI selectors.
+                  items:
+                    description: AMI contains resolved AMI selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the AMI
+                        type: string
+                      name:
+                        description: Name of the AMI
+                        type: string
+                      requirements:
+                        description: Requirements of the AMI to be utilized on an instance type
+                        items:
+                          description: |-
+                            A node selector requirement is a selector that contains values, a key, and an operator
+                            that relates the key and values.
+                          properties:
+                            key:
+                              description: The label key that the selector applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                Represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                              type: string
+                            values:
+                              description: |-
+                                An array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. If the operator is Gt or Lt, the values
+                                array must have a single element, which will be interpreted as an integer.
+                                This array is replaced during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                            - key
+                            - operator
+                          type: object
+                        type: array
+                    required:
+                      - id
+                      - requirements
+                    type: object
+                  type: array
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                instanceProfile:
+                  description: InstanceProfile contains the resolved instance profile for the role
+                  type: string
+                securityGroups:
+                  description: |-
+                    SecurityGroups contains the current Security Groups values that are available to the
+                    cluster under the SecurityGroups selectors.
+                  items:
+                    description: SecurityGroup contains resolved SecurityGroup selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the security group
+                        type: string
+                      name:
+                        description: Name of the security group
+                        type: string
+                    required:
+                      - id
+                    type: object
+                  type: array
+                subnets:
+                  description: |-
+                    Subnets contains the current Subnet values that are available to the
+                    cluster under the subnet selectors.
+                  items:
+                    description: Subnet contains resolved Subnet selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the subnet
+                        type: string
+                      zone:
+                        description: The associated availability zone
+                        type: string
+                      zoneID:
+                        description: The associated availability zone ID
+                        type: string
+                    required:
+                      - id
+                      - zone
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: EC2NodeClass is the Schema for the EC2NodeClass API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                EC2NodeClassSpec is the top level specification for the AWS Karpenter Provider.
+                This will contain configuration necessary to launch instances in AWS.
+              properties:
+                amiFamily:
+                  description: AMIFamily is the AMI family that instances use.
+                  enum:
+                    - AL2
+                    - AL2023
+                    - Bottlerocket
+                    - Ubuntu
+                    - Custom
+                    - Windows2019
+                    - Windows2022
+                  type: string
+                amiSelectorTerms:
+                  description: AMISelectorTerms is a list of or ami selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      AMISelectorTerm defines selection logic for an ami used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the ami id in EC2
+                        pattern: ami-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the ami name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      owner:
+                        description: |-
+                          Owner is the owner for the ami.
+                          You can specify a combination of AWS account IDs, "self", "amazon", and "aws-marketplace"
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: expected at least one, got none, ['tags', 'id', 'name']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && (has(x.tags) || has(x.name) || has(x.owner)))'
+                associatePublicIPAddress:
+                  description: AssociatePublicIPAddress controls if public IP addresses are assigned to instances that are launched with the nodeclass.
+                  type: boolean
+                blockDeviceMappings:
+                  description: BlockDeviceMappings to be applied to provisioned nodes.
+                  items:
+                    properties:
+                      deviceName:
+                        description: The device name (for example, /dev/sdh or xvdh).
+                        type: string
+                      ebs:
+                        description: EBS contains parameters used to automatically set up EBS volumes when an instance is launched.
+                        properties:
+                          deleteOnTermination:
+                            description: DeleteOnTermination indicates whether the EBS volume is deleted on instance termination.
+                            type: boolean
+                          encrypted:
+                            description: |-
+                              Encrypted indicates whether the EBS volume is encrypted. Encrypted volumes can only
+                              be attached to instances that support Amazon EBS encryption. If you are creating
+                              a volume from a snapshot, you can't specify an encryption value.
+                            type: boolean
+                          iops:
+                            description: |-
+                              IOPS is the number of I/O operations per second (IOPS). For gp3, io1, and io2 volumes,
+                              this represents the number of IOPS that are provisioned for the volume. For
+                              gp2 volumes, this represents the baseline performance of the volume and the
+                              rate at which the volume accumulates I/O credits for bursting.
+
+                              The following are the supported values for each volume type:
+
+                                 * gp3: 3,000-16,000 IOPS
+
+                                 * io1: 100-64,000 IOPS
+
+                                 * io2: 100-64,000 IOPS
+
+                              For io1 and io2 volumes, we guarantee 64,000 IOPS only for Instances built
+                              on the Nitro System (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances).
+                              Other instance families guarantee performance up to 32,000 IOPS.
+
+                              This parameter is supported for io1, io2, and gp3 volumes only. This parameter
+                              is not supported for gp2, st1, sc1, or standard volumes.
+                            format: int64
+                            type: integer
+                          kmsKeyID:
+                            description: KMSKeyID (ARN) of the symmetric Key Management Service (KMS) CMK used for encryption.
+                            type: string
+                          snapshotID:
+                            description: SnapshotID is the ID of an EBS snapshot
+                            type: string
+                          throughput:
+                            description: |-
+                              Throughput to provision for a gp3 volume, with a maximum of 1,000 MiB/s.
+                              Valid Range: Minimum value of 125. Maximum value of 1000.
+                            format: int64
+                            type: integer
+                          volumeSize:
+                            description: |-
+                              VolumeSize in `Gi`, `G`, `Ti`, or `T`. You must specify either a snapshot ID or
+                              a volume size. The following are the supported volumes sizes for each volume
+                              type:
+
+                                 * gp2 and gp3: 1-16,384
+
+                                 * io1 and io2: 4-16,384
+
+                                 * st1 and sc1: 125-16,384
+
+                                 * standard: 1-1,024
+                            pattern: ^((?:[1-9][0-9]{0,3}|[1-4][0-9]{4}|[5][0-8][0-9]{3}|59000)Gi|(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|[6][0-3][0-9]{3}|64000)G|([1-9]||[1-5][0-7]|58)Ti|([1-9]||[1-5][0-9]|6[0-3]|64)T)$
+                            type: string
+                          volumeType:
+                            description: |-
+                              VolumeType of the block device.
+                              For more information, see Amazon EBS volume types (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html)
+                              in the Amazon Elastic Compute Cloud User Guide.
+                            enum:
+                              - standard
+                              - io1
+                              - io2
+                              - gp2
+                              - sc1
+                              - st1
+                              - gp3
+                            type: string
+                        type: object
+                        x-kubernetes-validations:
+                          - message: snapshotID or volumeSize must be defined
+                            rule: has(self.snapshotID) || has(self.volumeSize)
+                      rootVolume:
+                        description: |-
+                          RootVolume is a flag indicating if this device is mounted as kubelet root dir. You can
+                          configure at most one root volume in BlockDeviceMappings.
+                        type: boolean
+                    type: object
+                  maxItems: 50
+                  type: array
+                  x-kubernetes-validations:
+                    - message: must have only one blockDeviceMappings with rootVolume
+                      rule: self.filter(x, has(x.rootVolume)?x.rootVolume==true:false).size() <= 1
+                context:
+                  description: |-
+                    Context is a Reserved field in EC2 APIs
+                    https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet.html
+                  type: string
+                detailedMonitoring:
+                  description: DetailedMonitoring controls if detailed monitoring is enabled for instances that are launched
+                  type: boolean
+                instanceProfile:
+                  description: |-
+                    InstanceProfile is the AWS entity that instances use.
+                    This field is mutually exclusive from role.
+                    The instance profile should already have a role assigned to it that Karpenter
+                     has PassRole permission on for instance launch using this instanceProfile to succeed.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: instanceProfile cannot be empty
+                      rule: self != ''
+                instanceStorePolicy:
+                  description: InstanceStorePolicy specifies how to handle instance-store disks.
+                  enum:
+                    - RAID0
+                  type: string
+                metadataOptions:
+                  default:
+                    httpEndpoint: enabled
+                    httpProtocolIPv6: disabled
+                    httpPutResponseHopLimit: 1
+                    httpTokens: required
+                  description: |-
+                    MetadataOptions for the generated launch template of provisioned nodes.
+
+                    This specifies the exposure of the Instance Metadata Service to
+                    provisioned EC2 nodes. For more information,
+                    see Instance Metadata and User Data
+                    (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
+                    in the Amazon Elastic Compute Cloud User Guide.
+
+                    Refer to recommended, security best practices
+                    (https://aws.github.io/aws-eks-best-practices/security/docs/iam/#restrict-access-to-the-instance-profile-assigned-to-the-worker-node)
+                    for limiting exposure of Instance Metadata and User Data to pods.
+                    If omitted, defaults to httpEndpoint enabled, with httpProtocolIPv6
+                    disabled, with httpPutResponseLimit of 1, and with httpTokens
+                    required.
+                  properties:
+                    httpEndpoint:
+                      default: enabled
+                      description: |-
+                        HTTPEndpoint enables or disables the HTTP metadata endpoint on provisioned
+                        nodes. If metadata options is non-nil, but this parameter is not specified,
+                        the default state is "enabled".
+
+                        If you specify a value of "disabled", instance metadata will not be accessible
+                        on the node.
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpProtocolIPv6:
+                      default: disabled
+                      description: |-
+                        HTTPProtocolIPv6 enables or disables the IPv6 endpoint for the instance metadata
+                        service on provisioned nodes. If metadata options is non-nil, but this parameter
+                        is not specified, the default state is "disabled".
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpPutResponseHopLimit:
+                      default: 2
+                      description: |-
+                        HTTPPutResponseHopLimit is the desired HTTP PUT response hop limit for
+                        instance metadata requests. The larger the number, the further instance
+                        metadata requests can travel. Possible values are integers from 1 to 64.
+                        If metadata options is non-nil, but this parameter is not specified, the
+                        default value is 2.
+                      format: int64
+                      maximum: 64
+                      minimum: 1
+                      type: integer
+                    httpTokens:
+                      default: required
+                      description: |-
+                        HTTPTokens determines the state of token usage for instance metadata
+                        requests. If metadata options is non-nil, but this parameter is not
+                        specified, the default state is "required".
+
+                        If the state is optional, one can choose to retrieve instance metadata with
+                        or without a signed token header on the request. If one retrieves the IAM
+                        role credentials without a token, the version 1.0 role credentials are
+                        returned. If one retrieves the IAM role credentials using a valid signed
+                        token, the version 2.0 role credentials are returned.
+
+                        If the state is "required", one must send a signed token header with any
+                        instance metadata retrieval requests. In this state, retrieving the IAM
+                        role credentials always returns the version 2.0 credentials; the version
+                        1.0 credentials are not available.
+                      enum:
+                        - required
+                        - optional
+                      type: string
+                  type: object
+                role:
+                  description: |-
+                    Role is the AWS identity that nodes use. This field is immutable.
+                    This field is mutually exclusive from instanceProfile.
+                    Marking this field as immutable avoids concerns around terminating managed instance profiles from running instances.
+                    This field may be made mutable in the future, assuming the correct garbage collection and drift handling is implemented
+                    for the old instance profiles on an update.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: role cannot be empty
+                      rule: self != ''
+                    - message: immutable field changed
+                      rule: self == oldSelf
+                securityGroupSelectorTerms:
+                  description: SecurityGroupSelectorTerms is a list of or security group selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SecurityGroupSelectorTerm defines selection logic for a security group used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the security group id in EC2
+                        pattern: sg-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the security group name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: securityGroupSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id', 'name']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && (has(x.tags) || has(x.name)))'
+                    - message: '''name'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.name) && (has(x.tags) || has(x.id)))'
+                subnetSelectorTerms:
+                  description: SubnetSelectorTerms is a list of or subnet selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SubnetSelectorTerm defines selection logic for a subnet used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the subnet id in EC2
+                        pattern: subnet-[0-9a-z]+
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: subnetSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id']
+                      rule: self.all(x, has(x.tags) || has(x.id))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in subnetSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && has(x.tags))'
+                tags:
+                  additionalProperties:
+                    type: string
+                  description: Tags to be applied on ec2 resources like instances and launch templates.
+                  type: object
+                  x-kubernetes-validations:
+                    - message: empty tag keys aren't supported
+                      rule: self.all(k, k != '')
+                    - message: tag contains a restricted tag matching kubernetes.io/cluster/
+                      rule: self.all(k, !k.startsWith('kubernetes.io/cluster') )
+                    - message: tag contains a restricted tag matching karpenter.sh/nodepool
+                      rule: self.all(k, k != 'karpenter.sh/nodepool')
+                    - message: tag contains a restricted tag matching karpenter.sh/managed-by
+                      rule: self.all(k, k !='karpenter.sh/managed-by')
+                    - message: tag contains a restricted tag matching karpenter.sh/nodeclaim
+                      rule: self.all(k, k !='karpenter.sh/nodeclaim')
+                    - message: tag contains a restricted tag matching karpenter.k8s.aws/ec2nodeclass
+                      rule: self.all(k, k !='karpenter.k8s.aws/ec2nodeclass')
+                userData:
+                  description: |-
+                    UserData to be applied to the provisioned nodes.
+                    It must be in the appropriate format based on the AMIFamily in use. Karpenter will merge certain fields into
+                    this UserData to ensure nodes are being provisioned with the correct configuration.
+                  type: string
+              required:
+                - amiFamily
+                - securityGroupSelectorTerms
+                - subnetSelectorTerms
+              type: object
+              x-kubernetes-validations:
+                - message: amiSelectorTerms is required when amiFamily == 'Custom'
+                  rule: 'self.amiFamily == ''Custom'' ? self.amiSelectorTerms.size() != 0 : true'
+                - message: must specify exactly one of ['role', 'instanceProfile']
+                  rule: (has(self.role) && !has(self.instanceProfile)) || (!has(self.role) && has(self.instanceProfile))
+                - message: changing from 'instanceProfile' to 'role' is not supported. You must delete and recreate this node class if you want to change this.
+                  rule: (has(oldSelf.role) && has(self.role)) || (has(oldSelf.instanceProfile) && has(self.instanceProfile))
+            status:
+              description: EC2NodeClassStatus contains the resolved state of the EC2NodeClass
+              properties:
+                amis:
+                  description: |-
+                    AMI contains the current AMI values that are available to the
+                    cluster under the AMI selectors.
+                  items:
+                    description: AMI contains resolved AMI selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the AMI
+                        type: string
+                      name:
+                        description: Name of the AMI
+                        type: string
+                      requirements:
+                        description: Requirements of the AMI to be utilized on an instance type
+                        items:
+                          description: |-
+                            A node selector requirement is a selector that contains values, a key, and an operator
+                            that relates the key and values.
+                          properties:
+                            key:
+                              description: The label key that the selector applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                Represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                              type: string
+                            values:
+                              description: |-
+                                An array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. If the operator is Gt or Lt, the values
+                                array must have a single element, which will be interpreted as an integer.
+                                This array is replaced during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                            - key
+                            - operator
+                          type: object
+                        type: array
+                    required:
+                      - id
+                      - requirements
+                    type: object
+                  type: array
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                instanceProfile:
+                  description: InstanceProfile contains the resolved instance profile for the role
+                  type: string
+                securityGroups:
+                  description: |-
+                    SecurityGroups contains the current Security Groups values that are available to the
+                    cluster under the SecurityGroups selectors.
+                  items:
+                    description: SecurityGroup contains resolved SecurityGroup selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the security group
+                        type: string
+                      name:
+                        description: Name of the security group
+                        type: string
+                    required:
+                      - id
+                    type: object
+                  type: array
+                subnets:
+                  description: |-
+                    Subnets contains the current Subnet values that are available to the
+                    cluster under the subnet selectors.
+                  items:
+                    description: Subnet contains resolved Subnet selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the subnet
+                        type: string
+                      zone:
+                        description: The associated availability zone
+                        type: string
+                      zoneID:
+                        description: The associated availability zone ID
+                        type: string
+                    required:
+                      - id
+                      - zone
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+        - v1
+      clientConfig:
+        service:
+          name: karpenter
+          namespace: kube-system
+          port: 8443

--- a/content/projects/karpenter/v1.0.7/karpenter.sh_nodeclaims.yaml
+++ b/content/projects/karpenter/v1.0.7/karpenter.sh_nodeclaims.yaml
@@ -1,0 +1,829 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: nodeclaims.karpenter.sh
+spec:
+  group: karpenter.sh
+  names:
+    categories:
+      - karpenter
+    kind: NodeClaim
+    listKind: NodeClaimList
+    plural: nodeclaims
+    singular: nodeclaim
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.labels.node\.kubernetes\.io/instance-type
+          name: Type
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/capacity-type
+          name: Capacity
+          type: string
+        - jsonPath: .metadata.labels.topology\.kubernetes\.io/zone
+          name: Zone
+          type: string
+        - jsonPath: .status.nodeName
+          name: Node
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .status.providerID
+          name: ID
+          priority: 1
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/nodepool
+          name: NodePool
+          priority: 1
+          type: string
+        - jsonPath: .spec.nodeClassRef.name
+          name: NodeClass
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: NodeClaim is the Schema for the NodeClaims API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: NodeClaimSpec describes the desired state of the NodeClaim
+              properties:
+                expireAfter:
+                  default: 720h
+                  description: |-
+                    ExpireAfter is the duration the controller will wait
+                    before terminating a node, measured from when the node is created. This
+                    is useful to implement features like eventually consistent node upgrade,
+                    memory leak protection, and disruption testing.
+                  pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                  type: string
+                nodeClassRef:
+                  description: NodeClassRef is a reference to an object that defines provider specific configuration
+                  properties:
+                    group:
+                      description: API version of the referent
+                      pattern: ^[^/]*$
+                      type: string
+                    kind:
+                      description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                      type: string
+                    name:
+                      description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                      type: string
+                  required:
+                    - group
+                    - kind
+                    - name
+                  type: object
+                requirements:
+                  description: Requirements are layered with GetLabels and applied to every node.
+                  items:
+                    description: |-
+                      A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                      and minValues that represent the requirement to have at least that many values.
+                    properties:
+                      key:
+                        description: The label key that the selector applies to.
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                        x-kubernetes-validations:
+                          - message: label domain "kubernetes.io" is restricted
+                            rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                          - message: label domain "k8s.io" is restricted
+                            rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                          - message: label domain "karpenter.sh" is restricted
+                            rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                          - message: label "kubernetes.io/hostname" is restricted
+                            rule: self != "kubernetes.io/hostname"
+                          - message: label domain "karpenter.k8s.aws" is restricted
+                            rule: self in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                      minValues:
+                        description: |-
+                          This field is ALPHA and can be dropped or replaced at any time
+                          MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                        maximum: 50
+                        minimum: 1
+                        type: integer
+                      operator:
+                        description: |-
+                          Represents a key's relationship to a set of values.
+                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                        type: string
+                        enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          - Gt
+                          - Lt
+                      values:
+                        description: |-
+                          An array of string values. If the operator is In or NotIn,
+                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                          the values array must be empty. If the operator is Gt or Lt, the values
+                          array must have a single element, which will be interpreted as an integer.
+                          This array is replaced during a strategic merge patch.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                        maxLength: 63
+                        pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                    required:
+                      - key
+                      - operator
+                    type: object
+                  maxItems: 100
+                  type: array
+                  x-kubernetes-validations:
+                    - message: requirements with operator 'In' must have a value defined
+                      rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                    - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                      rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                    - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                      rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                resources:
+                  description: Resources models the resource requirements for the NodeClaim to launch
+                  properties:
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: Requests describes the minimum required resources for the NodeClaim to launch
+                      type: object
+                  type: object
+                startupTaints:
+                  description: |-
+                    StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                    within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                    daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                    purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                taints:
+                  description: Taints will be applied to the NodeClaim's node.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                terminationGracePeriod:
+                  description: |-
+                    TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
+
+                    Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
+
+                    This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
+                    When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
+
+                    Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
+                    If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
+                    that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
+
+                    The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
+                    If left undefined, the controller will wait indefinitely for pods to be drained.
+                  pattern: ^([0-9]+(s|m|h))+$
+                  type: string
+              required:
+                - nodeClassRef
+                - requirements
+              type: object
+              x-kubernetes-validations:
+                - message: spec is immutable
+                  rule: self == oldSelf
+            status:
+              description: NodeClaimStatus defines the observed state of NodeClaim
+              properties:
+                allocatable:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Allocatable is the estimated allocatable capacity of the node
+                  type: object
+                capacity:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Capacity is the estimated full capacity of the node
+                  type: object
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        pattern: ^([A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?|)$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - status
+                      - type
+                    type: object
+                  type: array
+                imageID:
+                  description: ImageID is an identifier for the image that runs on the node
+                  type: string
+                lastPodEventTime:
+                  description: |-
+                    LastPodEventTime is updated with the last time a pod was scheduled
+                    or removed from the node. A pod going terminal or terminating
+                    is also considered as removed.
+                  format: date-time
+                  type: string
+                nodeName:
+                  description: NodeName is the name of the corresponding node object
+                  type: string
+                providerID:
+                  description: ProviderID of the corresponding node object
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.labels.node\.kubernetes\.io/instance-type
+          name: Type
+          type: string
+        - jsonPath: .metadata.labels.topology\.kubernetes\.io/zone
+          name: Zone
+          type: string
+        - jsonPath: .status.nodeName
+          name: Node
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .metadata.labels.karpenter\.sh/capacity-type
+          name: Capacity
+          priority: 1
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/nodepool
+          name: NodePool
+          priority: 1
+          type: string
+        - jsonPath: .spec.nodeClassRef.name
+          name: NodeClass
+          priority: 1
+          type: string
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: NodeClaim is the Schema for the NodeClaims API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: NodeClaimSpec describes the desired state of the NodeClaim
+              properties:
+                kubelet:
+                  description: |-
+                    Kubelet defines args to be used when configuring kubelet on provisioned nodes.
+                    They are a subset of the upstream types, recognizing not all options may be supported.
+                    Wherever possible, the types and names should reflect the upstream kubelet types.
+                  properties:
+                    clusterDNS:
+                      description: |-
+                        clusterDNS is a list of IP addresses for the cluster DNS server.
+                        Note that not all providers may use all addresses.
+                      items:
+                        type: string
+                      type: array
+                    cpuCFSQuota:
+                      description: CPUCFSQuota enables CPU CFS quota enforcement for containers that specify CPU limits.
+                      type: boolean
+                    evictionHard:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionHard is the map of signal names to quantities that define hard eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionHard are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionMaxPodGracePeriod:
+                      description: |-
+                        EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in
+                        response to soft eviction thresholds being met.
+                      format: int32
+                      type: integer
+                    evictionSoft:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionSoft is the map of signal names to quantities that define soft eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoft are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionSoftGracePeriod:
+                      additionalProperties:
+                        type: string
+                      description: EvictionSoftGracePeriod is the map of signal names to quantities that define grace periods for each eviction signal
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoftGracePeriod are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    imageGCHighThresholdPercent:
+                      description: |-
+                        ImageGCHighThresholdPercent is the percent of disk usage after which image
+                        garbage collection is always run. The percent is calculated by dividing this
+                        field value by 100, so this field must be between 0 and 100, inclusive.
+                        When specified, the value must be greater than ImageGCLowThresholdPercent.
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    imageGCLowThresholdPercent:
+                      description: |-
+                        ImageGCLowThresholdPercent is the percent of disk usage before which image
+                        garbage collection is never run. Lowest disk usage to garbage collect to.
+                        The percent is calculated by dividing this field value by 100,
+                        so the field value must be between 0 and 100, inclusive.
+                        When specified, the value must be less than imageGCHighThresholdPercent
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    kubeReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: KubeReserved contains resources reserved for Kubernetes system components.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for kubeReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: kubeReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                    maxPods:
+                      description: |-
+                        MaxPods is an override for the maximum number of pods that can run on
+                        a worker node instance.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    podsPerCore:
+                      description: |-
+                        PodsPerCore is an override for the number of pods that can run on a worker node
+                        instance based on the number of cpu cores. This value cannot exceed MaxPods, so, if
+                        MaxPods is a lower value, that value will be used.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    systemReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: SystemReserved contains resources reserved for OS system daemons and kernel memory.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for systemReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: systemReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                  type: object
+                  x-kubernetes-validations:
+                    - message: imageGCHighThresholdPercent must be greater than imageGCLowThresholdPercent
+                      rule: 'has(self.imageGCHighThresholdPercent) && has(self.imageGCLowThresholdPercent) ?  self.imageGCHighThresholdPercent > self.imageGCLowThresholdPercent  : true'
+                    - message: evictionSoft OwnerKey does not have a matching evictionSoftGracePeriod
+                      rule: has(self.evictionSoft) ? self.evictionSoft.all(e, (e in self.evictionSoftGracePeriod)):true
+                    - message: evictionSoftGracePeriod OwnerKey does not have a matching evictionSoft
+                      rule: has(self.evictionSoftGracePeriod) ? self.evictionSoftGracePeriod.all(e, (e in self.evictionSoft)):true
+                nodeClassRef:
+                  description: NodeClassRef is a reference to an object that defines provider specific configuration
+                  properties:
+                    apiVersion:
+                      description: API version of the referent
+                      type: string
+                    kind:
+                      description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                      type: string
+                    name:
+                      description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                      type: string
+                  required:
+                    - name
+                  type: object
+                requirements:
+                  description: Requirements are layered with GetLabels and applied to every node.
+                  items:
+                    description: |-
+                      A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                      and minValues that represent the requirement to have at least that many values.
+                    properties:
+                      key:
+                        description: The label key that the selector applies to.
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                        x-kubernetes-validations:
+                          - message: label domain "kubernetes.io" is restricted
+                            rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                          - message: label domain "k8s.io" is restricted
+                            rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                          - message: label domain "karpenter.sh" is restricted
+                            rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                          - message: label "kubernetes.io/hostname" is restricted
+                            rule: self != "kubernetes.io/hostname"
+                          - message: label domain "karpenter.k8s.aws" is restricted
+                            rule: self in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                      minValues:
+                        description: |-
+                          This field is ALPHA and can be dropped or replaced at any time
+                          MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                        maximum: 50
+                        minimum: 1
+                        type: integer
+                      operator:
+                        description: |-
+                          Represents a key's relationship to a set of values.
+                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                        type: string
+                        enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          - Gt
+                          - Lt
+                      values:
+                        description: |-
+                          An array of string values. If the operator is In or NotIn,
+                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                          the values array must be empty. If the operator is Gt or Lt, the values
+                          array must have a single element, which will be interpreted as an integer.
+                          This array is replaced during a strategic merge patch.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                        maxLength: 63
+                        pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                    required:
+                      - key
+                      - operator
+                    type: object
+                  maxItems: 100
+                  type: array
+                  x-kubernetes-validations:
+                    - message: requirements with operator 'In' must have a value defined
+                      rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                    - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                      rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                    - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                      rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                resources:
+                  description: Resources models the resource requirements for the NodeClaim to launch
+                  properties:
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: Requests describes the minimum required resources for the NodeClaim to launch
+                      type: object
+                  type: object
+                startupTaints:
+                  description: |-
+                    StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                    within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                    daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                    purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                taints:
+                  description: Taints will be applied to the NodeClaim's node.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+              required:
+                - nodeClassRef
+                - requirements
+              type: object
+            status:
+              description: NodeClaimStatus defines the observed state of NodeClaim
+              properties:
+                allocatable:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Allocatable is the estimated allocatable capacity of the node
+                  type: object
+                capacity:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Capacity is the estimated full capacity of the node
+                  type: object
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        pattern: ^([A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?|)$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - status
+                      - type
+                    type: object
+                  type: array
+                imageID:
+                  description: ImageID is an identifier for the image that runs on the node
+                  type: string
+                nodeName:
+                  description: NodeName is the name of the corresponding node object
+                  type: string
+                providerID:
+                  description: ProviderID of the corresponding node object
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+        - v1
+      clientConfig:
+        service:
+          name: karpenter
+          namespace: kube-system
+          port: 8443

--- a/content/projects/karpenter/v1.0.7/karpenter.sh_nodepools.yaml
+++ b/content/projects/karpenter/v1.0.7/karpenter.sh_nodepools.yaml
@@ -1,0 +1,1082 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: nodepools.karpenter.sh
+spec:
+  group: karpenter.sh
+  names:
+    categories:
+      - karpenter
+    kind: NodePool
+    listKind: NodePoolList
+    plural: nodepools
+    singular: nodepool
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.template.spec.nodeClassRef.name
+          name: NodeClass
+          type: string
+        - jsonPath: .status.resources.nodes
+          name: Nodes
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.weight
+          name: Weight
+          priority: 1
+          type: integer
+        - jsonPath: .status.resources.cpu
+          name: CPU
+          priority: 1
+          type: string
+        - jsonPath: .status.resources.memory
+          name: Memory
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: NodePool is the Schema for the NodePools API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                NodePoolSpec is the top level nodepool specification. Nodepools
+                launch nodes in response to pods that are unschedulable. A single nodepool
+                is capable of managing a diverse set of nodes. Node properties are determined
+                from a combination of nodepool and pod scheduling constraints.
+              properties:
+                disruption:
+                  default:
+                    consolidateAfter: 0s
+                  description: Disruption contains the parameters that relate to Karpenter's disruption logic
+                  properties:
+                    budgets:
+                      default:
+                        - nodes: 10%
+                      description: |-
+                        Budgets is a list of Budgets.
+                        If there are multiple active budgets, Karpenter uses
+                        the most restrictive value. If left undefined,
+                        this will default to one budget with a value to 10%.
+                      items:
+                        description: |-
+                          Budget defines when Karpenter will restrict the
+                          number of Node Claims that can be terminating simultaneously.
+                        properties:
+                          duration:
+                            description: |-
+                              Duration determines how long a Budget is active since each Schedule hit.
+                              Only minutes and hours are accepted, as cron does not work in seconds.
+                              If omitted, the budget is always active.
+                              This is required if Schedule is set.
+                              This regex has an optional 0s at the end since the duration.String() always adds
+                              a 0s at the end.
+                            pattern: ^((([0-9]+(h|m))|([0-9]+h[0-9]+m))(0s)?)$
+                            type: string
+                          nodes:
+                            default: 10%
+                            description: |-
+                              Nodes dictates the maximum number of NodeClaims owned by this NodePool
+                              that can be terminating at once. This is calculated by counting nodes that
+                              have a deletion timestamp set, or are actively being deleted by Karpenter.
+                              This field is required when specifying a budget.
+                              This cannot be of type intstr.IntOrString since kubebuilder doesn't support pattern
+                              checking for int nodes for IntOrString nodes.
+                              Ref: https://github.com/kubernetes-sigs/controller-tools/blob/55efe4be40394a288216dab63156b0a64fb82929/pkg/crd/markers/validation.go#L379-L388
+                            pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
+                            type: string
+                          reasons:
+                            description: |-
+                              Reasons is a list of disruption methods that this budget applies to. If Reasons is not set, this budget applies to all methods.
+                              Otherwise, this will apply to each reason defined.
+                              allowed reasons are Underutilized, Empty, and Drifted.
+                            items:
+                              description: DisruptionReason defines valid reasons for disruption budgets.
+                              enum:
+                                - Underutilized
+                                - Empty
+                                - Drifted
+                              type: string
+                            type: array
+                          schedule:
+                            description: |-
+                              Schedule specifies when a budget begins being active, following
+                              the upstream cronjob syntax. If omitted, the budget is always active.
+                              Timezones are not supported.
+                              This field is required if Duration is set.
+                            pattern: ^(@(annually|yearly|monthly|weekly|daily|midnight|hourly))|((.+)\s(.+)\s(.+)\s(.+)\s(.+))$
+                            type: string
+                        required:
+                          - nodes
+                        type: object
+                      maxItems: 50
+                      type: array
+                      x-kubernetes-validations:
+                        - message: '''schedule'' must be set with ''duration'''
+                          rule: self.all(x, has(x.schedule) == has(x.duration))
+                    consolidateAfter:
+                      description: |-
+                        ConsolidateAfter is the duration the controller will wait
+                        before attempting to terminate nodes that are underutilized.
+                        Refer to ConsolidationPolicy for how underutilization is considered.
+                      pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                      type: string
+                    consolidationPolicy:
+                      default: WhenEmptyOrUnderutilized
+                      description: |-
+                        ConsolidationPolicy describes which nodes Karpenter can disrupt through its consolidation
+                        algorithm. This policy defaults to "WhenEmptyOrUnderutilized" if not specified
+                      enum:
+                        - WhenEmpty
+                        - WhenEmptyOrUnderutilized
+                      type: string
+                  required:
+                    - consolidateAfter
+                  type: object
+                limits:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Limits define a set of bounds for provisioning capacity.
+                  type: object
+                template:
+                  description: |-
+                    Template contains the template of possibilities for the provisioning logic to launch a NodeClaim with.
+                    NodeClaims launched from this NodePool will often be further constrained than the template specifies.
+                  properties:
+                    metadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Annotations is an unstructured key value map stored with a resource that may be
+                            set by external tools to store and retrieve arbitrary metadata. They are not
+                            queryable and should be preserved when modifying objects.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                            maxLength: 63
+                            pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                          description: |-
+                            Map of string keys and values that can be used to organize and categorize
+                            (scope and select) objects. May match selectors of replication controllers
+                            and services.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
+                          type: object
+                          maxProperties: 100
+                          x-kubernetes-validations:
+                            - message: label domain "kubernetes.io" is restricted
+                              rule: self.all(x, x in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region",  "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || x.find("^([^/]+)").endsWith("node.kubernetes.io") || x.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !x.find("^([^/]+)").endsWith("kubernetes.io"))
+                            - message: label domain "k8s.io" is restricted
+                              rule: self.all(x, x.find("^([^/]+)").endsWith("kops.k8s.io") || !x.find("^([^/]+)").endsWith("k8s.io"))
+                            - message: label domain "karpenter.sh" is restricted
+                              rule: self.all(x, x in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !x.find("^([^/]+)").endsWith("karpenter.sh"))
+                            - message: label "karpenter.sh/nodepool" is restricted
+                              rule: self.all(x, x != "karpenter.sh/nodepool")
+                            - message: label "kubernetes.io/hostname" is restricted
+                              rule: self.all(x, x != "kubernetes.io/hostname")
+                            - message: label domain "karpenter.k8s.aws" is restricted
+                              rule: self.all(x, x in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !x.find("^([^/]+)").endsWith("karpenter.k8s.aws"))
+                      type: object
+                    spec:
+                      description: |-
+                        NodeClaimTemplateSpec describes the desired state of the NodeClaim in the Nodepool
+                        NodeClaimTemplateSpec is used in the NodePool's NodeClaimTemplate, with the resource requests omitted since
+                        users are not able to set resource requests in the NodePool.
+                      properties:
+                        expireAfter:
+                          default: 720h
+                          description: |-
+                            ExpireAfter is the duration the controller will wait
+                            before terminating a node, measured from when the node is created. This
+                            is useful to implement features like eventually consistent node upgrade,
+                            memory leak protection, and disruption testing.
+                          pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                          type: string
+                        nodeClassRef:
+                          description: NodeClassRef is a reference to an object that defines provider specific configuration
+                          properties:
+                            group:
+                              description: API version of the referent
+                              pattern: ^[^/]*$
+                              type: string
+                            kind:
+                              description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                              type: string
+                            name:
+                              description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                          required:
+                            - group
+                            - kind
+                            - name
+                          type: object
+                        requirements:
+                          description: Requirements are layered with GetLabels and applied to every node.
+                          items:
+                            description: |-
+                              A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                              and minValues that represent the requirement to have at least that many values.
+                            properties:
+                              key:
+                                description: The label key that the selector applies to.
+                                type: string
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                                x-kubernetes-validations:
+                                  - message: label domain "kubernetes.io" is restricted
+                                    rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                                  - message: label domain "k8s.io" is restricted
+                                    rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                                  - message: label domain "karpenter.sh" is restricted
+                                    rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                                  - message: label "karpenter.sh/nodepool" is restricted
+                                    rule: self != "karpenter.sh/nodepool"
+                                  - message: label "kubernetes.io/hostname" is restricted
+                                    rule: self != "kubernetes.io/hostname"
+                                  - message: label domain "karpenter.k8s.aws" is restricted
+                                    rule: self in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                              minValues:
+                                description: |-
+                                  This field is ALPHA and can be dropped or replaced at any time
+                                  MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                                maximum: 50
+                                minimum: 1
+                                type: integer
+                              operator:
+                                description: |-
+                                  Represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                type: string
+                                enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  - Gt
+                                  - Lt
+                              values:
+                                description: |-
+                                  An array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                  array must have a single element, which will be interpreted as an integer.
+                                  This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          maxItems: 100
+                          type: array
+                          x-kubernetes-validations:
+                            - message: requirements with operator 'In' must have a value defined
+                              rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                            - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                              rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                            - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                              rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                        startupTaints:
+                          description: |-
+                            StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                            within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                            daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                            purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        taints:
+                          description: Taints will be applied to the NodeClaim's node.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        terminationGracePeriod:
+                          description: |-
+                            TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
+
+                            Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
+
+                            This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
+                            When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
+
+                            Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
+                            If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
+                            that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
+
+                            The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
+                            If left undefined, the controller will wait indefinitely for pods to be drained.
+                          pattern: ^([0-9]+(s|m|h))+$
+                          type: string
+                      required:
+                        - nodeClassRef
+                        - requirements
+                      type: object
+                  required:
+                    - spec
+                  type: object
+                weight:
+                  description: |-
+                    Weight is the priority given to the nodepool during scheduling. A higher
+                    numerical weight indicates that this nodepool will be ordered
+                    ahead of other nodepools with lower weights. A nodepool with no weight
+                    will be treated as if it is a nodepool with a weight of 0.
+                  format: int32
+                  maximum: 100
+                  minimum: 1
+                  type: integer
+              required:
+                - template
+              type: object
+            status:
+              description: NodePoolStatus defines the observed state of NodePool
+              properties:
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                resources:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Resources is the list of resources that have been provisioned.
+                  type: object
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .spec.template.spec.nodeClassRef.name
+          name: NodeClass
+          type: string
+        - jsonPath: .spec.weight
+          name: Weight
+          priority: 1
+          type: string
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: NodePool is the Schema for the NodePools API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                NodePoolSpec is the top level nodepool specification. Nodepools
+                launch nodes in response to pods that are unschedulable. A single nodepool
+                is capable of managing a diverse set of nodes. Node properties are determined
+                from a combination of nodepool and pod scheduling constraints.
+              properties:
+                disruption:
+                  default:
+                    consolidationPolicy: WhenUnderutilized
+                    expireAfter: 720h
+                  description: Disruption contains the parameters that relate to Karpenter's disruption logic
+                  properties:
+                    budgets:
+                      default:
+                        - nodes: 10%
+                      description: |-
+                        Budgets is a list of Budgets.
+                        If there are multiple active budgets, Karpenter uses
+                        the most restrictive value. If left undefined,
+                        this will default to one budget with a value to 10%.
+                      items:
+                        description: |-
+                          Budget defines when Karpenter will restrict the
+                          number of Node Claims that can be terminating simultaneously.
+                        properties:
+                          duration:
+                            description: |-
+                              Duration determines how long a Budget is active since each Schedule hit.
+                              Only minutes and hours are accepted, as cron does not work in seconds.
+                              If omitted, the budget is always active.
+                              This is required if Schedule is set.
+                              This regex has an optional 0s at the end since the duration.String() always adds
+                              a 0s at the end.
+                            pattern: ^((([0-9]+(h|m))|([0-9]+h[0-9]+m))(0s)?)$
+                            type: string
+                          nodes:
+                            default: 10%
+                            description: |-
+                              Nodes dictates the maximum number of NodeClaims owned by this NodePool
+                              that can be terminating at once. This is calculated by counting nodes that
+                              have a deletion timestamp set, or are actively being deleted by Karpenter.
+                              This field is required when specifying a budget.
+                              This cannot be of type intstr.IntOrString since kubebuilder doesn't support pattern
+                              checking for int nodes for IntOrString nodes.
+                              Ref: https://github.com/kubernetes-sigs/controller-tools/blob/55efe4be40394a288216dab63156b0a64fb82929/pkg/crd/markers/validation.go#L379-L388
+                            pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
+                            type: string
+                          schedule:
+                            description: |-
+                              Schedule specifies when a budget begins being active, following
+                              the upstream cronjob syntax. If omitted, the budget is always active.
+                              Timezones are not supported.
+                              This field is required if Duration is set.
+                            pattern: ^(@(annually|yearly|monthly|weekly|daily|midnight|hourly))|((.+)\s(.+)\s(.+)\s(.+)\s(.+))$
+                            type: string
+                        required:
+                          - nodes
+                        type: object
+                      maxItems: 50
+                      type: array
+                      x-kubernetes-validations:
+                        - message: '''schedule'' must be set with ''duration'''
+                          rule: self.all(x, has(x.schedule) == has(x.duration))
+                    consolidateAfter:
+                      description: |-
+                        ConsolidateAfter is the duration the controller will wait
+                        before attempting to terminate nodes that are underutilized.
+                        Refer to ConsolidationPolicy for how underutilization is considered.
+                      pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                      type: string
+                    consolidationPolicy:
+                      default: WhenUnderutilized
+                      description: |-
+                        ConsolidationPolicy describes which nodes Karpenter can disrupt through its consolidation
+                        algorithm. This policy defaults to "WhenUnderutilized" if not specified
+                      enum:
+                        - WhenEmpty
+                        - WhenUnderutilized
+                      type: string
+                    expireAfter:
+                      default: 720h
+                      description: |-
+                        ExpireAfter is the duration the controller will wait
+                        before terminating a node, measured from when the node is created. This
+                        is useful to implement features like eventually consistent node upgrade,
+                        memory leak protection, and disruption testing.
+                      pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                      type: string
+                  type: object
+                  x-kubernetes-validations:
+                    - message: consolidateAfter cannot be combined with consolidationPolicy=WhenUnderutilized
+                      rule: 'has(self.consolidateAfter) ? self.consolidationPolicy != ''WhenUnderutilized'' || self.consolidateAfter == ''Never'' : true'
+                    - message: consolidateAfter must be specified with consolidationPolicy=WhenEmpty
+                      rule: 'self.consolidationPolicy == ''WhenEmpty'' ? has(self.consolidateAfter) : true'
+                limits:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Limits define a set of bounds for provisioning capacity.
+                  type: object
+                template:
+                  description: |-
+                    Template contains the template of possibilities for the provisioning logic to launch a NodeClaim with.
+                    NodeClaims launched from this NodePool will often be further constrained than the template specifies.
+                  properties:
+                    metadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Annotations is an unstructured key value map stored with a resource that may be
+                            set by external tools to store and retrieve arbitrary metadata. They are not
+                            queryable and should be preserved when modifying objects.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                            maxLength: 63
+                            pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                          description: |-
+                            Map of string keys and values that can be used to organize and categorize
+                            (scope and select) objects. May match selectors of replication controllers
+                            and services.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
+                          type: object
+                          maxProperties: 100
+                          x-kubernetes-validations:
+                            - message: label domain "kubernetes.io" is restricted
+                              rule: self.all(x, x in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region",  "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || x.find("^([^/]+)").endsWith("node.kubernetes.io") || x.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !x.find("^([^/]+)").endsWith("kubernetes.io"))
+                            - message: label domain "k8s.io" is restricted
+                              rule: self.all(x, x.find("^([^/]+)").endsWith("kops.k8s.io") || !x.find("^([^/]+)").endsWith("k8s.io"))
+                            - message: label domain "karpenter.sh" is restricted
+                              rule: self.all(x, x in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !x.find("^([^/]+)").endsWith("karpenter.sh"))
+                            - message: label "karpenter.sh/nodepool" is restricted
+                              rule: self.all(x, x != "karpenter.sh/nodepool")
+                            - message: label "kubernetes.io/hostname" is restricted
+                              rule: self.all(x, x != "kubernetes.io/hostname")
+                            - message: label domain "karpenter.k8s.aws" is restricted
+                              rule: self.all(x, x in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !x.find("^([^/]+)").endsWith("karpenter.k8s.aws"))
+                      type: object
+                    spec:
+                      description: NodeClaimSpec describes the desired state of the NodeClaim
+                      properties:
+                        kubelet:
+                          description: |-
+                            Kubelet defines args to be used when configuring kubelet on provisioned nodes.
+                            They are a subset of the upstream types, recognizing not all options may be supported.
+                            Wherever possible, the types and names should reflect the upstream kubelet types.
+                          properties:
+                            clusterDNS:
+                              description: |-
+                                clusterDNS is a list of IP addresses for the cluster DNS server.
+                                Note that not all providers may use all addresses.
+                              items:
+                                type: string
+                              type: array
+                            cpuCFSQuota:
+                              description: CPUCFSQuota enables CPU CFS quota enforcement for containers that specify CPU limits.
+                              type: boolean
+                            evictionHard:
+                              additionalProperties:
+                                type: string
+                                pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                              description: EvictionHard is the map of signal names to quantities that define hard eviction thresholds
+                              type: object
+                              x-kubernetes-validations:
+                                - message: valid keys for evictionHard are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                                  rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                            evictionMaxPodGracePeriod:
+                              description: |-
+                                EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in
+                                response to soft eviction thresholds being met.
+                              format: int32
+                              type: integer
+                            evictionSoft:
+                              additionalProperties:
+                                type: string
+                                pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                              description: EvictionSoft is the map of signal names to quantities that define soft eviction thresholds
+                              type: object
+                              x-kubernetes-validations:
+                                - message: valid keys for evictionSoft are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                                  rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                            evictionSoftGracePeriod:
+                              additionalProperties:
+                                type: string
+                              description: EvictionSoftGracePeriod is the map of signal names to quantities that define grace periods for each eviction signal
+                              type: object
+                              x-kubernetes-validations:
+                                - message: valid keys for evictionSoftGracePeriod are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                                  rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                            imageGCHighThresholdPercent:
+                              description: |-
+                                ImageGCHighThresholdPercent is the percent of disk usage after which image
+                                garbage collection is always run. The percent is calculated by dividing this
+                                field value by 100, so this field must be between 0 and 100, inclusive.
+                                When specified, the value must be greater than ImageGCLowThresholdPercent.
+                              format: int32
+                              maximum: 100
+                              minimum: 0
+                              type: integer
+                            imageGCLowThresholdPercent:
+                              description: |-
+                                ImageGCLowThresholdPercent is the percent of disk usage before which image
+                                garbage collection is never run. Lowest disk usage to garbage collect to.
+                                The percent is calculated by dividing this field value by 100,
+                                so the field value must be between 0 and 100, inclusive.
+                                When specified, the value must be less than imageGCHighThresholdPercent
+                              format: int32
+                              maximum: 100
+                              minimum: 0
+                              type: integer
+                            kubeReserved:
+                              additionalProperties:
+                                type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              description: KubeReserved contains resources reserved for Kubernetes system components.
+                              type: object
+                              x-kubernetes-validations:
+                                - message: valid keys for kubeReserved are ['cpu','memory','ephemeral-storage','pid']
+                                  rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                                - message: kubeReserved value cannot be a negative resource quantity
+                                  rule: self.all(x, !self[x].startsWith('-'))
+                            maxPods:
+                              description: |-
+                                MaxPods is an override for the maximum number of pods that can run on
+                                a worker node instance.
+                              format: int32
+                              minimum: 0
+                              type: integer
+                            podsPerCore:
+                              description: |-
+                                PodsPerCore is an override for the number of pods that can run on a worker node
+                                instance based on the number of cpu cores. This value cannot exceed MaxPods, so, if
+                                MaxPods is a lower value, that value will be used.
+                              format: int32
+                              minimum: 0
+                              type: integer
+                            systemReserved:
+                              additionalProperties:
+                                type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              description: SystemReserved contains resources reserved for OS system daemons and kernel memory.
+                              type: object
+                              x-kubernetes-validations:
+                                - message: valid keys for systemReserved are ['cpu','memory','ephemeral-storage','pid']
+                                  rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                                - message: systemReserved value cannot be a negative resource quantity
+                                  rule: self.all(x, !self[x].startsWith('-'))
+                          type: object
+                          x-kubernetes-validations:
+                            - message: imageGCHighThresholdPercent must be greater than imageGCLowThresholdPercent
+                              rule: 'has(self.imageGCHighThresholdPercent) && has(self.imageGCLowThresholdPercent) ?  self.imageGCHighThresholdPercent > self.imageGCLowThresholdPercent  : true'
+                            - message: evictionSoft OwnerKey does not have a matching evictionSoftGracePeriod
+                              rule: has(self.evictionSoft) ? self.evictionSoft.all(e, (e in self.evictionSoftGracePeriod)):true
+                            - message: evictionSoftGracePeriod OwnerKey does not have a matching evictionSoft
+                              rule: has(self.evictionSoftGracePeriod) ? self.evictionSoftGracePeriod.all(e, (e in self.evictionSoft)):true
+                        nodeClassRef:
+                          description: NodeClassRef is a reference to an object that defines provider specific configuration
+                          properties:
+                            apiVersion:
+                              description: API version of the referent
+                              type: string
+                            kind:
+                              description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                              type: string
+                            name:
+                              description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        requirements:
+                          description: Requirements are layered with GetLabels and applied to every node.
+                          items:
+                            description: |-
+                              A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                              and minValues that represent the requirement to have at least that many values.
+                            properties:
+                              key:
+                                description: The label key that the selector applies to.
+                                type: string
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                                x-kubernetes-validations:
+                                  - message: label domain "kubernetes.io" is restricted
+                                    rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                                  - message: label domain "k8s.io" is restricted
+                                    rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                                  - message: label domain "karpenter.sh" is restricted
+                                    rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                                  - message: label "karpenter.sh/nodepool" is restricted
+                                    rule: self != "karpenter.sh/nodepool"
+                                  - message: label "kubernetes.io/hostname" is restricted
+                                    rule: self != "kubernetes.io/hostname"
+                                  - message: label domain "karpenter.k8s.aws" is restricted
+                                    rule: self in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                              minValues:
+                                description: |-
+                                  This field is ALPHA and can be dropped or replaced at any time
+                                  MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                                maximum: 50
+                                minimum: 1
+                                type: integer
+                              operator:
+                                description: |-
+                                  Represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                type: string
+                                enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  - Gt
+                                  - Lt
+                              values:
+                                description: |-
+                                  An array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                  array must have a single element, which will be interpreted as an integer.
+                                  This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          maxItems: 100
+                          type: array
+                          x-kubernetes-validations:
+                            - message: requirements with operator 'In' must have a value defined
+                              rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                            - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                              rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                            - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                              rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                        resources:
+                          description: Resources models the resource requirements for the NodeClaim to launch
+                          properties:
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: Requests describes the minimum required resources for the NodeClaim to launch
+                              type: object
+                          type: object
+                          maxProperties: 0
+                        startupTaints:
+                          description: |-
+                            StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                            within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                            daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                            purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        taints:
+                          description: Taints will be applied to the NodeClaim's node.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                      required:
+                        - nodeClassRef
+                        - requirements
+                      type: object
+                  required:
+                    - spec
+                  type: object
+                weight:
+                  description: |-
+                    Weight is the priority given to the nodepool during scheduling. A higher
+                    numerical weight indicates that this nodepool will be ordered
+                    ahead of other nodepools with lower weights. A nodepool with no weight
+                    will be treated as if it is a nodepool with a weight of 0.
+                  format: int32
+                  maximum: 100
+                  minimum: 1
+                  type: integer
+              required:
+                - template
+              type: object
+            status:
+              description: NodePoolStatus defines the observed state of NodePool
+              properties:
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                resources:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Resources is the list of resources that have been provisioned.
+                  type: object
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+        - v1
+      clientConfig:
+        service:
+          name: karpenter
+          namespace: kube-system
+          port: 8443

--- a/content/projects/karpenter/v1.0.8/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/content/projects/karpenter/v1.0.8/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -1,0 +1,1306 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: ec2nodeclasses.karpenter.k8s.aws
+spec:
+  group: karpenter.k8s.aws
+  names:
+    categories:
+      - karpenter
+    kind: EC2NodeClass
+    listKind: EC2NodeClassList
+    plural: ec2nodeclasses
+    shortNames:
+      - ec2nc
+      - ec2ncs
+    singular: ec2nodeclass
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.role
+          name: Role
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: EC2NodeClass is the Schema for the EC2NodeClass API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                EC2NodeClassSpec is the top level specification for the AWS Karpenter Provider.
+                This will contain configuration necessary to launch instances in AWS.
+              properties:
+                amiFamily:
+                  description: |-
+                    AMIFamily dictates the UserData format and default BlockDeviceMappings used when generating launch templates.
+                    This field is optional when using an alias amiSelectorTerm, and the value will be inferred from the alias'
+                    family. When an alias is specified, this field may only be set to its corresponding family or 'Custom'. If no
+                    alias is specified, this field is required.
+                    NOTE: We ignore the AMIFamily for hashing here because we hash the AMIFamily dynamically by using the alias using
+                    the AMIFamily() helper function
+                  enum:
+                    - AL2
+                    - AL2023
+                    - Bottlerocket
+                    - Custom
+                    - Windows2019
+                    - Windows2022
+                  type: string
+                amiSelectorTerms:
+                  description: AMISelectorTerms is a list of or ami selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      AMISelectorTerm defines selection logic for an ami used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      alias:
+                        description: |-
+                          Alias specifies which EKS optimized AMI to select.
+                          Each alias consists of a family and an AMI version, specified as "family@version".
+                          Valid families include: al2, al2023, bottlerocket, windows2019, and windows2022.
+                          The version can either be pinned to a specific AMI release, with that AMIs version format (ex: "al2023@v20240625" or "bottlerocket@v1.10.0").
+                          The version can also be set to "latest" for any family. Setting the version to latest will result in drift when a new AMI is released. This is **not** recommended for production environments.
+                          Note: The Windows families do **not** support version pinning, and only latest may be used.
+                        maxLength: 30
+                        type: string
+                        x-kubernetes-validations:
+                          - message: '''alias'' is improperly formatted, must match the format ''family@version'''
+                            rule: self.matches('^[a-zA-Z0-9]+@.+$')
+                          - message: 'family is not supported, must be one of the following: ''al2'', ''al2023'', ''bottlerocket'', ''windows2019'', ''windows2022'''
+                            rule: self.split('@')[0] in ['al2','al2023','bottlerocket','windows2019','windows2022']
+                          - message: windows families may only specify version 'latest'
+                            rule: 'self.split(''@'')[0] in [''windows2019'',''windows2022''] ? self.split(''@'')[1] == ''latest'' : true'
+                      id:
+                        description: ID is the ami id in EC2
+                        pattern: ami-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the ami name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      owner:
+                        description: |-
+                          Owner is the owner for the ami.
+                          You can specify a combination of AWS account IDs, "self", "amazon", and "aws-marketplace"
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  minItems: 1
+                  type: array
+                  x-kubernetes-validations:
+                    - message: expected at least one, got none, ['tags', 'id', 'name', 'alias']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name) || has(x.alias))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.exists(x, has(x.id) && (has(x.alias) || has(x.tags) || has(x.name) || has(x.owner)))'
+                    - message: '''alias'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.exists(x, has(x.alias) && (has(x.id) || has(x.tags) || has(x.name) || has(x.owner)))'
+                    - message: '''alias'' is mutually exclusive, cannot be set with a combination of other amiSelectorTerms'
+                      rule: '!(self.exists(x, has(x.alias)) && self.size() != 1)'
+                associatePublicIPAddress:
+                  description: AssociatePublicIPAddress controls if public IP addresses are assigned to instances that are launched with the nodeclass.
+                  type: boolean
+                blockDeviceMappings:
+                  description: BlockDeviceMappings to be applied to provisioned nodes.
+                  items:
+                    properties:
+                      deviceName:
+                        description: The device name (for example, /dev/sdh or xvdh).
+                        type: string
+                      ebs:
+                        description: EBS contains parameters used to automatically set up EBS volumes when an instance is launched.
+                        properties:
+                          deleteOnTermination:
+                            description: DeleteOnTermination indicates whether the EBS volume is deleted on instance termination.
+                            type: boolean
+                          encrypted:
+                            description: |-
+                              Encrypted indicates whether the EBS volume is encrypted. Encrypted volumes can only
+                              be attached to instances that support Amazon EBS encryption. If you are creating
+                              a volume from a snapshot, you can't specify an encryption value.
+                            type: boolean
+                          iops:
+                            description: |-
+                              IOPS is the number of I/O operations per second (IOPS). For gp3, io1, and io2 volumes,
+                              this represents the number of IOPS that are provisioned for the volume. For
+                              gp2 volumes, this represents the baseline performance of the volume and the
+                              rate at which the volume accumulates I/O credits for bursting.
+
+                              The following are the supported values for each volume type:
+
+                                 * gp3: 3,000-16,000 IOPS
+
+                                 * io1: 100-64,000 IOPS
+
+                                 * io2: 100-64,000 IOPS
+
+                              For io1 and io2 volumes, we guarantee 64,000 IOPS only for Instances built
+                              on the Nitro System (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances).
+                              Other instance families guarantee performance up to 32,000 IOPS.
+
+                              This parameter is supported for io1, io2, and gp3 volumes only. This parameter
+                              is not supported for gp2, st1, sc1, or standard volumes.
+                            format: int64
+                            type: integer
+                          kmsKeyID:
+                            description: KMSKeyID (ARN) of the symmetric Key Management Service (KMS) CMK used for encryption.
+                            type: string
+                          snapshotID:
+                            description: SnapshotID is the ID of an EBS snapshot
+                            type: string
+                          throughput:
+                            description: |-
+                              Throughput to provision for a gp3 volume, with a maximum of 1,000 MiB/s.
+                              Valid Range: Minimum value of 125. Maximum value of 1000.
+                            format: int64
+                            type: integer
+                          volumeSize:
+                            description: |-
+                              VolumeSize in `Gi`, `G`, `Ti`, or `T`. You must specify either a snapshot ID or
+                              a volume size. The following are the supported volumes sizes for each volume
+                              type:
+
+                                 * gp2 and gp3: 1-16,384
+
+                                 * io1 and io2: 4-16,384
+
+                                 * st1 and sc1: 125-16,384
+
+                                 * standard: 1-1,024
+                            pattern: ^((?:[1-9][0-9]{0,3}|[1-4][0-9]{4}|[5][0-8][0-9]{3}|59000)Gi|(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|[6][0-3][0-9]{3}|64000)G|([1-9]||[1-5][0-7]|58)Ti|([1-9]||[1-5][0-9]|6[0-3]|64)T)$
+                            type: string
+                          volumeType:
+                            description: |-
+                              VolumeType of the block device.
+                              For more information, see Amazon EBS volume types (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html)
+                              in the Amazon Elastic Compute Cloud User Guide.
+                            enum:
+                              - standard
+                              - io1
+                              - io2
+                              - gp2
+                              - sc1
+                              - st1
+                              - gp3
+                            type: string
+                        type: object
+                        x-kubernetes-validations:
+                          - message: snapshotID or volumeSize must be defined
+                            rule: has(self.snapshotID) || has(self.volumeSize)
+                      rootVolume:
+                        description: |-
+                          RootVolume is a flag indicating if this device is mounted as kubelet root dir. You can
+                          configure at most one root volume in BlockDeviceMappings.
+                        type: boolean
+                    type: object
+                  maxItems: 50
+                  type: array
+                  x-kubernetes-validations:
+                    - message: must have only one blockDeviceMappings with rootVolume
+                      rule: self.filter(x, has(x.rootVolume)?x.rootVolume==true:false).size() <= 1
+                context:
+                  description: |-
+                    Context is a Reserved field in EC2 APIs
+                    https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet.html
+                  type: string
+                detailedMonitoring:
+                  description: DetailedMonitoring controls if detailed monitoring is enabled for instances that are launched
+                  type: boolean
+                instanceProfile:
+                  description: |-
+                    InstanceProfile is the AWS entity that instances use.
+                    This field is mutually exclusive from role.
+                    The instance profile should already have a role assigned to it that Karpenter
+                     has PassRole permission on for instance launch using this instanceProfile to succeed.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: instanceProfile cannot be empty
+                      rule: self != ''
+                instanceStorePolicy:
+                  description: InstanceStorePolicy specifies how to handle instance-store disks.
+                  enum:
+                    - RAID0
+                  type: string
+                kubelet:
+                  description: |-
+                    Kubelet defines args to be used when configuring kubelet on provisioned nodes.
+                    They are a subset of the upstream types, recognizing not all options may be supported.
+                    Wherever possible, the types and names should reflect the upstream kubelet types.
+                  properties:
+                    clusterDNS:
+                      description: |-
+                        clusterDNS is a list of IP addresses for the cluster DNS server.
+                        Note that not all providers may use all addresses.
+                      items:
+                        type: string
+                      type: array
+                    cpuCFSQuota:
+                      description: CPUCFSQuota enables CPU CFS quota enforcement for containers that specify CPU limits.
+                      type: boolean
+                    evictionHard:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionHard is the map of signal names to quantities that define hard eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionHard are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionMaxPodGracePeriod:
+                      description: |-
+                        EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in
+                        response to soft eviction thresholds being met.
+                      format: int32
+                      type: integer
+                    evictionSoft:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionSoft is the map of signal names to quantities that define soft eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoft are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionSoftGracePeriod:
+                      additionalProperties:
+                        type: string
+                      description: EvictionSoftGracePeriod is the map of signal names to quantities that define grace periods for each eviction signal
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoftGracePeriod are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    imageGCHighThresholdPercent:
+                      description: |-
+                        ImageGCHighThresholdPercent is the percent of disk usage after which image
+                        garbage collection is always run. The percent is calculated by dividing this
+                        field value by 100, so this field must be between 0 and 100, inclusive.
+                        When specified, the value must be greater than ImageGCLowThresholdPercent.
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    imageGCLowThresholdPercent:
+                      description: |-
+                        ImageGCLowThresholdPercent is the percent of disk usage before which image
+                        garbage collection is never run. Lowest disk usage to garbage collect to.
+                        The percent is calculated by dividing this field value by 100,
+                        so the field value must be between 0 and 100, inclusive.
+                        When specified, the value must be less than imageGCHighThresholdPercent
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    kubeReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: KubeReserved contains resources reserved for Kubernetes system components.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for kubeReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: kubeReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                    maxPods:
+                      description: |-
+                        MaxPods is an override for the maximum number of pods that can run on
+                        a worker node instance.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    podsPerCore:
+                      description: |-
+                        PodsPerCore is an override for the number of pods that can run on a worker node
+                        instance based on the number of cpu cores. This value cannot exceed MaxPods, so, if
+                        MaxPods is a lower value, that value will be used.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    systemReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: SystemReserved contains resources reserved for OS system daemons and kernel memory.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for systemReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: systemReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                  type: object
+                  x-kubernetes-validations:
+                    - message: imageGCHighThresholdPercent must be greater than imageGCLowThresholdPercent
+                      rule: 'has(self.imageGCHighThresholdPercent) && has(self.imageGCLowThresholdPercent) ?  self.imageGCHighThresholdPercent > self.imageGCLowThresholdPercent  : true'
+                    - message: evictionSoft OwnerKey does not have a matching evictionSoftGracePeriod
+                      rule: has(self.evictionSoft) ? self.evictionSoft.all(e, (e in self.evictionSoftGracePeriod)):true
+                    - message: evictionSoftGracePeriod OwnerKey does not have a matching evictionSoft
+                      rule: has(self.evictionSoftGracePeriod) ? self.evictionSoftGracePeriod.all(e, (e in self.evictionSoft)):true
+                metadataOptions:
+                  default:
+                    httpEndpoint: enabled
+                    httpProtocolIPv6: disabled
+                    httpPutResponseHopLimit: 1
+                    httpTokens: required
+                  description: |-
+                    MetadataOptions for the generated launch template of provisioned nodes.
+
+                    This specifies the exposure of the Instance Metadata Service to
+                    provisioned EC2 nodes. For more information,
+                    see Instance Metadata and User Data
+                    (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
+                    in the Amazon Elastic Compute Cloud User Guide.
+
+                    Refer to recommended, security best practices
+                    (https://aws.github.io/aws-eks-best-practices/security/docs/iam/#restrict-access-to-the-instance-profile-assigned-to-the-worker-node)
+                    for limiting exposure of Instance Metadata and User Data to pods.
+                    If omitted, defaults to httpEndpoint enabled, with httpProtocolIPv6
+                    disabled, with httpPutResponseLimit of 1, and with httpTokens
+                    required.
+                  properties:
+                    httpEndpoint:
+                      default: enabled
+                      description: |-
+                        HTTPEndpoint enables or disables the HTTP metadata endpoint on provisioned
+                        nodes. If metadata options is non-nil, but this parameter is not specified,
+                        the default state is "enabled".
+
+                        If you specify a value of "disabled", instance metadata will not be accessible
+                        on the node.
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpProtocolIPv6:
+                      default: disabled
+                      description: |-
+                        HTTPProtocolIPv6 enables or disables the IPv6 endpoint for the instance metadata
+                        service on provisioned nodes. If metadata options is non-nil, but this parameter
+                        is not specified, the default state is "disabled".
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpPutResponseHopLimit:
+                      default: 1
+                      description: |-
+                        HTTPPutResponseHopLimit is the desired HTTP PUT response hop limit for
+                        instance metadata requests. The larger the number, the further instance
+                        metadata requests can travel. Possible values are integers from 1 to 64.
+                        If metadata options is non-nil, but this parameter is not specified, the
+                        default value is 1.
+                      format: int64
+                      maximum: 64
+                      minimum: 1
+                      type: integer
+                    httpTokens:
+                      default: required
+                      description: |-
+                        HTTPTokens determines the state of token usage for instance metadata
+                        requests. If metadata options is non-nil, but this parameter is not
+                        specified, the default state is "required".
+
+                        If the state is optional, one can choose to retrieve instance metadata with
+                        or without a signed token header on the request. If one retrieves the IAM
+                        role credentials without a token, the version 1.0 role credentials are
+                        returned. If one retrieves the IAM role credentials using a valid signed
+                        token, the version 2.0 role credentials are returned.
+
+                        If the state is "required", one must send a signed token header with any
+                        instance metadata retrieval requests. In this state, retrieving the IAM
+                        role credentials always returns the version 2.0 credentials; the version
+                        1.0 credentials are not available.
+                      enum:
+                        - required
+                        - optional
+                      type: string
+                  type: object
+                role:
+                  description: |-
+                    Role is the AWS identity that nodes use. This field is immutable.
+                    This field is mutually exclusive from instanceProfile.
+                    Marking this field as immutable avoids concerns around terminating managed instance profiles from running instances.
+                    This field may be made mutable in the future, assuming the correct garbage collection and drift handling is implemented
+                    for the old instance profiles on an update.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: role cannot be empty
+                      rule: self != ''
+                    - message: immutable field changed
+                      rule: self == oldSelf
+                securityGroupSelectorTerms:
+                  description: SecurityGroupSelectorTerms is a list of or security group selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SecurityGroupSelectorTerm defines selection logic for a security group used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the security group id in EC2
+                        pattern: sg-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the security group name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: securityGroupSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id', 'name']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && (has(x.tags) || has(x.name)))'
+                    - message: '''name'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.name) && (has(x.tags) || has(x.id)))'
+                subnetSelectorTerms:
+                  description: SubnetSelectorTerms is a list of or subnet selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SubnetSelectorTerm defines selection logic for a subnet used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the subnet id in EC2
+                        pattern: subnet-[0-9a-z]+
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: subnetSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id']
+                      rule: self.all(x, has(x.tags) || has(x.id))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in subnetSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && has(x.tags))'
+                tags:
+                  additionalProperties:
+                    type: string
+                  description: Tags to be applied on ec2 resources like instances and launch templates.
+                  type: object
+                  x-kubernetes-validations:
+                    - message: empty tag keys aren't supported
+                      rule: self.all(k, k != '')
+                    - message: tag contains a restricted tag matching eks:eks-cluster-name
+                      rule: self.all(k, k !='eks:eks-cluster-name')
+                    - message: tag contains a restricted tag matching kubernetes.io/cluster/
+                      rule: self.all(k, !k.startsWith('kubernetes.io/cluster') )
+                    - message: tag contains a restricted tag matching karpenter.sh/nodepool
+                      rule: self.all(k, k != 'karpenter.sh/nodepool')
+                    - message: tag contains a restricted tag matching karpenter.sh/nodeclaim
+                      rule: self.all(k, k !='karpenter.sh/nodeclaim')
+                    - message: tag contains a restricted tag matching karpenter.k8s.aws/ec2nodeclass
+                      rule: self.all(k, k !='karpenter.k8s.aws/ec2nodeclass')
+                userData:
+                  description: |-
+                    UserData to be applied to the provisioned nodes.
+                    It must be in the appropriate format based on the AMIFamily in use. Karpenter will merge certain fields into
+                    this UserData to ensure nodes are being provisioned with the correct configuration.
+                  type: string
+              required:
+                - amiSelectorTerms
+                - securityGroupSelectorTerms
+                - subnetSelectorTerms
+              type: object
+              x-kubernetes-validations:
+                - message: must specify exactly one of ['role', 'instanceProfile']
+                  rule: (has(self.role) && !has(self.instanceProfile)) || (!has(self.role) && has(self.instanceProfile))
+                - message: changing from 'instanceProfile' to 'role' is not supported. You must delete and recreate this node class if you want to change this.
+                  rule: (has(oldSelf.role) && has(self.role)) || (has(oldSelf.instanceProfile) && has(self.instanceProfile))
+                - message: if set, amiFamily must be 'AL2' or 'Custom' when using an AL2 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''al2'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''AL2'') : true)'
+                - message: if set, amiFamily must be 'AL2023' or 'Custom' when using an AL2023 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''al2023'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''AL2023'') : true)'
+                - message: if set, amiFamily must be 'Bottlerocket' or 'Custom' when using a Bottlerocket alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''bottlerocket'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Bottlerocket'') : true)'
+                - message: if set, amiFamily must be 'Windows2019' or 'Custom' when using a Windows2019 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''windows2019'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Windows2019'') : true)'
+                - message: if set, amiFamily must be 'Windows2022' or 'Custom' when using a Windows2022 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''windows2022'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Windows2022'') : true)'
+                - message: must specify amiFamily if amiSelectorTerms does not contain an alias
+                  rule: 'self.amiSelectorTerms.exists(x, has(x.alias)) ? true : has(self.amiFamily)'
+            status:
+              description: EC2NodeClassStatus contains the resolved state of the EC2NodeClass
+              properties:
+                amis:
+                  description: |-
+                    AMI contains the current AMI values that are available to the
+                    cluster under the AMI selectors.
+                  items:
+                    description: AMI contains resolved AMI selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the AMI
+                        type: string
+                      name:
+                        description: Name of the AMI
+                        type: string
+                      requirements:
+                        description: Requirements of the AMI to be utilized on an instance type
+                        items:
+                          description: |-
+                            A node selector requirement is a selector that contains values, a key, and an operator
+                            that relates the key and values.
+                          properties:
+                            key:
+                              description: The label key that the selector applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                Represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                              type: string
+                            values:
+                              description: |-
+                                An array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. If the operator is Gt or Lt, the values
+                                array must have a single element, which will be interpreted as an integer.
+                                This array is replaced during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                            - key
+                            - operator
+                          type: object
+                        type: array
+                    required:
+                      - id
+                      - requirements
+                    type: object
+                  type: array
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                instanceProfile:
+                  description: InstanceProfile contains the resolved instance profile for the role
+                  type: string
+                securityGroups:
+                  description: |-
+                    SecurityGroups contains the current Security Groups values that are available to the
+                    cluster under the SecurityGroups selectors.
+                  items:
+                    description: SecurityGroup contains resolved SecurityGroup selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the security group
+                        type: string
+                      name:
+                        description: Name of the security group
+                        type: string
+                    required:
+                      - id
+                    type: object
+                  type: array
+                subnets:
+                  description: |-
+                    Subnets contains the current Subnet values that are available to the
+                    cluster under the subnet selectors.
+                  items:
+                    description: Subnet contains resolved Subnet selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the subnet
+                        type: string
+                      zone:
+                        description: The associated availability zone
+                        type: string
+                      zoneID:
+                        description: The associated availability zone ID
+                        type: string
+                    required:
+                      - id
+                      - zone
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: EC2NodeClass is the Schema for the EC2NodeClass API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                EC2NodeClassSpec is the top level specification for the AWS Karpenter Provider.
+                This will contain configuration necessary to launch instances in AWS.
+              properties:
+                amiFamily:
+                  description: AMIFamily is the AMI family that instances use.
+                  enum:
+                    - AL2
+                    - AL2023
+                    - Bottlerocket
+                    - Ubuntu
+                    - Custom
+                    - Windows2019
+                    - Windows2022
+                  type: string
+                amiSelectorTerms:
+                  description: AMISelectorTerms is a list of or ami selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      AMISelectorTerm defines selection logic for an ami used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the ami id in EC2
+                        pattern: ami-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the ami name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      owner:
+                        description: |-
+                          Owner is the owner for the ami.
+                          You can specify a combination of AWS account IDs, "self", "amazon", and "aws-marketplace"
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: expected at least one, got none, ['tags', 'id', 'name']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && (has(x.tags) || has(x.name) || has(x.owner)))'
+                associatePublicIPAddress:
+                  description: AssociatePublicIPAddress controls if public IP addresses are assigned to instances that are launched with the nodeclass.
+                  type: boolean
+                blockDeviceMappings:
+                  description: BlockDeviceMappings to be applied to provisioned nodes.
+                  items:
+                    properties:
+                      deviceName:
+                        description: The device name (for example, /dev/sdh or xvdh).
+                        type: string
+                      ebs:
+                        description: EBS contains parameters used to automatically set up EBS volumes when an instance is launched.
+                        properties:
+                          deleteOnTermination:
+                            description: DeleteOnTermination indicates whether the EBS volume is deleted on instance termination.
+                            type: boolean
+                          encrypted:
+                            description: |-
+                              Encrypted indicates whether the EBS volume is encrypted. Encrypted volumes can only
+                              be attached to instances that support Amazon EBS encryption. If you are creating
+                              a volume from a snapshot, you can't specify an encryption value.
+                            type: boolean
+                          iops:
+                            description: |-
+                              IOPS is the number of I/O operations per second (IOPS). For gp3, io1, and io2 volumes,
+                              this represents the number of IOPS that are provisioned for the volume. For
+                              gp2 volumes, this represents the baseline performance of the volume and the
+                              rate at which the volume accumulates I/O credits for bursting.
+
+                              The following are the supported values for each volume type:
+
+                                 * gp3: 3,000-16,000 IOPS
+
+                                 * io1: 100-64,000 IOPS
+
+                                 * io2: 100-64,000 IOPS
+
+                              For io1 and io2 volumes, we guarantee 64,000 IOPS only for Instances built
+                              on the Nitro System (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances).
+                              Other instance families guarantee performance up to 32,000 IOPS.
+
+                              This parameter is supported for io1, io2, and gp3 volumes only. This parameter
+                              is not supported for gp2, st1, sc1, or standard volumes.
+                            format: int64
+                            type: integer
+                          kmsKeyID:
+                            description: KMSKeyID (ARN) of the symmetric Key Management Service (KMS) CMK used for encryption.
+                            type: string
+                          snapshotID:
+                            description: SnapshotID is the ID of an EBS snapshot
+                            type: string
+                          throughput:
+                            description: |-
+                              Throughput to provision for a gp3 volume, with a maximum of 1,000 MiB/s.
+                              Valid Range: Minimum value of 125. Maximum value of 1000.
+                            format: int64
+                            type: integer
+                          volumeSize:
+                            description: |-
+                              VolumeSize in `Gi`, `G`, `Ti`, or `T`. You must specify either a snapshot ID or
+                              a volume size. The following are the supported volumes sizes for each volume
+                              type:
+
+                                 * gp2 and gp3: 1-16,384
+
+                                 * io1 and io2: 4-16,384
+
+                                 * st1 and sc1: 125-16,384
+
+                                 * standard: 1-1,024
+                            pattern: ^((?:[1-9][0-9]{0,3}|[1-4][0-9]{4}|[5][0-8][0-9]{3}|59000)Gi|(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|[6][0-3][0-9]{3}|64000)G|([1-9]||[1-5][0-7]|58)Ti|([1-9]||[1-5][0-9]|6[0-3]|64)T)$
+                            type: string
+                          volumeType:
+                            description: |-
+                              VolumeType of the block device.
+                              For more information, see Amazon EBS volume types (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html)
+                              in the Amazon Elastic Compute Cloud User Guide.
+                            enum:
+                              - standard
+                              - io1
+                              - io2
+                              - gp2
+                              - sc1
+                              - st1
+                              - gp3
+                            type: string
+                        type: object
+                        x-kubernetes-validations:
+                          - message: snapshotID or volumeSize must be defined
+                            rule: has(self.snapshotID) || has(self.volumeSize)
+                      rootVolume:
+                        description: |-
+                          RootVolume is a flag indicating if this device is mounted as kubelet root dir. You can
+                          configure at most one root volume in BlockDeviceMappings.
+                        type: boolean
+                    type: object
+                  maxItems: 50
+                  type: array
+                  x-kubernetes-validations:
+                    - message: must have only one blockDeviceMappings with rootVolume
+                      rule: self.filter(x, has(x.rootVolume)?x.rootVolume==true:false).size() <= 1
+                context:
+                  description: |-
+                    Context is a Reserved field in EC2 APIs
+                    https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet.html
+                  type: string
+                detailedMonitoring:
+                  description: DetailedMonitoring controls if detailed monitoring is enabled for instances that are launched
+                  type: boolean
+                instanceProfile:
+                  description: |-
+                    InstanceProfile is the AWS entity that instances use.
+                    This field is mutually exclusive from role.
+                    The instance profile should already have a role assigned to it that Karpenter
+                     has PassRole permission on for instance launch using this instanceProfile to succeed.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: instanceProfile cannot be empty
+                      rule: self != ''
+                instanceStorePolicy:
+                  description: InstanceStorePolicy specifies how to handle instance-store disks.
+                  enum:
+                    - RAID0
+                  type: string
+                metadataOptions:
+                  default:
+                    httpEndpoint: enabled
+                    httpProtocolIPv6: disabled
+                    httpPutResponseHopLimit: 1
+                    httpTokens: required
+                  description: |-
+                    MetadataOptions for the generated launch template of provisioned nodes.
+
+                    This specifies the exposure of the Instance Metadata Service to
+                    provisioned EC2 nodes. For more information,
+                    see Instance Metadata and User Data
+                    (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
+                    in the Amazon Elastic Compute Cloud User Guide.
+
+                    Refer to recommended, security best practices
+                    (https://aws.github.io/aws-eks-best-practices/security/docs/iam/#restrict-access-to-the-instance-profile-assigned-to-the-worker-node)
+                    for limiting exposure of Instance Metadata and User Data to pods.
+                    If omitted, defaults to httpEndpoint enabled, with httpProtocolIPv6
+                    disabled, with httpPutResponseLimit of 1, and with httpTokens
+                    required.
+                  properties:
+                    httpEndpoint:
+                      default: enabled
+                      description: |-
+                        HTTPEndpoint enables or disables the HTTP metadata endpoint on provisioned
+                        nodes. If metadata options is non-nil, but this parameter is not specified,
+                        the default state is "enabled".
+
+                        If you specify a value of "disabled", instance metadata will not be accessible
+                        on the node.
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpProtocolIPv6:
+                      default: disabled
+                      description: |-
+                        HTTPProtocolIPv6 enables or disables the IPv6 endpoint for the instance metadata
+                        service on provisioned nodes. If metadata options is non-nil, but this parameter
+                        is not specified, the default state is "disabled".
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpPutResponseHopLimit:
+                      default: 2
+                      description: |-
+                        HTTPPutResponseHopLimit is the desired HTTP PUT response hop limit for
+                        instance metadata requests. The larger the number, the further instance
+                        metadata requests can travel. Possible values are integers from 1 to 64.
+                        If metadata options is non-nil, but this parameter is not specified, the
+                        default value is 2.
+                      format: int64
+                      maximum: 64
+                      minimum: 1
+                      type: integer
+                    httpTokens:
+                      default: required
+                      description: |-
+                        HTTPTokens determines the state of token usage for instance metadata
+                        requests. If metadata options is non-nil, but this parameter is not
+                        specified, the default state is "required".
+
+                        If the state is optional, one can choose to retrieve instance metadata with
+                        or without a signed token header on the request. If one retrieves the IAM
+                        role credentials without a token, the version 1.0 role credentials are
+                        returned. If one retrieves the IAM role credentials using a valid signed
+                        token, the version 2.0 role credentials are returned.
+
+                        If the state is "required", one must send a signed token header with any
+                        instance metadata retrieval requests. In this state, retrieving the IAM
+                        role credentials always returns the version 2.0 credentials; the version
+                        1.0 credentials are not available.
+                      enum:
+                        - required
+                        - optional
+                      type: string
+                  type: object
+                role:
+                  description: |-
+                    Role is the AWS identity that nodes use. This field is immutable.
+                    This field is mutually exclusive from instanceProfile.
+                    Marking this field as immutable avoids concerns around terminating managed instance profiles from running instances.
+                    This field may be made mutable in the future, assuming the correct garbage collection and drift handling is implemented
+                    for the old instance profiles on an update.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: role cannot be empty
+                      rule: self != ''
+                    - message: immutable field changed
+                      rule: self == oldSelf
+                securityGroupSelectorTerms:
+                  description: SecurityGroupSelectorTerms is a list of or security group selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SecurityGroupSelectorTerm defines selection logic for a security group used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the security group id in EC2
+                        pattern: sg-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the security group name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: securityGroupSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id', 'name']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && (has(x.tags) || has(x.name)))'
+                    - message: '''name'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.name) && (has(x.tags) || has(x.id)))'
+                subnetSelectorTerms:
+                  description: SubnetSelectorTerms is a list of or subnet selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SubnetSelectorTerm defines selection logic for a subnet used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the subnet id in EC2
+                        pattern: subnet-[0-9a-z]+
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: subnetSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id']
+                      rule: self.all(x, has(x.tags) || has(x.id))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in subnetSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && has(x.tags))'
+                tags:
+                  additionalProperties:
+                    type: string
+                  description: Tags to be applied on ec2 resources like instances and launch templates.
+                  type: object
+                  x-kubernetes-validations:
+                    - message: empty tag keys aren't supported
+                      rule: self.all(k, k != '')
+                    - message: tag contains a restricted tag matching kubernetes.io/cluster/
+                      rule: self.all(k, !k.startsWith('kubernetes.io/cluster') )
+                    - message: tag contains a restricted tag matching karpenter.sh/nodepool
+                      rule: self.all(k, k != 'karpenter.sh/nodepool')
+                    - message: tag contains a restricted tag matching karpenter.sh/managed-by
+                      rule: self.all(k, k !='karpenter.sh/managed-by')
+                    - message: tag contains a restricted tag matching karpenter.sh/nodeclaim
+                      rule: self.all(k, k !='karpenter.sh/nodeclaim')
+                    - message: tag contains a restricted tag matching karpenter.k8s.aws/ec2nodeclass
+                      rule: self.all(k, k !='karpenter.k8s.aws/ec2nodeclass')
+                userData:
+                  description: |-
+                    UserData to be applied to the provisioned nodes.
+                    It must be in the appropriate format based on the AMIFamily in use. Karpenter will merge certain fields into
+                    this UserData to ensure nodes are being provisioned with the correct configuration.
+                  type: string
+              required:
+                - amiFamily
+                - securityGroupSelectorTerms
+                - subnetSelectorTerms
+              type: object
+              x-kubernetes-validations:
+                - message: amiSelectorTerms is required when amiFamily == 'Custom'
+                  rule: 'self.amiFamily == ''Custom'' ? self.amiSelectorTerms.size() != 0 : true'
+                - message: must specify exactly one of ['role', 'instanceProfile']
+                  rule: (has(self.role) && !has(self.instanceProfile)) || (!has(self.role) && has(self.instanceProfile))
+                - message: changing from 'instanceProfile' to 'role' is not supported. You must delete and recreate this node class if you want to change this.
+                  rule: (has(oldSelf.role) && has(self.role)) || (has(oldSelf.instanceProfile) && has(self.instanceProfile))
+            status:
+              description: EC2NodeClassStatus contains the resolved state of the EC2NodeClass
+              properties:
+                amis:
+                  description: |-
+                    AMI contains the current AMI values that are available to the
+                    cluster under the AMI selectors.
+                  items:
+                    description: AMI contains resolved AMI selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the AMI
+                        type: string
+                      name:
+                        description: Name of the AMI
+                        type: string
+                      requirements:
+                        description: Requirements of the AMI to be utilized on an instance type
+                        items:
+                          description: |-
+                            A node selector requirement is a selector that contains values, a key, and an operator
+                            that relates the key and values.
+                          properties:
+                            key:
+                              description: The label key that the selector applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                Represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                              type: string
+                            values:
+                              description: |-
+                                An array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. If the operator is Gt or Lt, the values
+                                array must have a single element, which will be interpreted as an integer.
+                                This array is replaced during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                            - key
+                            - operator
+                          type: object
+                        type: array
+                    required:
+                      - id
+                      - requirements
+                    type: object
+                  type: array
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                instanceProfile:
+                  description: InstanceProfile contains the resolved instance profile for the role
+                  type: string
+                securityGroups:
+                  description: |-
+                    SecurityGroups contains the current Security Groups values that are available to the
+                    cluster under the SecurityGroups selectors.
+                  items:
+                    description: SecurityGroup contains resolved SecurityGroup selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the security group
+                        type: string
+                      name:
+                        description: Name of the security group
+                        type: string
+                    required:
+                      - id
+                    type: object
+                  type: array
+                subnets:
+                  description: |-
+                    Subnets contains the current Subnet values that are available to the
+                    cluster under the subnet selectors.
+                  items:
+                    description: Subnet contains resolved Subnet selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the subnet
+                        type: string
+                      zone:
+                        description: The associated availability zone
+                        type: string
+                      zoneID:
+                        description: The associated availability zone ID
+                        type: string
+                    required:
+                      - id
+                      - zone
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+        - v1
+      clientConfig:
+        service:
+          name: karpenter
+          namespace: kube-system
+          port: 8443

--- a/content/projects/karpenter/v1.0.8/karpenter.sh_nodeclaims.yaml
+++ b/content/projects/karpenter/v1.0.8/karpenter.sh_nodeclaims.yaml
@@ -1,0 +1,829 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: nodeclaims.karpenter.sh
+spec:
+  group: karpenter.sh
+  names:
+    categories:
+      - karpenter
+    kind: NodeClaim
+    listKind: NodeClaimList
+    plural: nodeclaims
+    singular: nodeclaim
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.labels.node\.kubernetes\.io/instance-type
+          name: Type
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/capacity-type
+          name: Capacity
+          type: string
+        - jsonPath: .metadata.labels.topology\.kubernetes\.io/zone
+          name: Zone
+          type: string
+        - jsonPath: .status.nodeName
+          name: Node
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .status.providerID
+          name: ID
+          priority: 1
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/nodepool
+          name: NodePool
+          priority: 1
+          type: string
+        - jsonPath: .spec.nodeClassRef.name
+          name: NodeClass
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: NodeClaim is the Schema for the NodeClaims API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: NodeClaimSpec describes the desired state of the NodeClaim
+              properties:
+                expireAfter:
+                  default: 720h
+                  description: |-
+                    ExpireAfter is the duration the controller will wait
+                    before terminating a node, measured from when the node is created. This
+                    is useful to implement features like eventually consistent node upgrade,
+                    memory leak protection, and disruption testing.
+                  pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                  type: string
+                nodeClassRef:
+                  description: NodeClassRef is a reference to an object that defines provider specific configuration
+                  properties:
+                    group:
+                      description: API version of the referent
+                      pattern: ^[^/]*$
+                      type: string
+                    kind:
+                      description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                      type: string
+                    name:
+                      description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                      type: string
+                  required:
+                    - group
+                    - kind
+                    - name
+                  type: object
+                requirements:
+                  description: Requirements are layered with GetLabels and applied to every node.
+                  items:
+                    description: |-
+                      A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                      and minValues that represent the requirement to have at least that many values.
+                    properties:
+                      key:
+                        description: The label key that the selector applies to.
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                        x-kubernetes-validations:
+                          - message: label domain "kubernetes.io" is restricted
+                            rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                          - message: label domain "k8s.io" is restricted
+                            rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                          - message: label domain "karpenter.sh" is restricted
+                            rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                          - message: label "kubernetes.io/hostname" is restricted
+                            rule: self != "kubernetes.io/hostname"
+                          - message: label domain "karpenter.k8s.aws" is restricted
+                            rule: self in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                      minValues:
+                        description: |-
+                          This field is ALPHA and can be dropped or replaced at any time
+                          MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                        maximum: 50
+                        minimum: 1
+                        type: integer
+                      operator:
+                        description: |-
+                          Represents a key's relationship to a set of values.
+                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                        type: string
+                        enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          - Gt
+                          - Lt
+                      values:
+                        description: |-
+                          An array of string values. If the operator is In or NotIn,
+                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                          the values array must be empty. If the operator is Gt or Lt, the values
+                          array must have a single element, which will be interpreted as an integer.
+                          This array is replaced during a strategic merge patch.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                        maxLength: 63
+                        pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                    required:
+                      - key
+                      - operator
+                    type: object
+                  maxItems: 100
+                  type: array
+                  x-kubernetes-validations:
+                    - message: requirements with operator 'In' must have a value defined
+                      rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                    - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                      rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                    - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                      rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                resources:
+                  description: Resources models the resource requirements for the NodeClaim to launch
+                  properties:
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: Requests describes the minimum required resources for the NodeClaim to launch
+                      type: object
+                  type: object
+                startupTaints:
+                  description: |-
+                    StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                    within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                    daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                    purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                taints:
+                  description: Taints will be applied to the NodeClaim's node.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                terminationGracePeriod:
+                  description: |-
+                    TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
+
+                    Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
+
+                    This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
+                    When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
+
+                    Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
+                    If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
+                    that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
+
+                    The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
+                    If left undefined, the controller will wait indefinitely for pods to be drained.
+                  pattern: ^([0-9]+(s|m|h))+$
+                  type: string
+              required:
+                - nodeClassRef
+                - requirements
+              type: object
+              x-kubernetes-validations:
+                - message: spec is immutable
+                  rule: self == oldSelf
+            status:
+              description: NodeClaimStatus defines the observed state of NodeClaim
+              properties:
+                allocatable:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Allocatable is the estimated allocatable capacity of the node
+                  type: object
+                capacity:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Capacity is the estimated full capacity of the node
+                  type: object
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        pattern: ^([A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?|)$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - status
+                      - type
+                    type: object
+                  type: array
+                imageID:
+                  description: ImageID is an identifier for the image that runs on the node
+                  type: string
+                lastPodEventTime:
+                  description: |-
+                    LastPodEventTime is updated with the last time a pod was scheduled
+                    or removed from the node. A pod going terminal or terminating
+                    is also considered as removed.
+                  format: date-time
+                  type: string
+                nodeName:
+                  description: NodeName is the name of the corresponding node object
+                  type: string
+                providerID:
+                  description: ProviderID of the corresponding node object
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.labels.node\.kubernetes\.io/instance-type
+          name: Type
+          type: string
+        - jsonPath: .metadata.labels.topology\.kubernetes\.io/zone
+          name: Zone
+          type: string
+        - jsonPath: .status.nodeName
+          name: Node
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .metadata.labels.karpenter\.sh/capacity-type
+          name: Capacity
+          priority: 1
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/nodepool
+          name: NodePool
+          priority: 1
+          type: string
+        - jsonPath: .spec.nodeClassRef.name
+          name: NodeClass
+          priority: 1
+          type: string
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: NodeClaim is the Schema for the NodeClaims API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: NodeClaimSpec describes the desired state of the NodeClaim
+              properties:
+                kubelet:
+                  description: |-
+                    Kubelet defines args to be used when configuring kubelet on provisioned nodes.
+                    They are a subset of the upstream types, recognizing not all options may be supported.
+                    Wherever possible, the types and names should reflect the upstream kubelet types.
+                  properties:
+                    clusterDNS:
+                      description: |-
+                        clusterDNS is a list of IP addresses for the cluster DNS server.
+                        Note that not all providers may use all addresses.
+                      items:
+                        type: string
+                      type: array
+                    cpuCFSQuota:
+                      description: CPUCFSQuota enables CPU CFS quota enforcement for containers that specify CPU limits.
+                      type: boolean
+                    evictionHard:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionHard is the map of signal names to quantities that define hard eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionHard are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionMaxPodGracePeriod:
+                      description: |-
+                        EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in
+                        response to soft eviction thresholds being met.
+                      format: int32
+                      type: integer
+                    evictionSoft:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionSoft is the map of signal names to quantities that define soft eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoft are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionSoftGracePeriod:
+                      additionalProperties:
+                        type: string
+                      description: EvictionSoftGracePeriod is the map of signal names to quantities that define grace periods for each eviction signal
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoftGracePeriod are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    imageGCHighThresholdPercent:
+                      description: |-
+                        ImageGCHighThresholdPercent is the percent of disk usage after which image
+                        garbage collection is always run. The percent is calculated by dividing this
+                        field value by 100, so this field must be between 0 and 100, inclusive.
+                        When specified, the value must be greater than ImageGCLowThresholdPercent.
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    imageGCLowThresholdPercent:
+                      description: |-
+                        ImageGCLowThresholdPercent is the percent of disk usage before which image
+                        garbage collection is never run. Lowest disk usage to garbage collect to.
+                        The percent is calculated by dividing this field value by 100,
+                        so the field value must be between 0 and 100, inclusive.
+                        When specified, the value must be less than imageGCHighThresholdPercent
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    kubeReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: KubeReserved contains resources reserved for Kubernetes system components.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for kubeReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: kubeReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                    maxPods:
+                      description: |-
+                        MaxPods is an override for the maximum number of pods that can run on
+                        a worker node instance.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    podsPerCore:
+                      description: |-
+                        PodsPerCore is an override for the number of pods that can run on a worker node
+                        instance based on the number of cpu cores. This value cannot exceed MaxPods, so, if
+                        MaxPods is a lower value, that value will be used.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    systemReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: SystemReserved contains resources reserved for OS system daemons and kernel memory.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for systemReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: systemReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                  type: object
+                  x-kubernetes-validations:
+                    - message: imageGCHighThresholdPercent must be greater than imageGCLowThresholdPercent
+                      rule: 'has(self.imageGCHighThresholdPercent) && has(self.imageGCLowThresholdPercent) ?  self.imageGCHighThresholdPercent > self.imageGCLowThresholdPercent  : true'
+                    - message: evictionSoft OwnerKey does not have a matching evictionSoftGracePeriod
+                      rule: has(self.evictionSoft) ? self.evictionSoft.all(e, (e in self.evictionSoftGracePeriod)):true
+                    - message: evictionSoftGracePeriod OwnerKey does not have a matching evictionSoft
+                      rule: has(self.evictionSoftGracePeriod) ? self.evictionSoftGracePeriod.all(e, (e in self.evictionSoft)):true
+                nodeClassRef:
+                  description: NodeClassRef is a reference to an object that defines provider specific configuration
+                  properties:
+                    apiVersion:
+                      description: API version of the referent
+                      type: string
+                    kind:
+                      description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                      type: string
+                    name:
+                      description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                      type: string
+                  required:
+                    - name
+                  type: object
+                requirements:
+                  description: Requirements are layered with GetLabels and applied to every node.
+                  items:
+                    description: |-
+                      A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                      and minValues that represent the requirement to have at least that many values.
+                    properties:
+                      key:
+                        description: The label key that the selector applies to.
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                        x-kubernetes-validations:
+                          - message: label domain "kubernetes.io" is restricted
+                            rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                          - message: label domain "k8s.io" is restricted
+                            rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                          - message: label domain "karpenter.sh" is restricted
+                            rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                          - message: label "kubernetes.io/hostname" is restricted
+                            rule: self != "kubernetes.io/hostname"
+                          - message: label domain "karpenter.k8s.aws" is restricted
+                            rule: self in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                      minValues:
+                        description: |-
+                          This field is ALPHA and can be dropped or replaced at any time
+                          MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                        maximum: 50
+                        minimum: 1
+                        type: integer
+                      operator:
+                        description: |-
+                          Represents a key's relationship to a set of values.
+                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                        type: string
+                        enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          - Gt
+                          - Lt
+                      values:
+                        description: |-
+                          An array of string values. If the operator is In or NotIn,
+                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                          the values array must be empty. If the operator is Gt or Lt, the values
+                          array must have a single element, which will be interpreted as an integer.
+                          This array is replaced during a strategic merge patch.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                        maxLength: 63
+                        pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                    required:
+                      - key
+                      - operator
+                    type: object
+                  maxItems: 100
+                  type: array
+                  x-kubernetes-validations:
+                    - message: requirements with operator 'In' must have a value defined
+                      rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                    - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                      rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                    - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                      rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                resources:
+                  description: Resources models the resource requirements for the NodeClaim to launch
+                  properties:
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: Requests describes the minimum required resources for the NodeClaim to launch
+                      type: object
+                  type: object
+                startupTaints:
+                  description: |-
+                    StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                    within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                    daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                    purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                taints:
+                  description: Taints will be applied to the NodeClaim's node.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+              required:
+                - nodeClassRef
+                - requirements
+              type: object
+            status:
+              description: NodeClaimStatus defines the observed state of NodeClaim
+              properties:
+                allocatable:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Allocatable is the estimated allocatable capacity of the node
+                  type: object
+                capacity:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Capacity is the estimated full capacity of the node
+                  type: object
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        pattern: ^([A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?|)$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - status
+                      - type
+                    type: object
+                  type: array
+                imageID:
+                  description: ImageID is an identifier for the image that runs on the node
+                  type: string
+                nodeName:
+                  description: NodeName is the name of the corresponding node object
+                  type: string
+                providerID:
+                  description: ProviderID of the corresponding node object
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+        - v1
+      clientConfig:
+        service:
+          name: karpenter
+          namespace: kube-system
+          port: 8443

--- a/content/projects/karpenter/v1.0.8/karpenter.sh_nodepools.yaml
+++ b/content/projects/karpenter/v1.0.8/karpenter.sh_nodepools.yaml
@@ -1,0 +1,1082 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: nodepools.karpenter.sh
+spec:
+  group: karpenter.sh
+  names:
+    categories:
+      - karpenter
+    kind: NodePool
+    listKind: NodePoolList
+    plural: nodepools
+    singular: nodepool
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.template.spec.nodeClassRef.name
+          name: NodeClass
+          type: string
+        - jsonPath: .status.resources.nodes
+          name: Nodes
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.weight
+          name: Weight
+          priority: 1
+          type: integer
+        - jsonPath: .status.resources.cpu
+          name: CPU
+          priority: 1
+          type: string
+        - jsonPath: .status.resources.memory
+          name: Memory
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: NodePool is the Schema for the NodePools API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                NodePoolSpec is the top level nodepool specification. Nodepools
+                launch nodes in response to pods that are unschedulable. A single nodepool
+                is capable of managing a diverse set of nodes. Node properties are determined
+                from a combination of nodepool and pod scheduling constraints.
+              properties:
+                disruption:
+                  default:
+                    consolidateAfter: 0s
+                  description: Disruption contains the parameters that relate to Karpenter's disruption logic
+                  properties:
+                    budgets:
+                      default:
+                        - nodes: 10%
+                      description: |-
+                        Budgets is a list of Budgets.
+                        If there are multiple active budgets, Karpenter uses
+                        the most restrictive value. If left undefined,
+                        this will default to one budget with a value to 10%.
+                      items:
+                        description: |-
+                          Budget defines when Karpenter will restrict the
+                          number of Node Claims that can be terminating simultaneously.
+                        properties:
+                          duration:
+                            description: |-
+                              Duration determines how long a Budget is active since each Schedule hit.
+                              Only minutes and hours are accepted, as cron does not work in seconds.
+                              If omitted, the budget is always active.
+                              This is required if Schedule is set.
+                              This regex has an optional 0s at the end since the duration.String() always adds
+                              a 0s at the end.
+                            pattern: ^((([0-9]+(h|m))|([0-9]+h[0-9]+m))(0s)?)$
+                            type: string
+                          nodes:
+                            default: 10%
+                            description: |-
+                              Nodes dictates the maximum number of NodeClaims owned by this NodePool
+                              that can be terminating at once. This is calculated by counting nodes that
+                              have a deletion timestamp set, or are actively being deleted by Karpenter.
+                              This field is required when specifying a budget.
+                              This cannot be of type intstr.IntOrString since kubebuilder doesn't support pattern
+                              checking for int nodes for IntOrString nodes.
+                              Ref: https://github.com/kubernetes-sigs/controller-tools/blob/55efe4be40394a288216dab63156b0a64fb82929/pkg/crd/markers/validation.go#L379-L388
+                            pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
+                            type: string
+                          reasons:
+                            description: |-
+                              Reasons is a list of disruption methods that this budget applies to. If Reasons is not set, this budget applies to all methods.
+                              Otherwise, this will apply to each reason defined.
+                              allowed reasons are Underutilized, Empty, and Drifted.
+                            items:
+                              description: DisruptionReason defines valid reasons for disruption budgets.
+                              enum:
+                                - Underutilized
+                                - Empty
+                                - Drifted
+                              type: string
+                            type: array
+                          schedule:
+                            description: |-
+                              Schedule specifies when a budget begins being active, following
+                              the upstream cronjob syntax. If omitted, the budget is always active.
+                              Timezones are not supported.
+                              This field is required if Duration is set.
+                            pattern: ^(@(annually|yearly|monthly|weekly|daily|midnight|hourly))|((.+)\s(.+)\s(.+)\s(.+)\s(.+))$
+                            type: string
+                        required:
+                          - nodes
+                        type: object
+                      maxItems: 50
+                      type: array
+                      x-kubernetes-validations:
+                        - message: '''schedule'' must be set with ''duration'''
+                          rule: self.all(x, has(x.schedule) == has(x.duration))
+                    consolidateAfter:
+                      description: |-
+                        ConsolidateAfter is the duration the controller will wait
+                        before attempting to terminate nodes that are underutilized.
+                        Refer to ConsolidationPolicy for how underutilization is considered.
+                      pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                      type: string
+                    consolidationPolicy:
+                      default: WhenEmptyOrUnderutilized
+                      description: |-
+                        ConsolidationPolicy describes which nodes Karpenter can disrupt through its consolidation
+                        algorithm. This policy defaults to "WhenEmptyOrUnderutilized" if not specified
+                      enum:
+                        - WhenEmpty
+                        - WhenEmptyOrUnderutilized
+                      type: string
+                  required:
+                    - consolidateAfter
+                  type: object
+                limits:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Limits define a set of bounds for provisioning capacity.
+                  type: object
+                template:
+                  description: |-
+                    Template contains the template of possibilities for the provisioning logic to launch a NodeClaim with.
+                    NodeClaims launched from this NodePool will often be further constrained than the template specifies.
+                  properties:
+                    metadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Annotations is an unstructured key value map stored with a resource that may be
+                            set by external tools to store and retrieve arbitrary metadata. They are not
+                            queryable and should be preserved when modifying objects.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                            maxLength: 63
+                            pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                          description: |-
+                            Map of string keys and values that can be used to organize and categorize
+                            (scope and select) objects. May match selectors of replication controllers
+                            and services.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
+                          type: object
+                          maxProperties: 100
+                          x-kubernetes-validations:
+                            - message: label domain "kubernetes.io" is restricted
+                              rule: self.all(x, x in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region",  "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || x.find("^([^/]+)").endsWith("node.kubernetes.io") || x.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !x.find("^([^/]+)").endsWith("kubernetes.io"))
+                            - message: label domain "k8s.io" is restricted
+                              rule: self.all(x, x.find("^([^/]+)").endsWith("kops.k8s.io") || !x.find("^([^/]+)").endsWith("k8s.io"))
+                            - message: label domain "karpenter.sh" is restricted
+                              rule: self.all(x, x in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !x.find("^([^/]+)").endsWith("karpenter.sh"))
+                            - message: label "karpenter.sh/nodepool" is restricted
+                              rule: self.all(x, x != "karpenter.sh/nodepool")
+                            - message: label "kubernetes.io/hostname" is restricted
+                              rule: self.all(x, x != "kubernetes.io/hostname")
+                            - message: label domain "karpenter.k8s.aws" is restricted
+                              rule: self.all(x, x in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !x.find("^([^/]+)").endsWith("karpenter.k8s.aws"))
+                      type: object
+                    spec:
+                      description: |-
+                        NodeClaimTemplateSpec describes the desired state of the NodeClaim in the Nodepool
+                        NodeClaimTemplateSpec is used in the NodePool's NodeClaimTemplate, with the resource requests omitted since
+                        users are not able to set resource requests in the NodePool.
+                      properties:
+                        expireAfter:
+                          default: 720h
+                          description: |-
+                            ExpireAfter is the duration the controller will wait
+                            before terminating a node, measured from when the node is created. This
+                            is useful to implement features like eventually consistent node upgrade,
+                            memory leak protection, and disruption testing.
+                          pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                          type: string
+                        nodeClassRef:
+                          description: NodeClassRef is a reference to an object that defines provider specific configuration
+                          properties:
+                            group:
+                              description: API version of the referent
+                              pattern: ^[^/]*$
+                              type: string
+                            kind:
+                              description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                              type: string
+                            name:
+                              description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                          required:
+                            - group
+                            - kind
+                            - name
+                          type: object
+                        requirements:
+                          description: Requirements are layered with GetLabels and applied to every node.
+                          items:
+                            description: |-
+                              A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                              and minValues that represent the requirement to have at least that many values.
+                            properties:
+                              key:
+                                description: The label key that the selector applies to.
+                                type: string
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                                x-kubernetes-validations:
+                                  - message: label domain "kubernetes.io" is restricted
+                                    rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                                  - message: label domain "k8s.io" is restricted
+                                    rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                                  - message: label domain "karpenter.sh" is restricted
+                                    rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                                  - message: label "karpenter.sh/nodepool" is restricted
+                                    rule: self != "karpenter.sh/nodepool"
+                                  - message: label "kubernetes.io/hostname" is restricted
+                                    rule: self != "kubernetes.io/hostname"
+                                  - message: label domain "karpenter.k8s.aws" is restricted
+                                    rule: self in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                              minValues:
+                                description: |-
+                                  This field is ALPHA and can be dropped or replaced at any time
+                                  MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                                maximum: 50
+                                minimum: 1
+                                type: integer
+                              operator:
+                                description: |-
+                                  Represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                type: string
+                                enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  - Gt
+                                  - Lt
+                              values:
+                                description: |-
+                                  An array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                  array must have a single element, which will be interpreted as an integer.
+                                  This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          maxItems: 100
+                          type: array
+                          x-kubernetes-validations:
+                            - message: requirements with operator 'In' must have a value defined
+                              rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                            - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                              rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                            - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                              rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                        startupTaints:
+                          description: |-
+                            StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                            within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                            daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                            purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        taints:
+                          description: Taints will be applied to the NodeClaim's node.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        terminationGracePeriod:
+                          description: |-
+                            TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
+
+                            Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
+
+                            This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
+                            When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
+
+                            Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
+                            If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
+                            that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
+
+                            The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
+                            If left undefined, the controller will wait indefinitely for pods to be drained.
+                          pattern: ^([0-9]+(s|m|h))+$
+                          type: string
+                      required:
+                        - nodeClassRef
+                        - requirements
+                      type: object
+                  required:
+                    - spec
+                  type: object
+                weight:
+                  description: |-
+                    Weight is the priority given to the nodepool during scheduling. A higher
+                    numerical weight indicates that this nodepool will be ordered
+                    ahead of other nodepools with lower weights. A nodepool with no weight
+                    will be treated as if it is a nodepool with a weight of 0.
+                  format: int32
+                  maximum: 100
+                  minimum: 1
+                  type: integer
+              required:
+                - template
+              type: object
+            status:
+              description: NodePoolStatus defines the observed state of NodePool
+              properties:
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                resources:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Resources is the list of resources that have been provisioned.
+                  type: object
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .spec.template.spec.nodeClassRef.name
+          name: NodeClass
+          type: string
+        - jsonPath: .spec.weight
+          name: Weight
+          priority: 1
+          type: string
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: NodePool is the Schema for the NodePools API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                NodePoolSpec is the top level nodepool specification. Nodepools
+                launch nodes in response to pods that are unschedulable. A single nodepool
+                is capable of managing a diverse set of nodes. Node properties are determined
+                from a combination of nodepool and pod scheduling constraints.
+              properties:
+                disruption:
+                  default:
+                    consolidationPolicy: WhenUnderutilized
+                    expireAfter: 720h
+                  description: Disruption contains the parameters that relate to Karpenter's disruption logic
+                  properties:
+                    budgets:
+                      default:
+                        - nodes: 10%
+                      description: |-
+                        Budgets is a list of Budgets.
+                        If there are multiple active budgets, Karpenter uses
+                        the most restrictive value. If left undefined,
+                        this will default to one budget with a value to 10%.
+                      items:
+                        description: |-
+                          Budget defines when Karpenter will restrict the
+                          number of Node Claims that can be terminating simultaneously.
+                        properties:
+                          duration:
+                            description: |-
+                              Duration determines how long a Budget is active since each Schedule hit.
+                              Only minutes and hours are accepted, as cron does not work in seconds.
+                              If omitted, the budget is always active.
+                              This is required if Schedule is set.
+                              This regex has an optional 0s at the end since the duration.String() always adds
+                              a 0s at the end.
+                            pattern: ^((([0-9]+(h|m))|([0-9]+h[0-9]+m))(0s)?)$
+                            type: string
+                          nodes:
+                            default: 10%
+                            description: |-
+                              Nodes dictates the maximum number of NodeClaims owned by this NodePool
+                              that can be terminating at once. This is calculated by counting nodes that
+                              have a deletion timestamp set, or are actively being deleted by Karpenter.
+                              This field is required when specifying a budget.
+                              This cannot be of type intstr.IntOrString since kubebuilder doesn't support pattern
+                              checking for int nodes for IntOrString nodes.
+                              Ref: https://github.com/kubernetes-sigs/controller-tools/blob/55efe4be40394a288216dab63156b0a64fb82929/pkg/crd/markers/validation.go#L379-L388
+                            pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
+                            type: string
+                          schedule:
+                            description: |-
+                              Schedule specifies when a budget begins being active, following
+                              the upstream cronjob syntax. If omitted, the budget is always active.
+                              Timezones are not supported.
+                              This field is required if Duration is set.
+                            pattern: ^(@(annually|yearly|monthly|weekly|daily|midnight|hourly))|((.+)\s(.+)\s(.+)\s(.+)\s(.+))$
+                            type: string
+                        required:
+                          - nodes
+                        type: object
+                      maxItems: 50
+                      type: array
+                      x-kubernetes-validations:
+                        - message: '''schedule'' must be set with ''duration'''
+                          rule: self.all(x, has(x.schedule) == has(x.duration))
+                    consolidateAfter:
+                      description: |-
+                        ConsolidateAfter is the duration the controller will wait
+                        before attempting to terminate nodes that are underutilized.
+                        Refer to ConsolidationPolicy for how underutilization is considered.
+                      pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                      type: string
+                    consolidationPolicy:
+                      default: WhenUnderutilized
+                      description: |-
+                        ConsolidationPolicy describes which nodes Karpenter can disrupt through its consolidation
+                        algorithm. This policy defaults to "WhenUnderutilized" if not specified
+                      enum:
+                        - WhenEmpty
+                        - WhenUnderutilized
+                      type: string
+                    expireAfter:
+                      default: 720h
+                      description: |-
+                        ExpireAfter is the duration the controller will wait
+                        before terminating a node, measured from when the node is created. This
+                        is useful to implement features like eventually consistent node upgrade,
+                        memory leak protection, and disruption testing.
+                      pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                      type: string
+                  type: object
+                  x-kubernetes-validations:
+                    - message: consolidateAfter cannot be combined with consolidationPolicy=WhenUnderutilized
+                      rule: 'has(self.consolidateAfter) ? self.consolidationPolicy != ''WhenUnderutilized'' || self.consolidateAfter == ''Never'' : true'
+                    - message: consolidateAfter must be specified with consolidationPolicy=WhenEmpty
+                      rule: 'self.consolidationPolicy == ''WhenEmpty'' ? has(self.consolidateAfter) : true'
+                limits:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Limits define a set of bounds for provisioning capacity.
+                  type: object
+                template:
+                  description: |-
+                    Template contains the template of possibilities for the provisioning logic to launch a NodeClaim with.
+                    NodeClaims launched from this NodePool will often be further constrained than the template specifies.
+                  properties:
+                    metadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Annotations is an unstructured key value map stored with a resource that may be
+                            set by external tools to store and retrieve arbitrary metadata. They are not
+                            queryable and should be preserved when modifying objects.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                            maxLength: 63
+                            pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                          description: |-
+                            Map of string keys and values that can be used to organize and categorize
+                            (scope and select) objects. May match selectors of replication controllers
+                            and services.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
+                          type: object
+                          maxProperties: 100
+                          x-kubernetes-validations:
+                            - message: label domain "kubernetes.io" is restricted
+                              rule: self.all(x, x in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region",  "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || x.find("^([^/]+)").endsWith("node.kubernetes.io") || x.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !x.find("^([^/]+)").endsWith("kubernetes.io"))
+                            - message: label domain "k8s.io" is restricted
+                              rule: self.all(x, x.find("^([^/]+)").endsWith("kops.k8s.io") || !x.find("^([^/]+)").endsWith("k8s.io"))
+                            - message: label domain "karpenter.sh" is restricted
+                              rule: self.all(x, x in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !x.find("^([^/]+)").endsWith("karpenter.sh"))
+                            - message: label "karpenter.sh/nodepool" is restricted
+                              rule: self.all(x, x != "karpenter.sh/nodepool")
+                            - message: label "kubernetes.io/hostname" is restricted
+                              rule: self.all(x, x != "kubernetes.io/hostname")
+                            - message: label domain "karpenter.k8s.aws" is restricted
+                              rule: self.all(x, x in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !x.find("^([^/]+)").endsWith("karpenter.k8s.aws"))
+                      type: object
+                    spec:
+                      description: NodeClaimSpec describes the desired state of the NodeClaim
+                      properties:
+                        kubelet:
+                          description: |-
+                            Kubelet defines args to be used when configuring kubelet on provisioned nodes.
+                            They are a subset of the upstream types, recognizing not all options may be supported.
+                            Wherever possible, the types and names should reflect the upstream kubelet types.
+                          properties:
+                            clusterDNS:
+                              description: |-
+                                clusterDNS is a list of IP addresses for the cluster DNS server.
+                                Note that not all providers may use all addresses.
+                              items:
+                                type: string
+                              type: array
+                            cpuCFSQuota:
+                              description: CPUCFSQuota enables CPU CFS quota enforcement for containers that specify CPU limits.
+                              type: boolean
+                            evictionHard:
+                              additionalProperties:
+                                type: string
+                                pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                              description: EvictionHard is the map of signal names to quantities that define hard eviction thresholds
+                              type: object
+                              x-kubernetes-validations:
+                                - message: valid keys for evictionHard are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                                  rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                            evictionMaxPodGracePeriod:
+                              description: |-
+                                EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in
+                                response to soft eviction thresholds being met.
+                              format: int32
+                              type: integer
+                            evictionSoft:
+                              additionalProperties:
+                                type: string
+                                pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                              description: EvictionSoft is the map of signal names to quantities that define soft eviction thresholds
+                              type: object
+                              x-kubernetes-validations:
+                                - message: valid keys for evictionSoft are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                                  rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                            evictionSoftGracePeriod:
+                              additionalProperties:
+                                type: string
+                              description: EvictionSoftGracePeriod is the map of signal names to quantities that define grace periods for each eviction signal
+                              type: object
+                              x-kubernetes-validations:
+                                - message: valid keys for evictionSoftGracePeriod are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                                  rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                            imageGCHighThresholdPercent:
+                              description: |-
+                                ImageGCHighThresholdPercent is the percent of disk usage after which image
+                                garbage collection is always run. The percent is calculated by dividing this
+                                field value by 100, so this field must be between 0 and 100, inclusive.
+                                When specified, the value must be greater than ImageGCLowThresholdPercent.
+                              format: int32
+                              maximum: 100
+                              minimum: 0
+                              type: integer
+                            imageGCLowThresholdPercent:
+                              description: |-
+                                ImageGCLowThresholdPercent is the percent of disk usage before which image
+                                garbage collection is never run. Lowest disk usage to garbage collect to.
+                                The percent is calculated by dividing this field value by 100,
+                                so the field value must be between 0 and 100, inclusive.
+                                When specified, the value must be less than imageGCHighThresholdPercent
+                              format: int32
+                              maximum: 100
+                              minimum: 0
+                              type: integer
+                            kubeReserved:
+                              additionalProperties:
+                                type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              description: KubeReserved contains resources reserved for Kubernetes system components.
+                              type: object
+                              x-kubernetes-validations:
+                                - message: valid keys for kubeReserved are ['cpu','memory','ephemeral-storage','pid']
+                                  rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                                - message: kubeReserved value cannot be a negative resource quantity
+                                  rule: self.all(x, !self[x].startsWith('-'))
+                            maxPods:
+                              description: |-
+                                MaxPods is an override for the maximum number of pods that can run on
+                                a worker node instance.
+                              format: int32
+                              minimum: 0
+                              type: integer
+                            podsPerCore:
+                              description: |-
+                                PodsPerCore is an override for the number of pods that can run on a worker node
+                                instance based on the number of cpu cores. This value cannot exceed MaxPods, so, if
+                                MaxPods is a lower value, that value will be used.
+                              format: int32
+                              minimum: 0
+                              type: integer
+                            systemReserved:
+                              additionalProperties:
+                                type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              description: SystemReserved contains resources reserved for OS system daemons and kernel memory.
+                              type: object
+                              x-kubernetes-validations:
+                                - message: valid keys for systemReserved are ['cpu','memory','ephemeral-storage','pid']
+                                  rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                                - message: systemReserved value cannot be a negative resource quantity
+                                  rule: self.all(x, !self[x].startsWith('-'))
+                          type: object
+                          x-kubernetes-validations:
+                            - message: imageGCHighThresholdPercent must be greater than imageGCLowThresholdPercent
+                              rule: 'has(self.imageGCHighThresholdPercent) && has(self.imageGCLowThresholdPercent) ?  self.imageGCHighThresholdPercent > self.imageGCLowThresholdPercent  : true'
+                            - message: evictionSoft OwnerKey does not have a matching evictionSoftGracePeriod
+                              rule: has(self.evictionSoft) ? self.evictionSoft.all(e, (e in self.evictionSoftGracePeriod)):true
+                            - message: evictionSoftGracePeriod OwnerKey does not have a matching evictionSoft
+                              rule: has(self.evictionSoftGracePeriod) ? self.evictionSoftGracePeriod.all(e, (e in self.evictionSoft)):true
+                        nodeClassRef:
+                          description: NodeClassRef is a reference to an object that defines provider specific configuration
+                          properties:
+                            apiVersion:
+                              description: API version of the referent
+                              type: string
+                            kind:
+                              description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                              type: string
+                            name:
+                              description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        requirements:
+                          description: Requirements are layered with GetLabels and applied to every node.
+                          items:
+                            description: |-
+                              A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                              and minValues that represent the requirement to have at least that many values.
+                            properties:
+                              key:
+                                description: The label key that the selector applies to.
+                                type: string
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                                x-kubernetes-validations:
+                                  - message: label domain "kubernetes.io" is restricted
+                                    rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                                  - message: label domain "k8s.io" is restricted
+                                    rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                                  - message: label domain "karpenter.sh" is restricted
+                                    rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                                  - message: label "karpenter.sh/nodepool" is restricted
+                                    rule: self != "karpenter.sh/nodepool"
+                                  - message: label "kubernetes.io/hostname" is restricted
+                                    rule: self != "kubernetes.io/hostname"
+                                  - message: label domain "karpenter.k8s.aws" is restricted
+                                    rule: self in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                              minValues:
+                                description: |-
+                                  This field is ALPHA and can be dropped or replaced at any time
+                                  MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                                maximum: 50
+                                minimum: 1
+                                type: integer
+                              operator:
+                                description: |-
+                                  Represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                type: string
+                                enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  - Gt
+                                  - Lt
+                              values:
+                                description: |-
+                                  An array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                  array must have a single element, which will be interpreted as an integer.
+                                  This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          maxItems: 100
+                          type: array
+                          x-kubernetes-validations:
+                            - message: requirements with operator 'In' must have a value defined
+                              rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                            - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                              rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                            - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                              rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                        resources:
+                          description: Resources models the resource requirements for the NodeClaim to launch
+                          properties:
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: Requests describes the minimum required resources for the NodeClaim to launch
+                              type: object
+                          type: object
+                          maxProperties: 0
+                        startupTaints:
+                          description: |-
+                            StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                            within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                            daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                            purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        taints:
+                          description: Taints will be applied to the NodeClaim's node.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                      required:
+                        - nodeClassRef
+                        - requirements
+                      type: object
+                  required:
+                    - spec
+                  type: object
+                weight:
+                  description: |-
+                    Weight is the priority given to the nodepool during scheduling. A higher
+                    numerical weight indicates that this nodepool will be ordered
+                    ahead of other nodepools with lower weights. A nodepool with no weight
+                    will be treated as if it is a nodepool with a weight of 0.
+                  format: int32
+                  maximum: 100
+                  minimum: 1
+                  type: integer
+              required:
+                - template
+              type: object
+            status:
+              description: NodePoolStatus defines the observed state of NodePool
+              properties:
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                resources:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Resources is the list of resources that have been provisioned.
+                  type: object
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+        - v1
+      clientConfig:
+        service:
+          name: karpenter
+          namespace: kube-system
+          port: 8443

--- a/content/projects/karpenter/v1.0.9/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/content/projects/karpenter/v1.0.9/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -1,0 +1,1306 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: ec2nodeclasses.karpenter.k8s.aws
+spec:
+  group: karpenter.k8s.aws
+  names:
+    categories:
+      - karpenter
+    kind: EC2NodeClass
+    listKind: EC2NodeClassList
+    plural: ec2nodeclasses
+    shortNames:
+      - ec2nc
+      - ec2ncs
+    singular: ec2nodeclass
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.role
+          name: Role
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: EC2NodeClass is the Schema for the EC2NodeClass API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                EC2NodeClassSpec is the top level specification for the AWS Karpenter Provider.
+                This will contain configuration necessary to launch instances in AWS.
+              properties:
+                amiFamily:
+                  description: |-
+                    AMIFamily dictates the UserData format and default BlockDeviceMappings used when generating launch templates.
+                    This field is optional when using an alias amiSelectorTerm, and the value will be inferred from the alias'
+                    family. When an alias is specified, this field may only be set to its corresponding family or 'Custom'. If no
+                    alias is specified, this field is required.
+                    NOTE: We ignore the AMIFamily for hashing here because we hash the AMIFamily dynamically by using the alias using
+                    the AMIFamily() helper function
+                  enum:
+                    - AL2
+                    - AL2023
+                    - Bottlerocket
+                    - Custom
+                    - Windows2019
+                    - Windows2022
+                  type: string
+                amiSelectorTerms:
+                  description: AMISelectorTerms is a list of or ami selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      AMISelectorTerm defines selection logic for an ami used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      alias:
+                        description: |-
+                          Alias specifies which EKS optimized AMI to select.
+                          Each alias consists of a family and an AMI version, specified as "family@version".
+                          Valid families include: al2, al2023, bottlerocket, windows2019, and windows2022.
+                          The version can either be pinned to a specific AMI release, with that AMIs version format (ex: "al2023@v20240625" or "bottlerocket@v1.10.0").
+                          The version can also be set to "latest" for any family. Setting the version to latest will result in drift when a new AMI is released. This is **not** recommended for production environments.
+                          Note: The Windows families do **not** support version pinning, and only latest may be used.
+                        maxLength: 30
+                        type: string
+                        x-kubernetes-validations:
+                          - message: '''alias'' is improperly formatted, must match the format ''family@version'''
+                            rule: self.matches('^[a-zA-Z0-9]+@.+$')
+                          - message: 'family is not supported, must be one of the following: ''al2'', ''al2023'', ''bottlerocket'', ''windows2019'', ''windows2022'''
+                            rule: self.split('@')[0] in ['al2','al2023','bottlerocket','windows2019','windows2022']
+                          - message: windows families may only specify version 'latest'
+                            rule: 'self.split(''@'')[0] in [''windows2019'',''windows2022''] ? self.split(''@'')[1] == ''latest'' : true'
+                      id:
+                        description: ID is the ami id in EC2
+                        pattern: ami-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the ami name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      owner:
+                        description: |-
+                          Owner is the owner for the ami.
+                          You can specify a combination of AWS account IDs, "self", "amazon", and "aws-marketplace"
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  minItems: 1
+                  type: array
+                  x-kubernetes-validations:
+                    - message: expected at least one, got none, ['tags', 'id', 'name', 'alias']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name) || has(x.alias))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.exists(x, has(x.id) && (has(x.alias) || has(x.tags) || has(x.name) || has(x.owner)))'
+                    - message: '''alias'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.exists(x, has(x.alias) && (has(x.id) || has(x.tags) || has(x.name) || has(x.owner)))'
+                    - message: '''alias'' is mutually exclusive, cannot be set with a combination of other amiSelectorTerms'
+                      rule: '!(self.exists(x, has(x.alias)) && self.size() != 1)'
+                associatePublicIPAddress:
+                  description: AssociatePublicIPAddress controls if public IP addresses are assigned to instances that are launched with the nodeclass.
+                  type: boolean
+                blockDeviceMappings:
+                  description: BlockDeviceMappings to be applied to provisioned nodes.
+                  items:
+                    properties:
+                      deviceName:
+                        description: The device name (for example, /dev/sdh or xvdh).
+                        type: string
+                      ebs:
+                        description: EBS contains parameters used to automatically set up EBS volumes when an instance is launched.
+                        properties:
+                          deleteOnTermination:
+                            description: DeleteOnTermination indicates whether the EBS volume is deleted on instance termination.
+                            type: boolean
+                          encrypted:
+                            description: |-
+                              Encrypted indicates whether the EBS volume is encrypted. Encrypted volumes can only
+                              be attached to instances that support Amazon EBS encryption. If you are creating
+                              a volume from a snapshot, you can't specify an encryption value.
+                            type: boolean
+                          iops:
+                            description: |-
+                              IOPS is the number of I/O operations per second (IOPS). For gp3, io1, and io2 volumes,
+                              this represents the number of IOPS that are provisioned for the volume. For
+                              gp2 volumes, this represents the baseline performance of the volume and the
+                              rate at which the volume accumulates I/O credits for bursting.
+
+                              The following are the supported values for each volume type:
+
+                                 * gp3: 3,000-16,000 IOPS
+
+                                 * io1: 100-64,000 IOPS
+
+                                 * io2: 100-64,000 IOPS
+
+                              For io1 and io2 volumes, we guarantee 64,000 IOPS only for Instances built
+                              on the Nitro System (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances).
+                              Other instance families guarantee performance up to 32,000 IOPS.
+
+                              This parameter is supported for io1, io2, and gp3 volumes only. This parameter
+                              is not supported for gp2, st1, sc1, or standard volumes.
+                            format: int64
+                            type: integer
+                          kmsKeyID:
+                            description: KMSKeyID (ARN) of the symmetric Key Management Service (KMS) CMK used for encryption.
+                            type: string
+                          snapshotID:
+                            description: SnapshotID is the ID of an EBS snapshot
+                            type: string
+                          throughput:
+                            description: |-
+                              Throughput to provision for a gp3 volume, with a maximum of 1,000 MiB/s.
+                              Valid Range: Minimum value of 125. Maximum value of 1000.
+                            format: int64
+                            type: integer
+                          volumeSize:
+                            description: |-
+                              VolumeSize in `Gi`, `G`, `Ti`, or `T`. You must specify either a snapshot ID or
+                              a volume size. The following are the supported volumes sizes for each volume
+                              type:
+
+                                 * gp2 and gp3: 1-16,384
+
+                                 * io1 and io2: 4-16,384
+
+                                 * st1 and sc1: 125-16,384
+
+                                 * standard: 1-1,024
+                            pattern: ^((?:[1-9][0-9]{0,3}|[1-4][0-9]{4}|[5][0-8][0-9]{3}|59000)Gi|(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|[6][0-3][0-9]{3}|64000)G|([1-9]||[1-5][0-7]|58)Ti|([1-9]||[1-5][0-9]|6[0-3]|64)T)$
+                            type: string
+                          volumeType:
+                            description: |-
+                              VolumeType of the block device.
+                              For more information, see Amazon EBS volume types (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html)
+                              in the Amazon Elastic Compute Cloud User Guide.
+                            enum:
+                              - standard
+                              - io1
+                              - io2
+                              - gp2
+                              - sc1
+                              - st1
+                              - gp3
+                            type: string
+                        type: object
+                        x-kubernetes-validations:
+                          - message: snapshotID or volumeSize must be defined
+                            rule: has(self.snapshotID) || has(self.volumeSize)
+                      rootVolume:
+                        description: |-
+                          RootVolume is a flag indicating if this device is mounted as kubelet root dir. You can
+                          configure at most one root volume in BlockDeviceMappings.
+                        type: boolean
+                    type: object
+                  maxItems: 50
+                  type: array
+                  x-kubernetes-validations:
+                    - message: must have only one blockDeviceMappings with rootVolume
+                      rule: self.filter(x, has(x.rootVolume)?x.rootVolume==true:false).size() <= 1
+                context:
+                  description: |-
+                    Context is a Reserved field in EC2 APIs
+                    https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet.html
+                  type: string
+                detailedMonitoring:
+                  description: DetailedMonitoring controls if detailed monitoring is enabled for instances that are launched
+                  type: boolean
+                instanceProfile:
+                  description: |-
+                    InstanceProfile is the AWS entity that instances use.
+                    This field is mutually exclusive from role.
+                    The instance profile should already have a role assigned to it that Karpenter
+                     has PassRole permission on for instance launch using this instanceProfile to succeed.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: instanceProfile cannot be empty
+                      rule: self != ''
+                instanceStorePolicy:
+                  description: InstanceStorePolicy specifies how to handle instance-store disks.
+                  enum:
+                    - RAID0
+                  type: string
+                kubelet:
+                  description: |-
+                    Kubelet defines args to be used when configuring kubelet on provisioned nodes.
+                    They are a subset of the upstream types, recognizing not all options may be supported.
+                    Wherever possible, the types and names should reflect the upstream kubelet types.
+                  properties:
+                    clusterDNS:
+                      description: |-
+                        clusterDNS is a list of IP addresses for the cluster DNS server.
+                        Note that not all providers may use all addresses.
+                      items:
+                        type: string
+                      type: array
+                    cpuCFSQuota:
+                      description: CPUCFSQuota enables CPU CFS quota enforcement for containers that specify CPU limits.
+                      type: boolean
+                    evictionHard:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionHard is the map of signal names to quantities that define hard eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionHard are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionMaxPodGracePeriod:
+                      description: |-
+                        EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in
+                        response to soft eviction thresholds being met.
+                      format: int32
+                      type: integer
+                    evictionSoft:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionSoft is the map of signal names to quantities that define soft eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoft are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionSoftGracePeriod:
+                      additionalProperties:
+                        type: string
+                      description: EvictionSoftGracePeriod is the map of signal names to quantities that define grace periods for each eviction signal
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoftGracePeriod are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    imageGCHighThresholdPercent:
+                      description: |-
+                        ImageGCHighThresholdPercent is the percent of disk usage after which image
+                        garbage collection is always run. The percent is calculated by dividing this
+                        field value by 100, so this field must be between 0 and 100, inclusive.
+                        When specified, the value must be greater than ImageGCLowThresholdPercent.
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    imageGCLowThresholdPercent:
+                      description: |-
+                        ImageGCLowThresholdPercent is the percent of disk usage before which image
+                        garbage collection is never run. Lowest disk usage to garbage collect to.
+                        The percent is calculated by dividing this field value by 100,
+                        so the field value must be between 0 and 100, inclusive.
+                        When specified, the value must be less than imageGCHighThresholdPercent
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    kubeReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: KubeReserved contains resources reserved for Kubernetes system components.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for kubeReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: kubeReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                    maxPods:
+                      description: |-
+                        MaxPods is an override for the maximum number of pods that can run on
+                        a worker node instance.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    podsPerCore:
+                      description: |-
+                        PodsPerCore is an override for the number of pods that can run on a worker node
+                        instance based on the number of cpu cores. This value cannot exceed MaxPods, so, if
+                        MaxPods is a lower value, that value will be used.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    systemReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: SystemReserved contains resources reserved for OS system daemons and kernel memory.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for systemReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: systemReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                  type: object
+                  x-kubernetes-validations:
+                    - message: imageGCHighThresholdPercent must be greater than imageGCLowThresholdPercent
+                      rule: 'has(self.imageGCHighThresholdPercent) && has(self.imageGCLowThresholdPercent) ?  self.imageGCHighThresholdPercent > self.imageGCLowThresholdPercent  : true'
+                    - message: evictionSoft OwnerKey does not have a matching evictionSoftGracePeriod
+                      rule: has(self.evictionSoft) ? self.evictionSoft.all(e, (e in self.evictionSoftGracePeriod)):true
+                    - message: evictionSoftGracePeriod OwnerKey does not have a matching evictionSoft
+                      rule: has(self.evictionSoftGracePeriod) ? self.evictionSoftGracePeriod.all(e, (e in self.evictionSoft)):true
+                metadataOptions:
+                  default:
+                    httpEndpoint: enabled
+                    httpProtocolIPv6: disabled
+                    httpPutResponseHopLimit: 1
+                    httpTokens: required
+                  description: |-
+                    MetadataOptions for the generated launch template of provisioned nodes.
+
+                    This specifies the exposure of the Instance Metadata Service to
+                    provisioned EC2 nodes. For more information,
+                    see Instance Metadata and User Data
+                    (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
+                    in the Amazon Elastic Compute Cloud User Guide.
+
+                    Refer to recommended, security best practices
+                    (https://aws.github.io/aws-eks-best-practices/security/docs/iam/#restrict-access-to-the-instance-profile-assigned-to-the-worker-node)
+                    for limiting exposure of Instance Metadata and User Data to pods.
+                    If omitted, defaults to httpEndpoint enabled, with httpProtocolIPv6
+                    disabled, with httpPutResponseLimit of 1, and with httpTokens
+                    required.
+                  properties:
+                    httpEndpoint:
+                      default: enabled
+                      description: |-
+                        HTTPEndpoint enables or disables the HTTP metadata endpoint on provisioned
+                        nodes. If metadata options is non-nil, but this parameter is not specified,
+                        the default state is "enabled".
+
+                        If you specify a value of "disabled", instance metadata will not be accessible
+                        on the node.
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpProtocolIPv6:
+                      default: disabled
+                      description: |-
+                        HTTPProtocolIPv6 enables or disables the IPv6 endpoint for the instance metadata
+                        service on provisioned nodes. If metadata options is non-nil, but this parameter
+                        is not specified, the default state is "disabled".
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpPutResponseHopLimit:
+                      default: 1
+                      description: |-
+                        HTTPPutResponseHopLimit is the desired HTTP PUT response hop limit for
+                        instance metadata requests. The larger the number, the further instance
+                        metadata requests can travel. Possible values are integers from 1 to 64.
+                        If metadata options is non-nil, but this parameter is not specified, the
+                        default value is 1.
+                      format: int64
+                      maximum: 64
+                      minimum: 1
+                      type: integer
+                    httpTokens:
+                      default: required
+                      description: |-
+                        HTTPTokens determines the state of token usage for instance metadata
+                        requests. If metadata options is non-nil, but this parameter is not
+                        specified, the default state is "required".
+
+                        If the state is optional, one can choose to retrieve instance metadata with
+                        or without a signed token header on the request. If one retrieves the IAM
+                        role credentials without a token, the version 1.0 role credentials are
+                        returned. If one retrieves the IAM role credentials using a valid signed
+                        token, the version 2.0 role credentials are returned.
+
+                        If the state is "required", one must send a signed token header with any
+                        instance metadata retrieval requests. In this state, retrieving the IAM
+                        role credentials always returns the version 2.0 credentials; the version
+                        1.0 credentials are not available.
+                      enum:
+                        - required
+                        - optional
+                      type: string
+                  type: object
+                role:
+                  description: |-
+                    Role is the AWS identity that nodes use. This field is immutable.
+                    This field is mutually exclusive from instanceProfile.
+                    Marking this field as immutable avoids concerns around terminating managed instance profiles from running instances.
+                    This field may be made mutable in the future, assuming the correct garbage collection and drift handling is implemented
+                    for the old instance profiles on an update.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: role cannot be empty
+                      rule: self != ''
+                    - message: immutable field changed
+                      rule: self == oldSelf
+                securityGroupSelectorTerms:
+                  description: SecurityGroupSelectorTerms is a list of or security group selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SecurityGroupSelectorTerm defines selection logic for a security group used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the security group id in EC2
+                        pattern: sg-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the security group name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: securityGroupSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id', 'name']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && (has(x.tags) || has(x.name)))'
+                    - message: '''name'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.name) && (has(x.tags) || has(x.id)))'
+                subnetSelectorTerms:
+                  description: SubnetSelectorTerms is a list of or subnet selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SubnetSelectorTerm defines selection logic for a subnet used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the subnet id in EC2
+                        pattern: subnet-[0-9a-z]+
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: subnetSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id']
+                      rule: self.all(x, has(x.tags) || has(x.id))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in subnetSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && has(x.tags))'
+                tags:
+                  additionalProperties:
+                    type: string
+                  description: Tags to be applied on ec2 resources like instances and launch templates.
+                  type: object
+                  x-kubernetes-validations:
+                    - message: empty tag keys aren't supported
+                      rule: self.all(k, k != '')
+                    - message: tag contains a restricted tag matching eks:eks-cluster-name
+                      rule: self.all(k, k !='eks:eks-cluster-name')
+                    - message: tag contains a restricted tag matching kubernetes.io/cluster/
+                      rule: self.all(k, !k.startsWith('kubernetes.io/cluster') )
+                    - message: tag contains a restricted tag matching karpenter.sh/nodepool
+                      rule: self.all(k, k != 'karpenter.sh/nodepool')
+                    - message: tag contains a restricted tag matching karpenter.sh/nodeclaim
+                      rule: self.all(k, k !='karpenter.sh/nodeclaim')
+                    - message: tag contains a restricted tag matching karpenter.k8s.aws/ec2nodeclass
+                      rule: self.all(k, k !='karpenter.k8s.aws/ec2nodeclass')
+                userData:
+                  description: |-
+                    UserData to be applied to the provisioned nodes.
+                    It must be in the appropriate format based on the AMIFamily in use. Karpenter will merge certain fields into
+                    this UserData to ensure nodes are being provisioned with the correct configuration.
+                  type: string
+              required:
+                - amiSelectorTerms
+                - securityGroupSelectorTerms
+                - subnetSelectorTerms
+              type: object
+              x-kubernetes-validations:
+                - message: must specify exactly one of ['role', 'instanceProfile']
+                  rule: (has(self.role) && !has(self.instanceProfile)) || (!has(self.role) && has(self.instanceProfile))
+                - message: changing from 'instanceProfile' to 'role' is not supported. You must delete and recreate this node class if you want to change this.
+                  rule: (has(oldSelf.role) && has(self.role)) || (has(oldSelf.instanceProfile) && has(self.instanceProfile))
+                - message: if set, amiFamily must be 'AL2' or 'Custom' when using an AL2 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''al2'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''AL2'') : true)'
+                - message: if set, amiFamily must be 'AL2023' or 'Custom' when using an AL2023 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''al2023'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''AL2023'') : true)'
+                - message: if set, amiFamily must be 'Bottlerocket' or 'Custom' when using a Bottlerocket alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''bottlerocket'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Bottlerocket'') : true)'
+                - message: if set, amiFamily must be 'Windows2019' or 'Custom' when using a Windows2019 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''windows2019'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Windows2019'') : true)'
+                - message: if set, amiFamily must be 'Windows2022' or 'Custom' when using a Windows2022 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''windows2022'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Windows2022'') : true)'
+                - message: must specify amiFamily if amiSelectorTerms does not contain an alias
+                  rule: 'self.amiSelectorTerms.exists(x, has(x.alias)) ? true : has(self.amiFamily)'
+            status:
+              description: EC2NodeClassStatus contains the resolved state of the EC2NodeClass
+              properties:
+                amis:
+                  description: |-
+                    AMI contains the current AMI values that are available to the
+                    cluster under the AMI selectors.
+                  items:
+                    description: AMI contains resolved AMI selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the AMI
+                        type: string
+                      name:
+                        description: Name of the AMI
+                        type: string
+                      requirements:
+                        description: Requirements of the AMI to be utilized on an instance type
+                        items:
+                          description: |-
+                            A node selector requirement is a selector that contains values, a key, and an operator
+                            that relates the key and values.
+                          properties:
+                            key:
+                              description: The label key that the selector applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                Represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                              type: string
+                            values:
+                              description: |-
+                                An array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. If the operator is Gt or Lt, the values
+                                array must have a single element, which will be interpreted as an integer.
+                                This array is replaced during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                            - key
+                            - operator
+                          type: object
+                        type: array
+                    required:
+                      - id
+                      - requirements
+                    type: object
+                  type: array
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                instanceProfile:
+                  description: InstanceProfile contains the resolved instance profile for the role
+                  type: string
+                securityGroups:
+                  description: |-
+                    SecurityGroups contains the current Security Groups values that are available to the
+                    cluster under the SecurityGroups selectors.
+                  items:
+                    description: SecurityGroup contains resolved SecurityGroup selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the security group
+                        type: string
+                      name:
+                        description: Name of the security group
+                        type: string
+                    required:
+                      - id
+                    type: object
+                  type: array
+                subnets:
+                  description: |-
+                    Subnets contains the current Subnet values that are available to the
+                    cluster under the subnet selectors.
+                  items:
+                    description: Subnet contains resolved Subnet selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the subnet
+                        type: string
+                      zone:
+                        description: The associated availability zone
+                        type: string
+                      zoneID:
+                        description: The associated availability zone ID
+                        type: string
+                    required:
+                      - id
+                      - zone
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: EC2NodeClass is the Schema for the EC2NodeClass API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                EC2NodeClassSpec is the top level specification for the AWS Karpenter Provider.
+                This will contain configuration necessary to launch instances in AWS.
+              properties:
+                amiFamily:
+                  description: AMIFamily is the AMI family that instances use.
+                  enum:
+                    - AL2
+                    - AL2023
+                    - Bottlerocket
+                    - Ubuntu
+                    - Custom
+                    - Windows2019
+                    - Windows2022
+                  type: string
+                amiSelectorTerms:
+                  description: AMISelectorTerms is a list of or ami selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      AMISelectorTerm defines selection logic for an ami used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the ami id in EC2
+                        pattern: ami-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the ami name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      owner:
+                        description: |-
+                          Owner is the owner for the ami.
+                          You can specify a combination of AWS account IDs, "self", "amazon", and "aws-marketplace"
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: expected at least one, got none, ['tags', 'id', 'name']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && (has(x.tags) || has(x.name) || has(x.owner)))'
+                associatePublicIPAddress:
+                  description: AssociatePublicIPAddress controls if public IP addresses are assigned to instances that are launched with the nodeclass.
+                  type: boolean
+                blockDeviceMappings:
+                  description: BlockDeviceMappings to be applied to provisioned nodes.
+                  items:
+                    properties:
+                      deviceName:
+                        description: The device name (for example, /dev/sdh or xvdh).
+                        type: string
+                      ebs:
+                        description: EBS contains parameters used to automatically set up EBS volumes when an instance is launched.
+                        properties:
+                          deleteOnTermination:
+                            description: DeleteOnTermination indicates whether the EBS volume is deleted on instance termination.
+                            type: boolean
+                          encrypted:
+                            description: |-
+                              Encrypted indicates whether the EBS volume is encrypted. Encrypted volumes can only
+                              be attached to instances that support Amazon EBS encryption. If you are creating
+                              a volume from a snapshot, you can't specify an encryption value.
+                            type: boolean
+                          iops:
+                            description: |-
+                              IOPS is the number of I/O operations per second (IOPS). For gp3, io1, and io2 volumes,
+                              this represents the number of IOPS that are provisioned for the volume. For
+                              gp2 volumes, this represents the baseline performance of the volume and the
+                              rate at which the volume accumulates I/O credits for bursting.
+
+                              The following are the supported values for each volume type:
+
+                                 * gp3: 3,000-16,000 IOPS
+
+                                 * io1: 100-64,000 IOPS
+
+                                 * io2: 100-64,000 IOPS
+
+                              For io1 and io2 volumes, we guarantee 64,000 IOPS only for Instances built
+                              on the Nitro System (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances).
+                              Other instance families guarantee performance up to 32,000 IOPS.
+
+                              This parameter is supported for io1, io2, and gp3 volumes only. This parameter
+                              is not supported for gp2, st1, sc1, or standard volumes.
+                            format: int64
+                            type: integer
+                          kmsKeyID:
+                            description: KMSKeyID (ARN) of the symmetric Key Management Service (KMS) CMK used for encryption.
+                            type: string
+                          snapshotID:
+                            description: SnapshotID is the ID of an EBS snapshot
+                            type: string
+                          throughput:
+                            description: |-
+                              Throughput to provision for a gp3 volume, with a maximum of 1,000 MiB/s.
+                              Valid Range: Minimum value of 125. Maximum value of 1000.
+                            format: int64
+                            type: integer
+                          volumeSize:
+                            description: |-
+                              VolumeSize in `Gi`, `G`, `Ti`, or `T`. You must specify either a snapshot ID or
+                              a volume size. The following are the supported volumes sizes for each volume
+                              type:
+
+                                 * gp2 and gp3: 1-16,384
+
+                                 * io1 and io2: 4-16,384
+
+                                 * st1 and sc1: 125-16,384
+
+                                 * standard: 1-1,024
+                            pattern: ^((?:[1-9][0-9]{0,3}|[1-4][0-9]{4}|[5][0-8][0-9]{3}|59000)Gi|(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|[6][0-3][0-9]{3}|64000)G|([1-9]||[1-5][0-7]|58)Ti|([1-9]||[1-5][0-9]|6[0-3]|64)T)$
+                            type: string
+                          volumeType:
+                            description: |-
+                              VolumeType of the block device.
+                              For more information, see Amazon EBS volume types (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html)
+                              in the Amazon Elastic Compute Cloud User Guide.
+                            enum:
+                              - standard
+                              - io1
+                              - io2
+                              - gp2
+                              - sc1
+                              - st1
+                              - gp3
+                            type: string
+                        type: object
+                        x-kubernetes-validations:
+                          - message: snapshotID or volumeSize must be defined
+                            rule: has(self.snapshotID) || has(self.volumeSize)
+                      rootVolume:
+                        description: |-
+                          RootVolume is a flag indicating if this device is mounted as kubelet root dir. You can
+                          configure at most one root volume in BlockDeviceMappings.
+                        type: boolean
+                    type: object
+                  maxItems: 50
+                  type: array
+                  x-kubernetes-validations:
+                    - message: must have only one blockDeviceMappings with rootVolume
+                      rule: self.filter(x, has(x.rootVolume)?x.rootVolume==true:false).size() <= 1
+                context:
+                  description: |-
+                    Context is a Reserved field in EC2 APIs
+                    https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet.html
+                  type: string
+                detailedMonitoring:
+                  description: DetailedMonitoring controls if detailed monitoring is enabled for instances that are launched
+                  type: boolean
+                instanceProfile:
+                  description: |-
+                    InstanceProfile is the AWS entity that instances use.
+                    This field is mutually exclusive from role.
+                    The instance profile should already have a role assigned to it that Karpenter
+                     has PassRole permission on for instance launch using this instanceProfile to succeed.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: instanceProfile cannot be empty
+                      rule: self != ''
+                instanceStorePolicy:
+                  description: InstanceStorePolicy specifies how to handle instance-store disks.
+                  enum:
+                    - RAID0
+                  type: string
+                metadataOptions:
+                  default:
+                    httpEndpoint: enabled
+                    httpProtocolIPv6: disabled
+                    httpPutResponseHopLimit: 1
+                    httpTokens: required
+                  description: |-
+                    MetadataOptions for the generated launch template of provisioned nodes.
+
+                    This specifies the exposure of the Instance Metadata Service to
+                    provisioned EC2 nodes. For more information,
+                    see Instance Metadata and User Data
+                    (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
+                    in the Amazon Elastic Compute Cloud User Guide.
+
+                    Refer to recommended, security best practices
+                    (https://aws.github.io/aws-eks-best-practices/security/docs/iam/#restrict-access-to-the-instance-profile-assigned-to-the-worker-node)
+                    for limiting exposure of Instance Metadata and User Data to pods.
+                    If omitted, defaults to httpEndpoint enabled, with httpProtocolIPv6
+                    disabled, with httpPutResponseLimit of 1, and with httpTokens
+                    required.
+                  properties:
+                    httpEndpoint:
+                      default: enabled
+                      description: |-
+                        HTTPEndpoint enables or disables the HTTP metadata endpoint on provisioned
+                        nodes. If metadata options is non-nil, but this parameter is not specified,
+                        the default state is "enabled".
+
+                        If you specify a value of "disabled", instance metadata will not be accessible
+                        on the node.
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpProtocolIPv6:
+                      default: disabled
+                      description: |-
+                        HTTPProtocolIPv6 enables or disables the IPv6 endpoint for the instance metadata
+                        service on provisioned nodes. If metadata options is non-nil, but this parameter
+                        is not specified, the default state is "disabled".
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpPutResponseHopLimit:
+                      default: 2
+                      description: |-
+                        HTTPPutResponseHopLimit is the desired HTTP PUT response hop limit for
+                        instance metadata requests. The larger the number, the further instance
+                        metadata requests can travel. Possible values are integers from 1 to 64.
+                        If metadata options is non-nil, but this parameter is not specified, the
+                        default value is 2.
+                      format: int64
+                      maximum: 64
+                      minimum: 1
+                      type: integer
+                    httpTokens:
+                      default: required
+                      description: |-
+                        HTTPTokens determines the state of token usage for instance metadata
+                        requests. If metadata options is non-nil, but this parameter is not
+                        specified, the default state is "required".
+
+                        If the state is optional, one can choose to retrieve instance metadata with
+                        or without a signed token header on the request. If one retrieves the IAM
+                        role credentials without a token, the version 1.0 role credentials are
+                        returned. If one retrieves the IAM role credentials using a valid signed
+                        token, the version 2.0 role credentials are returned.
+
+                        If the state is "required", one must send a signed token header with any
+                        instance metadata retrieval requests. In this state, retrieving the IAM
+                        role credentials always returns the version 2.0 credentials; the version
+                        1.0 credentials are not available.
+                      enum:
+                        - required
+                        - optional
+                      type: string
+                  type: object
+                role:
+                  description: |-
+                    Role is the AWS identity that nodes use. This field is immutable.
+                    This field is mutually exclusive from instanceProfile.
+                    Marking this field as immutable avoids concerns around terminating managed instance profiles from running instances.
+                    This field may be made mutable in the future, assuming the correct garbage collection and drift handling is implemented
+                    for the old instance profiles on an update.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: role cannot be empty
+                      rule: self != ''
+                    - message: immutable field changed
+                      rule: self == oldSelf
+                securityGroupSelectorTerms:
+                  description: SecurityGroupSelectorTerms is a list of or security group selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SecurityGroupSelectorTerm defines selection logic for a security group used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the security group id in EC2
+                        pattern: sg-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the security group name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: securityGroupSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id', 'name']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && (has(x.tags) || has(x.name)))'
+                    - message: '''name'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.name) && (has(x.tags) || has(x.id)))'
+                subnetSelectorTerms:
+                  description: SubnetSelectorTerms is a list of or subnet selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SubnetSelectorTerm defines selection logic for a subnet used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the subnet id in EC2
+                        pattern: subnet-[0-9a-z]+
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: subnetSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id']
+                      rule: self.all(x, has(x.tags) || has(x.id))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in subnetSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && has(x.tags))'
+                tags:
+                  additionalProperties:
+                    type: string
+                  description: Tags to be applied on ec2 resources like instances and launch templates.
+                  type: object
+                  x-kubernetes-validations:
+                    - message: empty tag keys aren't supported
+                      rule: self.all(k, k != '')
+                    - message: tag contains a restricted tag matching kubernetes.io/cluster/
+                      rule: self.all(k, !k.startsWith('kubernetes.io/cluster') )
+                    - message: tag contains a restricted tag matching karpenter.sh/nodepool
+                      rule: self.all(k, k != 'karpenter.sh/nodepool')
+                    - message: tag contains a restricted tag matching karpenter.sh/managed-by
+                      rule: self.all(k, k !='karpenter.sh/managed-by')
+                    - message: tag contains a restricted tag matching karpenter.sh/nodeclaim
+                      rule: self.all(k, k !='karpenter.sh/nodeclaim')
+                    - message: tag contains a restricted tag matching karpenter.k8s.aws/ec2nodeclass
+                      rule: self.all(k, k !='karpenter.k8s.aws/ec2nodeclass')
+                userData:
+                  description: |-
+                    UserData to be applied to the provisioned nodes.
+                    It must be in the appropriate format based on the AMIFamily in use. Karpenter will merge certain fields into
+                    this UserData to ensure nodes are being provisioned with the correct configuration.
+                  type: string
+              required:
+                - amiFamily
+                - securityGroupSelectorTerms
+                - subnetSelectorTerms
+              type: object
+              x-kubernetes-validations:
+                - message: amiSelectorTerms is required when amiFamily == 'Custom'
+                  rule: 'self.amiFamily == ''Custom'' ? self.amiSelectorTerms.size() != 0 : true'
+                - message: must specify exactly one of ['role', 'instanceProfile']
+                  rule: (has(self.role) && !has(self.instanceProfile)) || (!has(self.role) && has(self.instanceProfile))
+                - message: changing from 'instanceProfile' to 'role' is not supported. You must delete and recreate this node class if you want to change this.
+                  rule: (has(oldSelf.role) && has(self.role)) || (has(oldSelf.instanceProfile) && has(self.instanceProfile))
+            status:
+              description: EC2NodeClassStatus contains the resolved state of the EC2NodeClass
+              properties:
+                amis:
+                  description: |-
+                    AMI contains the current AMI values that are available to the
+                    cluster under the AMI selectors.
+                  items:
+                    description: AMI contains resolved AMI selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the AMI
+                        type: string
+                      name:
+                        description: Name of the AMI
+                        type: string
+                      requirements:
+                        description: Requirements of the AMI to be utilized on an instance type
+                        items:
+                          description: |-
+                            A node selector requirement is a selector that contains values, a key, and an operator
+                            that relates the key and values.
+                          properties:
+                            key:
+                              description: The label key that the selector applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                Represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                              type: string
+                            values:
+                              description: |-
+                                An array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. If the operator is Gt or Lt, the values
+                                array must have a single element, which will be interpreted as an integer.
+                                This array is replaced during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                            - key
+                            - operator
+                          type: object
+                        type: array
+                    required:
+                      - id
+                      - requirements
+                    type: object
+                  type: array
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                instanceProfile:
+                  description: InstanceProfile contains the resolved instance profile for the role
+                  type: string
+                securityGroups:
+                  description: |-
+                    SecurityGroups contains the current Security Groups values that are available to the
+                    cluster under the SecurityGroups selectors.
+                  items:
+                    description: SecurityGroup contains resolved SecurityGroup selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the security group
+                        type: string
+                      name:
+                        description: Name of the security group
+                        type: string
+                    required:
+                      - id
+                    type: object
+                  type: array
+                subnets:
+                  description: |-
+                    Subnets contains the current Subnet values that are available to the
+                    cluster under the subnet selectors.
+                  items:
+                    description: Subnet contains resolved Subnet selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the subnet
+                        type: string
+                      zone:
+                        description: The associated availability zone
+                        type: string
+                      zoneID:
+                        description: The associated availability zone ID
+                        type: string
+                    required:
+                      - id
+                      - zone
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+        - v1
+      clientConfig:
+        service:
+          name: karpenter
+          namespace: kube-system
+          port: 8443

--- a/content/projects/karpenter/v1.0.9/karpenter.sh_nodeclaims.yaml
+++ b/content/projects/karpenter/v1.0.9/karpenter.sh_nodeclaims.yaml
@@ -1,0 +1,829 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: nodeclaims.karpenter.sh
+spec:
+  group: karpenter.sh
+  names:
+    categories:
+      - karpenter
+    kind: NodeClaim
+    listKind: NodeClaimList
+    plural: nodeclaims
+    singular: nodeclaim
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.labels.node\.kubernetes\.io/instance-type
+          name: Type
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/capacity-type
+          name: Capacity
+          type: string
+        - jsonPath: .metadata.labels.topology\.kubernetes\.io/zone
+          name: Zone
+          type: string
+        - jsonPath: .status.nodeName
+          name: Node
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .status.providerID
+          name: ID
+          priority: 1
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/nodepool
+          name: NodePool
+          priority: 1
+          type: string
+        - jsonPath: .spec.nodeClassRef.name
+          name: NodeClass
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: NodeClaim is the Schema for the NodeClaims API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: NodeClaimSpec describes the desired state of the NodeClaim
+              properties:
+                expireAfter:
+                  default: 720h
+                  description: |-
+                    ExpireAfter is the duration the controller will wait
+                    before terminating a node, measured from when the node is created. This
+                    is useful to implement features like eventually consistent node upgrade,
+                    memory leak protection, and disruption testing.
+                  pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                  type: string
+                nodeClassRef:
+                  description: NodeClassRef is a reference to an object that defines provider specific configuration
+                  properties:
+                    group:
+                      description: API version of the referent
+                      pattern: ^[^/]*$
+                      type: string
+                    kind:
+                      description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                      type: string
+                    name:
+                      description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                      type: string
+                  required:
+                    - group
+                    - kind
+                    - name
+                  type: object
+                requirements:
+                  description: Requirements are layered with GetLabels and applied to every node.
+                  items:
+                    description: |-
+                      A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                      and minValues that represent the requirement to have at least that many values.
+                    properties:
+                      key:
+                        description: The label key that the selector applies to.
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                        x-kubernetes-validations:
+                          - message: label domain "kubernetes.io" is restricted
+                            rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                          - message: label domain "k8s.io" is restricted
+                            rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                          - message: label domain "karpenter.sh" is restricted
+                            rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                          - message: label "kubernetes.io/hostname" is restricted
+                            rule: self != "kubernetes.io/hostname"
+                          - message: label domain "karpenter.k8s.aws" is restricted
+                            rule: self in ["karpenter.k8s.aws/ec2nodeclass", "karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz", "karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                      minValues:
+                        description: |-
+                          This field is ALPHA and can be dropped or replaced at any time
+                          MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                        maximum: 50
+                        minimum: 1
+                        type: integer
+                      operator:
+                        description: |-
+                          Represents a key's relationship to a set of values.
+                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                        type: string
+                        enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          - Gt
+                          - Lt
+                      values:
+                        description: |-
+                          An array of string values. If the operator is In or NotIn,
+                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                          the values array must be empty. If the operator is Gt or Lt, the values
+                          array must have a single element, which will be interpreted as an integer.
+                          This array is replaced during a strategic merge patch.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                        maxLength: 63
+                        pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                    required:
+                      - key
+                      - operator
+                    type: object
+                  maxItems: 100
+                  type: array
+                  x-kubernetes-validations:
+                    - message: requirements with operator 'In' must have a value defined
+                      rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                    - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                      rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                    - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                      rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                resources:
+                  description: Resources models the resource requirements for the NodeClaim to launch
+                  properties:
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: Requests describes the minimum required resources for the NodeClaim to launch
+                      type: object
+                  type: object
+                startupTaints:
+                  description: |-
+                    StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                    within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                    daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                    purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                taints:
+                  description: Taints will be applied to the NodeClaim's node.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                terminationGracePeriod:
+                  description: |-
+                    TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
+
+                    Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
+
+                    This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
+                    When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
+
+                    Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
+                    If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
+                    that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
+
+                    The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
+                    If left undefined, the controller will wait indefinitely for pods to be drained.
+                  pattern: ^([0-9]+(s|m|h))+$
+                  type: string
+              required:
+                - nodeClassRef
+                - requirements
+              type: object
+              x-kubernetes-validations:
+                - message: spec is immutable
+                  rule: self == oldSelf
+            status:
+              description: NodeClaimStatus defines the observed state of NodeClaim
+              properties:
+                allocatable:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Allocatable is the estimated allocatable capacity of the node
+                  type: object
+                capacity:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Capacity is the estimated full capacity of the node
+                  type: object
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        pattern: ^([A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?|)$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - status
+                      - type
+                    type: object
+                  type: array
+                imageID:
+                  description: ImageID is an identifier for the image that runs on the node
+                  type: string
+                lastPodEventTime:
+                  description: |-
+                    LastPodEventTime is updated with the last time a pod was scheduled
+                    or removed from the node. A pod going terminal or terminating
+                    is also considered as removed.
+                  format: date-time
+                  type: string
+                nodeName:
+                  description: NodeName is the name of the corresponding node object
+                  type: string
+                providerID:
+                  description: ProviderID of the corresponding node object
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.labels.node\.kubernetes\.io/instance-type
+          name: Type
+          type: string
+        - jsonPath: .metadata.labels.topology\.kubernetes\.io/zone
+          name: Zone
+          type: string
+        - jsonPath: .status.nodeName
+          name: Node
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .metadata.labels.karpenter\.sh/capacity-type
+          name: Capacity
+          priority: 1
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/nodepool
+          name: NodePool
+          priority: 1
+          type: string
+        - jsonPath: .spec.nodeClassRef.name
+          name: NodeClass
+          priority: 1
+          type: string
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: NodeClaim is the Schema for the NodeClaims API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: NodeClaimSpec describes the desired state of the NodeClaim
+              properties:
+                kubelet:
+                  description: |-
+                    Kubelet defines args to be used when configuring kubelet on provisioned nodes.
+                    They are a subset of the upstream types, recognizing not all options may be supported.
+                    Wherever possible, the types and names should reflect the upstream kubelet types.
+                  properties:
+                    clusterDNS:
+                      description: |-
+                        clusterDNS is a list of IP addresses for the cluster DNS server.
+                        Note that not all providers may use all addresses.
+                      items:
+                        type: string
+                      type: array
+                    cpuCFSQuota:
+                      description: CPUCFSQuota enables CPU CFS quota enforcement for containers that specify CPU limits.
+                      type: boolean
+                    evictionHard:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionHard is the map of signal names to quantities that define hard eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionHard are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionMaxPodGracePeriod:
+                      description: |-
+                        EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in
+                        response to soft eviction thresholds being met.
+                      format: int32
+                      type: integer
+                    evictionSoft:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionSoft is the map of signal names to quantities that define soft eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoft are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionSoftGracePeriod:
+                      additionalProperties:
+                        type: string
+                      description: EvictionSoftGracePeriod is the map of signal names to quantities that define grace periods for each eviction signal
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoftGracePeriod are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    imageGCHighThresholdPercent:
+                      description: |-
+                        ImageGCHighThresholdPercent is the percent of disk usage after which image
+                        garbage collection is always run. The percent is calculated by dividing this
+                        field value by 100, so this field must be between 0 and 100, inclusive.
+                        When specified, the value must be greater than ImageGCLowThresholdPercent.
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    imageGCLowThresholdPercent:
+                      description: |-
+                        ImageGCLowThresholdPercent is the percent of disk usage before which image
+                        garbage collection is never run. Lowest disk usage to garbage collect to.
+                        The percent is calculated by dividing this field value by 100,
+                        so the field value must be between 0 and 100, inclusive.
+                        When specified, the value must be less than imageGCHighThresholdPercent
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    kubeReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: KubeReserved contains resources reserved for Kubernetes system components.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for kubeReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: kubeReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                    maxPods:
+                      description: |-
+                        MaxPods is an override for the maximum number of pods that can run on
+                        a worker node instance.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    podsPerCore:
+                      description: |-
+                        PodsPerCore is an override for the number of pods that can run on a worker node
+                        instance based on the number of cpu cores. This value cannot exceed MaxPods, so, if
+                        MaxPods is a lower value, that value will be used.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    systemReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: SystemReserved contains resources reserved for OS system daemons and kernel memory.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for systemReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: systemReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                  type: object
+                  x-kubernetes-validations:
+                    - message: imageGCHighThresholdPercent must be greater than imageGCLowThresholdPercent
+                      rule: 'has(self.imageGCHighThresholdPercent) && has(self.imageGCLowThresholdPercent) ?  self.imageGCHighThresholdPercent > self.imageGCLowThresholdPercent  : true'
+                    - message: evictionSoft OwnerKey does not have a matching evictionSoftGracePeriod
+                      rule: has(self.evictionSoft) ? self.evictionSoft.all(e, (e in self.evictionSoftGracePeriod)):true
+                    - message: evictionSoftGracePeriod OwnerKey does not have a matching evictionSoft
+                      rule: has(self.evictionSoftGracePeriod) ? self.evictionSoftGracePeriod.all(e, (e in self.evictionSoft)):true
+                nodeClassRef:
+                  description: NodeClassRef is a reference to an object that defines provider specific configuration
+                  properties:
+                    apiVersion:
+                      description: API version of the referent
+                      type: string
+                    kind:
+                      description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                      type: string
+                    name:
+                      description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                      type: string
+                  required:
+                    - name
+                  type: object
+                requirements:
+                  description: Requirements are layered with GetLabels and applied to every node.
+                  items:
+                    description: |-
+                      A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                      and minValues that represent the requirement to have at least that many values.
+                    properties:
+                      key:
+                        description: The label key that the selector applies to.
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                        x-kubernetes-validations:
+                          - message: label domain "kubernetes.io" is restricted
+                            rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                          - message: label domain "k8s.io" is restricted
+                            rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                          - message: label domain "karpenter.sh" is restricted
+                            rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                          - message: label "kubernetes.io/hostname" is restricted
+                            rule: self != "kubernetes.io/hostname"
+                          - message: label domain "karpenter.k8s.aws" is restricted
+                            rule: self in ["karpenter.k8s.aws/ec2nodeclass", "karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz", "karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                      minValues:
+                        description: |-
+                          This field is ALPHA and can be dropped or replaced at any time
+                          MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                        maximum: 50
+                        minimum: 1
+                        type: integer
+                      operator:
+                        description: |-
+                          Represents a key's relationship to a set of values.
+                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                        type: string
+                        enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          - Gt
+                          - Lt
+                      values:
+                        description: |-
+                          An array of string values. If the operator is In or NotIn,
+                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                          the values array must be empty. If the operator is Gt or Lt, the values
+                          array must have a single element, which will be interpreted as an integer.
+                          This array is replaced during a strategic merge patch.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                        maxLength: 63
+                        pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                    required:
+                      - key
+                      - operator
+                    type: object
+                  maxItems: 100
+                  type: array
+                  x-kubernetes-validations:
+                    - message: requirements with operator 'In' must have a value defined
+                      rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                    - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                      rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                    - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                      rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                resources:
+                  description: Resources models the resource requirements for the NodeClaim to launch
+                  properties:
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: Requests describes the minimum required resources for the NodeClaim to launch
+                      type: object
+                  type: object
+                startupTaints:
+                  description: |-
+                    StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                    within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                    daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                    purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                taints:
+                  description: Taints will be applied to the NodeClaim's node.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+              required:
+                - nodeClassRef
+                - requirements
+              type: object
+            status:
+              description: NodeClaimStatus defines the observed state of NodeClaim
+              properties:
+                allocatable:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Allocatable is the estimated allocatable capacity of the node
+                  type: object
+                capacity:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Capacity is the estimated full capacity of the node
+                  type: object
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        pattern: ^([A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?|)$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - status
+                      - type
+                    type: object
+                  type: array
+                imageID:
+                  description: ImageID is an identifier for the image that runs on the node
+                  type: string
+                nodeName:
+                  description: NodeName is the name of the corresponding node object
+                  type: string
+                providerID:
+                  description: ProviderID of the corresponding node object
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+        - v1
+      clientConfig:
+        service:
+          name: karpenter
+          namespace: kube-system
+          port: 8443

--- a/content/projects/karpenter/v1.0.9/karpenter.sh_nodepools.yaml
+++ b/content/projects/karpenter/v1.0.9/karpenter.sh_nodepools.yaml
@@ -1,0 +1,1082 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: nodepools.karpenter.sh
+spec:
+  group: karpenter.sh
+  names:
+    categories:
+      - karpenter
+    kind: NodePool
+    listKind: NodePoolList
+    plural: nodepools
+    singular: nodepool
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.template.spec.nodeClassRef.name
+          name: NodeClass
+          type: string
+        - jsonPath: .status.resources.nodes
+          name: Nodes
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.weight
+          name: Weight
+          priority: 1
+          type: integer
+        - jsonPath: .status.resources.cpu
+          name: CPU
+          priority: 1
+          type: string
+        - jsonPath: .status.resources.memory
+          name: Memory
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: NodePool is the Schema for the NodePools API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                NodePoolSpec is the top level nodepool specification. Nodepools
+                launch nodes in response to pods that are unschedulable. A single nodepool
+                is capable of managing a diverse set of nodes. Node properties are determined
+                from a combination of nodepool and pod scheduling constraints.
+              properties:
+                disruption:
+                  default:
+                    consolidateAfter: 0s
+                  description: Disruption contains the parameters that relate to Karpenter's disruption logic
+                  properties:
+                    budgets:
+                      default:
+                        - nodes: 10%
+                      description: |-
+                        Budgets is a list of Budgets.
+                        If there are multiple active budgets, Karpenter uses
+                        the most restrictive value. If left undefined,
+                        this will default to one budget with a value to 10%.
+                      items:
+                        description: |-
+                          Budget defines when Karpenter will restrict the
+                          number of Node Claims that can be terminating simultaneously.
+                        properties:
+                          duration:
+                            description: |-
+                              Duration determines how long a Budget is active since each Schedule hit.
+                              Only minutes and hours are accepted, as cron does not work in seconds.
+                              If omitted, the budget is always active.
+                              This is required if Schedule is set.
+                              This regex has an optional 0s at the end since the duration.String() always adds
+                              a 0s at the end.
+                            pattern: ^((([0-9]+(h|m))|([0-9]+h[0-9]+m))(0s)?)$
+                            type: string
+                          nodes:
+                            default: 10%
+                            description: |-
+                              Nodes dictates the maximum number of NodeClaims owned by this NodePool
+                              that can be terminating at once. This is calculated by counting nodes that
+                              have a deletion timestamp set, or are actively being deleted by Karpenter.
+                              This field is required when specifying a budget.
+                              This cannot be of type intstr.IntOrString since kubebuilder doesn't support pattern
+                              checking for int nodes for IntOrString nodes.
+                              Ref: https://github.com/kubernetes-sigs/controller-tools/blob/55efe4be40394a288216dab63156b0a64fb82929/pkg/crd/markers/validation.go#L379-L388
+                            pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
+                            type: string
+                          reasons:
+                            description: |-
+                              Reasons is a list of disruption methods that this budget applies to. If Reasons is not set, this budget applies to all methods.
+                              Otherwise, this will apply to each reason defined.
+                              allowed reasons are Underutilized, Empty, and Drifted.
+                            items:
+                              description: DisruptionReason defines valid reasons for disruption budgets.
+                              enum:
+                                - Underutilized
+                                - Empty
+                                - Drifted
+                              type: string
+                            type: array
+                          schedule:
+                            description: |-
+                              Schedule specifies when a budget begins being active, following
+                              the upstream cronjob syntax. If omitted, the budget is always active.
+                              Timezones are not supported.
+                              This field is required if Duration is set.
+                            pattern: ^(@(annually|yearly|monthly|weekly|daily|midnight|hourly))|((.+)\s(.+)\s(.+)\s(.+)\s(.+))$
+                            type: string
+                        required:
+                          - nodes
+                        type: object
+                      maxItems: 50
+                      type: array
+                      x-kubernetes-validations:
+                        - message: '''schedule'' must be set with ''duration'''
+                          rule: self.all(x, has(x.schedule) == has(x.duration))
+                    consolidateAfter:
+                      description: |-
+                        ConsolidateAfter is the duration the controller will wait
+                        before attempting to terminate nodes that are underutilized.
+                        Refer to ConsolidationPolicy for how underutilization is considered.
+                      pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                      type: string
+                    consolidationPolicy:
+                      default: WhenEmptyOrUnderutilized
+                      description: |-
+                        ConsolidationPolicy describes which nodes Karpenter can disrupt through its consolidation
+                        algorithm. This policy defaults to "WhenEmptyOrUnderutilized" if not specified
+                      enum:
+                        - WhenEmpty
+                        - WhenEmptyOrUnderutilized
+                      type: string
+                  required:
+                    - consolidateAfter
+                  type: object
+                limits:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Limits define a set of bounds for provisioning capacity.
+                  type: object
+                template:
+                  description: |-
+                    Template contains the template of possibilities for the provisioning logic to launch a NodeClaim with.
+                    NodeClaims launched from this NodePool will often be further constrained than the template specifies.
+                  properties:
+                    metadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Annotations is an unstructured key value map stored with a resource that may be
+                            set by external tools to store and retrieve arbitrary metadata. They are not
+                            queryable and should be preserved when modifying objects.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                            maxLength: 63
+                            pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                          description: |-
+                            Map of string keys and values that can be used to organize and categorize
+                            (scope and select) objects. May match selectors of replication controllers
+                            and services.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
+                          type: object
+                          maxProperties: 100
+                          x-kubernetes-validations:
+                            - message: label domain "kubernetes.io" is restricted
+                              rule: self.all(x, x in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region",  "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || x.find("^([^/]+)").endsWith("node.kubernetes.io") || x.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !x.find("^([^/]+)").endsWith("kubernetes.io"))
+                            - message: label domain "k8s.io" is restricted
+                              rule: self.all(x, x.find("^([^/]+)").endsWith("kops.k8s.io") || !x.find("^([^/]+)").endsWith("k8s.io"))
+                            - message: label domain "karpenter.sh" is restricted
+                              rule: self.all(x, x in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !x.find("^([^/]+)").endsWith("karpenter.sh"))
+                            - message: label "karpenter.sh/nodepool" is restricted
+                              rule: self.all(x, x != "karpenter.sh/nodepool")
+                            - message: label "kubernetes.io/hostname" is restricted
+                              rule: self.all(x, x != "kubernetes.io/hostname")
+                            - message: label domain "karpenter.k8s.aws" is restricted
+                              rule: self.all(x, x in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !x.find("^([^/]+)").endsWith("karpenter.k8s.aws"))
+                      type: object
+                    spec:
+                      description: |-
+                        NodeClaimTemplateSpec describes the desired state of the NodeClaim in the Nodepool
+                        NodeClaimTemplateSpec is used in the NodePool's NodeClaimTemplate, with the resource requests omitted since
+                        users are not able to set resource requests in the NodePool.
+                      properties:
+                        expireAfter:
+                          default: 720h
+                          description: |-
+                            ExpireAfter is the duration the controller will wait
+                            before terminating a node, measured from when the node is created. This
+                            is useful to implement features like eventually consistent node upgrade,
+                            memory leak protection, and disruption testing.
+                          pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                          type: string
+                        nodeClassRef:
+                          description: NodeClassRef is a reference to an object that defines provider specific configuration
+                          properties:
+                            group:
+                              description: API version of the referent
+                              pattern: ^[^/]*$
+                              type: string
+                            kind:
+                              description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                              type: string
+                            name:
+                              description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                          required:
+                            - group
+                            - kind
+                            - name
+                          type: object
+                        requirements:
+                          description: Requirements are layered with GetLabels and applied to every node.
+                          items:
+                            description: |-
+                              A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                              and minValues that represent the requirement to have at least that many values.
+                            properties:
+                              key:
+                                description: The label key that the selector applies to.
+                                type: string
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                                x-kubernetes-validations:
+                                  - message: label domain "kubernetes.io" is restricted
+                                    rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                                  - message: label domain "k8s.io" is restricted
+                                    rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                                  - message: label domain "karpenter.sh" is restricted
+                                    rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                                  - message: label "karpenter.sh/nodepool" is restricted
+                                    rule: self != "karpenter.sh/nodepool"
+                                  - message: label "kubernetes.io/hostname" is restricted
+                                    rule: self != "kubernetes.io/hostname"
+                                  - message: label domain "karpenter.k8s.aws" is restricted
+                                    rule: self in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                              minValues:
+                                description: |-
+                                  This field is ALPHA and can be dropped or replaced at any time
+                                  MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                                maximum: 50
+                                minimum: 1
+                                type: integer
+                              operator:
+                                description: |-
+                                  Represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                type: string
+                                enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  - Gt
+                                  - Lt
+                              values:
+                                description: |-
+                                  An array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                  array must have a single element, which will be interpreted as an integer.
+                                  This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          maxItems: 100
+                          type: array
+                          x-kubernetes-validations:
+                            - message: requirements with operator 'In' must have a value defined
+                              rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                            - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                              rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                            - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                              rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                        startupTaints:
+                          description: |-
+                            StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                            within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                            daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                            purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        taints:
+                          description: Taints will be applied to the NodeClaim's node.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        terminationGracePeriod:
+                          description: |-
+                            TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
+
+                            Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
+
+                            This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
+                            When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
+
+                            Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
+                            If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
+                            that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
+
+                            The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
+                            If left undefined, the controller will wait indefinitely for pods to be drained.
+                          pattern: ^([0-9]+(s|m|h))+$
+                          type: string
+                      required:
+                        - nodeClassRef
+                        - requirements
+                      type: object
+                  required:
+                    - spec
+                  type: object
+                weight:
+                  description: |-
+                    Weight is the priority given to the nodepool during scheduling. A higher
+                    numerical weight indicates that this nodepool will be ordered
+                    ahead of other nodepools with lower weights. A nodepool with no weight
+                    will be treated as if it is a nodepool with a weight of 0.
+                  format: int32
+                  maximum: 100
+                  minimum: 1
+                  type: integer
+              required:
+                - template
+              type: object
+            status:
+              description: NodePoolStatus defines the observed state of NodePool
+              properties:
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                resources:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Resources is the list of resources that have been provisioned.
+                  type: object
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .spec.template.spec.nodeClassRef.name
+          name: NodeClass
+          type: string
+        - jsonPath: .spec.weight
+          name: Weight
+          priority: 1
+          type: string
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: NodePool is the Schema for the NodePools API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                NodePoolSpec is the top level nodepool specification. Nodepools
+                launch nodes in response to pods that are unschedulable. A single nodepool
+                is capable of managing a diverse set of nodes. Node properties are determined
+                from a combination of nodepool and pod scheduling constraints.
+              properties:
+                disruption:
+                  default:
+                    consolidationPolicy: WhenUnderutilized
+                    expireAfter: 720h
+                  description: Disruption contains the parameters that relate to Karpenter's disruption logic
+                  properties:
+                    budgets:
+                      default:
+                        - nodes: 10%
+                      description: |-
+                        Budgets is a list of Budgets.
+                        If there are multiple active budgets, Karpenter uses
+                        the most restrictive value. If left undefined,
+                        this will default to one budget with a value to 10%.
+                      items:
+                        description: |-
+                          Budget defines when Karpenter will restrict the
+                          number of Node Claims that can be terminating simultaneously.
+                        properties:
+                          duration:
+                            description: |-
+                              Duration determines how long a Budget is active since each Schedule hit.
+                              Only minutes and hours are accepted, as cron does not work in seconds.
+                              If omitted, the budget is always active.
+                              This is required if Schedule is set.
+                              This regex has an optional 0s at the end since the duration.String() always adds
+                              a 0s at the end.
+                            pattern: ^((([0-9]+(h|m))|([0-9]+h[0-9]+m))(0s)?)$
+                            type: string
+                          nodes:
+                            default: 10%
+                            description: |-
+                              Nodes dictates the maximum number of NodeClaims owned by this NodePool
+                              that can be terminating at once. This is calculated by counting nodes that
+                              have a deletion timestamp set, or are actively being deleted by Karpenter.
+                              This field is required when specifying a budget.
+                              This cannot be of type intstr.IntOrString since kubebuilder doesn't support pattern
+                              checking for int nodes for IntOrString nodes.
+                              Ref: https://github.com/kubernetes-sigs/controller-tools/blob/55efe4be40394a288216dab63156b0a64fb82929/pkg/crd/markers/validation.go#L379-L388
+                            pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
+                            type: string
+                          schedule:
+                            description: |-
+                              Schedule specifies when a budget begins being active, following
+                              the upstream cronjob syntax. If omitted, the budget is always active.
+                              Timezones are not supported.
+                              This field is required if Duration is set.
+                            pattern: ^(@(annually|yearly|monthly|weekly|daily|midnight|hourly))|((.+)\s(.+)\s(.+)\s(.+)\s(.+))$
+                            type: string
+                        required:
+                          - nodes
+                        type: object
+                      maxItems: 50
+                      type: array
+                      x-kubernetes-validations:
+                        - message: '''schedule'' must be set with ''duration'''
+                          rule: self.all(x, has(x.schedule) == has(x.duration))
+                    consolidateAfter:
+                      description: |-
+                        ConsolidateAfter is the duration the controller will wait
+                        before attempting to terminate nodes that are underutilized.
+                        Refer to ConsolidationPolicy for how underutilization is considered.
+                      pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                      type: string
+                    consolidationPolicy:
+                      default: WhenUnderutilized
+                      description: |-
+                        ConsolidationPolicy describes which nodes Karpenter can disrupt through its consolidation
+                        algorithm. This policy defaults to "WhenUnderutilized" if not specified
+                      enum:
+                        - WhenEmpty
+                        - WhenUnderutilized
+                      type: string
+                    expireAfter:
+                      default: 720h
+                      description: |-
+                        ExpireAfter is the duration the controller will wait
+                        before terminating a node, measured from when the node is created. This
+                        is useful to implement features like eventually consistent node upgrade,
+                        memory leak protection, and disruption testing.
+                      pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                      type: string
+                  type: object
+                  x-kubernetes-validations:
+                    - message: consolidateAfter cannot be combined with consolidationPolicy=WhenUnderutilized
+                      rule: 'has(self.consolidateAfter) ? self.consolidationPolicy != ''WhenUnderutilized'' || self.consolidateAfter == ''Never'' : true'
+                    - message: consolidateAfter must be specified with consolidationPolicy=WhenEmpty
+                      rule: 'self.consolidationPolicy == ''WhenEmpty'' ? has(self.consolidateAfter) : true'
+                limits:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Limits define a set of bounds for provisioning capacity.
+                  type: object
+                template:
+                  description: |-
+                    Template contains the template of possibilities for the provisioning logic to launch a NodeClaim with.
+                    NodeClaims launched from this NodePool will often be further constrained than the template specifies.
+                  properties:
+                    metadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Annotations is an unstructured key value map stored with a resource that may be
+                            set by external tools to store and retrieve arbitrary metadata. They are not
+                            queryable and should be preserved when modifying objects.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                            maxLength: 63
+                            pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                          description: |-
+                            Map of string keys and values that can be used to organize and categorize
+                            (scope and select) objects. May match selectors of replication controllers
+                            and services.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
+                          type: object
+                          maxProperties: 100
+                          x-kubernetes-validations:
+                            - message: label domain "kubernetes.io" is restricted
+                              rule: self.all(x, x in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region",  "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || x.find("^([^/]+)").endsWith("node.kubernetes.io") || x.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !x.find("^([^/]+)").endsWith("kubernetes.io"))
+                            - message: label domain "k8s.io" is restricted
+                              rule: self.all(x, x.find("^([^/]+)").endsWith("kops.k8s.io") || !x.find("^([^/]+)").endsWith("k8s.io"))
+                            - message: label domain "karpenter.sh" is restricted
+                              rule: self.all(x, x in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !x.find("^([^/]+)").endsWith("karpenter.sh"))
+                            - message: label "karpenter.sh/nodepool" is restricted
+                              rule: self.all(x, x != "karpenter.sh/nodepool")
+                            - message: label "kubernetes.io/hostname" is restricted
+                              rule: self.all(x, x != "kubernetes.io/hostname")
+                            - message: label domain "karpenter.k8s.aws" is restricted
+                              rule: self.all(x, x in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !x.find("^([^/]+)").endsWith("karpenter.k8s.aws"))
+                      type: object
+                    spec:
+                      description: NodeClaimSpec describes the desired state of the NodeClaim
+                      properties:
+                        kubelet:
+                          description: |-
+                            Kubelet defines args to be used when configuring kubelet on provisioned nodes.
+                            They are a subset of the upstream types, recognizing not all options may be supported.
+                            Wherever possible, the types and names should reflect the upstream kubelet types.
+                          properties:
+                            clusterDNS:
+                              description: |-
+                                clusterDNS is a list of IP addresses for the cluster DNS server.
+                                Note that not all providers may use all addresses.
+                              items:
+                                type: string
+                              type: array
+                            cpuCFSQuota:
+                              description: CPUCFSQuota enables CPU CFS quota enforcement for containers that specify CPU limits.
+                              type: boolean
+                            evictionHard:
+                              additionalProperties:
+                                type: string
+                                pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                              description: EvictionHard is the map of signal names to quantities that define hard eviction thresholds
+                              type: object
+                              x-kubernetes-validations:
+                                - message: valid keys for evictionHard are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                                  rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                            evictionMaxPodGracePeriod:
+                              description: |-
+                                EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in
+                                response to soft eviction thresholds being met.
+                              format: int32
+                              type: integer
+                            evictionSoft:
+                              additionalProperties:
+                                type: string
+                                pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                              description: EvictionSoft is the map of signal names to quantities that define soft eviction thresholds
+                              type: object
+                              x-kubernetes-validations:
+                                - message: valid keys for evictionSoft are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                                  rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                            evictionSoftGracePeriod:
+                              additionalProperties:
+                                type: string
+                              description: EvictionSoftGracePeriod is the map of signal names to quantities that define grace periods for each eviction signal
+                              type: object
+                              x-kubernetes-validations:
+                                - message: valid keys for evictionSoftGracePeriod are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                                  rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                            imageGCHighThresholdPercent:
+                              description: |-
+                                ImageGCHighThresholdPercent is the percent of disk usage after which image
+                                garbage collection is always run. The percent is calculated by dividing this
+                                field value by 100, so this field must be between 0 and 100, inclusive.
+                                When specified, the value must be greater than ImageGCLowThresholdPercent.
+                              format: int32
+                              maximum: 100
+                              minimum: 0
+                              type: integer
+                            imageGCLowThresholdPercent:
+                              description: |-
+                                ImageGCLowThresholdPercent is the percent of disk usage before which image
+                                garbage collection is never run. Lowest disk usage to garbage collect to.
+                                The percent is calculated by dividing this field value by 100,
+                                so the field value must be between 0 and 100, inclusive.
+                                When specified, the value must be less than imageGCHighThresholdPercent
+                              format: int32
+                              maximum: 100
+                              minimum: 0
+                              type: integer
+                            kubeReserved:
+                              additionalProperties:
+                                type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              description: KubeReserved contains resources reserved for Kubernetes system components.
+                              type: object
+                              x-kubernetes-validations:
+                                - message: valid keys for kubeReserved are ['cpu','memory','ephemeral-storage','pid']
+                                  rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                                - message: kubeReserved value cannot be a negative resource quantity
+                                  rule: self.all(x, !self[x].startsWith('-'))
+                            maxPods:
+                              description: |-
+                                MaxPods is an override for the maximum number of pods that can run on
+                                a worker node instance.
+                              format: int32
+                              minimum: 0
+                              type: integer
+                            podsPerCore:
+                              description: |-
+                                PodsPerCore is an override for the number of pods that can run on a worker node
+                                instance based on the number of cpu cores. This value cannot exceed MaxPods, so, if
+                                MaxPods is a lower value, that value will be used.
+                              format: int32
+                              minimum: 0
+                              type: integer
+                            systemReserved:
+                              additionalProperties:
+                                type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              description: SystemReserved contains resources reserved for OS system daemons and kernel memory.
+                              type: object
+                              x-kubernetes-validations:
+                                - message: valid keys for systemReserved are ['cpu','memory','ephemeral-storage','pid']
+                                  rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                                - message: systemReserved value cannot be a negative resource quantity
+                                  rule: self.all(x, !self[x].startsWith('-'))
+                          type: object
+                          x-kubernetes-validations:
+                            - message: imageGCHighThresholdPercent must be greater than imageGCLowThresholdPercent
+                              rule: 'has(self.imageGCHighThresholdPercent) && has(self.imageGCLowThresholdPercent) ?  self.imageGCHighThresholdPercent > self.imageGCLowThresholdPercent  : true'
+                            - message: evictionSoft OwnerKey does not have a matching evictionSoftGracePeriod
+                              rule: has(self.evictionSoft) ? self.evictionSoft.all(e, (e in self.evictionSoftGracePeriod)):true
+                            - message: evictionSoftGracePeriod OwnerKey does not have a matching evictionSoft
+                              rule: has(self.evictionSoftGracePeriod) ? self.evictionSoftGracePeriod.all(e, (e in self.evictionSoft)):true
+                        nodeClassRef:
+                          description: NodeClassRef is a reference to an object that defines provider specific configuration
+                          properties:
+                            apiVersion:
+                              description: API version of the referent
+                              type: string
+                            kind:
+                              description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                              type: string
+                            name:
+                              description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        requirements:
+                          description: Requirements are layered with GetLabels and applied to every node.
+                          items:
+                            description: |-
+                              A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                              and minValues that represent the requirement to have at least that many values.
+                            properties:
+                              key:
+                                description: The label key that the selector applies to.
+                                type: string
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                                x-kubernetes-validations:
+                                  - message: label domain "kubernetes.io" is restricted
+                                    rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                                  - message: label domain "k8s.io" is restricted
+                                    rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                                  - message: label domain "karpenter.sh" is restricted
+                                    rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                                  - message: label "karpenter.sh/nodepool" is restricted
+                                    rule: self != "karpenter.sh/nodepool"
+                                  - message: label "kubernetes.io/hostname" is restricted
+                                    rule: self != "kubernetes.io/hostname"
+                                  - message: label domain "karpenter.k8s.aws" is restricted
+                                    rule: self in ["karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu","karpenter.k8s.aws/instance-cpu-manufacturer","karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                              minValues:
+                                description: |-
+                                  This field is ALPHA and can be dropped or replaced at any time
+                                  MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                                maximum: 50
+                                minimum: 1
+                                type: integer
+                              operator:
+                                description: |-
+                                  Represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                type: string
+                                enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  - Gt
+                                  - Lt
+                              values:
+                                description: |-
+                                  An array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                  array must have a single element, which will be interpreted as an integer.
+                                  This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          maxItems: 100
+                          type: array
+                          x-kubernetes-validations:
+                            - message: requirements with operator 'In' must have a value defined
+                              rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                            - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                              rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                            - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                              rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                        resources:
+                          description: Resources models the resource requirements for the NodeClaim to launch
+                          properties:
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: Requests describes the minimum required resources for the NodeClaim to launch
+                              type: object
+                          type: object
+                          maxProperties: 0
+                        startupTaints:
+                          description: |-
+                            StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                            within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                            daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                            purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        taints:
+                          description: Taints will be applied to the NodeClaim's node.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                      required:
+                        - nodeClassRef
+                        - requirements
+                      type: object
+                  required:
+                    - spec
+                  type: object
+                weight:
+                  description: |-
+                    Weight is the priority given to the nodepool during scheduling. A higher
+                    numerical weight indicates that this nodepool will be ordered
+                    ahead of other nodepools with lower weights. A nodepool with no weight
+                    will be treated as if it is a nodepool with a weight of 0.
+                  format: int32
+                  maximum: 100
+                  minimum: 1
+                  type: integer
+              required:
+                - template
+              type: object
+            status:
+              description: NodePoolStatus defines the observed state of NodePool
+              properties:
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                resources:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Resources is the list of resources that have been provisioned.
+                  type: object
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+        - v1
+      clientConfig:
+        service:
+          name: karpenter
+          namespace: kube-system
+          port: 8443

--- a/content/projects/karpenter/v1.1.0/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/content/projects/karpenter/v1.1.0/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -1,0 +1,739 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: ec2nodeclasses.karpenter.k8s.aws
+spec:
+  group: karpenter.k8s.aws
+  names:
+    categories:
+      - karpenter
+    kind: EC2NodeClass
+    listKind: EC2NodeClassList
+    plural: ec2nodeclasses
+    shortNames:
+      - ec2nc
+      - ec2ncs
+    singular: ec2nodeclass
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.role
+          name: Role
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: EC2NodeClass is the Schema for the EC2NodeClass API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                EC2NodeClassSpec is the top level specification for the AWS Karpenter Provider.
+                This will contain configuration necessary to launch instances in AWS.
+              properties:
+                amiFamily:
+                  description: |-
+                    AMIFamily dictates the UserData format and default BlockDeviceMappings used when generating launch templates.
+                    This field is optional when using an alias amiSelectorTerm, and the value will be inferred from the alias'
+                    family. When an alias is specified, this field may only be set to its corresponding family or 'Custom'. If no
+                    alias is specified, this field is required.
+                    NOTE: We ignore the AMIFamily for hashing here because we hash the AMIFamily dynamically by using the alias using
+                    the AMIFamily() helper function
+                  enum:
+                    - AL2
+                    - AL2023
+                    - Bottlerocket
+                    - Custom
+                    - Windows2019
+                    - Windows2022
+                  type: string
+                amiSelectorTerms:
+                  description: AMISelectorTerms is a list of or ami selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      AMISelectorTerm defines selection logic for an ami used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      alias:
+                        description: |-
+                          Alias specifies which EKS optimized AMI to select.
+                          Each alias consists of a family and an AMI version, specified as "family@version".
+                          Valid families include: al2, al2023, bottlerocket, windows2019, and windows2022.
+                          The version can either be pinned to a specific AMI release, with that AMIs version format (ex: "al2023@v20240625" or "bottlerocket@v1.10.0").
+                          The version can also be set to "latest" for any family. Setting the version to latest will result in drift when a new AMI is released. This is **not** recommended for production environments.
+                          Note: The Windows families do **not** support version pinning, and only latest may be used.
+                        maxLength: 30
+                        type: string
+                        x-kubernetes-validations:
+                          - message: '''alias'' is improperly formatted, must match the format ''family@version'''
+                            rule: self.matches('^[a-zA-Z0-9]+@.+$')
+                          - message: 'family is not supported, must be one of the following: ''al2'', ''al2023'', ''bottlerocket'', ''windows2019'', ''windows2022'''
+                            rule: self.split('@')[0] in ['al2','al2023','bottlerocket','windows2019','windows2022']
+                          - message: windows families may only specify version 'latest'
+                            rule: 'self.split(''@'')[0] in [''windows2019'',''windows2022''] ? self.split(''@'')[1] == ''latest'' : true'
+                      id:
+                        description: ID is the ami id in EC2
+                        pattern: ami-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the ami name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      owner:
+                        description: |-
+                          Owner is the owner for the ami.
+                          You can specify a combination of AWS account IDs, "self", "amazon", and "aws-marketplace"
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  minItems: 1
+                  type: array
+                  x-kubernetes-validations:
+                    - message: expected at least one, got none, ['tags', 'id', 'name', 'alias']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name) || has(x.alias))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.exists(x, has(x.id) && (has(x.alias) || has(x.tags) || has(x.name) || has(x.owner)))'
+                    - message: '''alias'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.exists(x, has(x.alias) && (has(x.id) || has(x.tags) || has(x.name) || has(x.owner)))'
+                    - message: '''alias'' is mutually exclusive, cannot be set with a combination of other amiSelectorTerms'
+                      rule: '!(self.exists(x, has(x.alias)) && self.size() != 1)'
+                associatePublicIPAddress:
+                  description: AssociatePublicIPAddress controls if public IP addresses are assigned to instances that are launched with the nodeclass.
+                  type: boolean
+                blockDeviceMappings:
+                  description: BlockDeviceMappings to be applied to provisioned nodes.
+                  items:
+                    properties:
+                      deviceName:
+                        description: The device name (for example, /dev/sdh or xvdh).
+                        type: string
+                      ebs:
+                        description: EBS contains parameters used to automatically set up EBS volumes when an instance is launched.
+                        properties:
+                          deleteOnTermination:
+                            description: DeleteOnTermination indicates whether the EBS volume is deleted on instance termination.
+                            type: boolean
+                          encrypted:
+                            description: |-
+                              Encrypted indicates whether the EBS volume is encrypted. Encrypted volumes can only
+                              be attached to instances that support Amazon EBS encryption. If you are creating
+                              a volume from a snapshot, you can't specify an encryption value.
+                            type: boolean
+                          iops:
+                            description: |-
+                              IOPS is the number of I/O operations per second (IOPS). For gp3, io1, and io2 volumes,
+                              this represents the number of IOPS that are provisioned for the volume. For
+                              gp2 volumes, this represents the baseline performance of the volume and the
+                              rate at which the volume accumulates I/O credits for bursting.
+
+                              The following are the supported values for each volume type:
+
+                                 * gp3: 3,000-16,000 IOPS
+
+                                 * io1: 100-64,000 IOPS
+
+                                 * io2: 100-64,000 IOPS
+
+                              For io1 and io2 volumes, we guarantee 64,000 IOPS only for Instances built
+                              on the Nitro System (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances).
+                              Other instance families guarantee performance up to 32,000 IOPS.
+
+                              This parameter is supported for io1, io2, and gp3 volumes only. This parameter
+                              is not supported for gp2, st1, sc1, or standard volumes.
+                            format: int64
+                            type: integer
+                          kmsKeyID:
+                            description: KMSKeyID (ARN) of the symmetric Key Management Service (KMS) CMK used for encryption.
+                            type: string
+                          snapshotID:
+                            description: SnapshotID is the ID of an EBS snapshot
+                            type: string
+                          throughput:
+                            description: |-
+                              Throughput to provision for a gp3 volume, with a maximum of 1,000 MiB/s.
+                              Valid Range: Minimum value of 125. Maximum value of 1000.
+                            format: int64
+                            type: integer
+                          volumeSize:
+                            description: |-
+                              VolumeSize in `Gi`, `G`, `Ti`, or `T`. You must specify either a snapshot ID or
+                              a volume size. The following are the supported volumes sizes for each volume
+                              type:
+
+                                 * gp2 and gp3: 1-16,384
+
+                                 * io1 and io2: 4-16,384
+
+                                 * st1 and sc1: 125-16,384
+
+                                 * standard: 1-1,024
+                            pattern: ^((?:[1-9][0-9]{0,3}|[1-4][0-9]{4}|[5][0-8][0-9]{3}|59000)Gi|(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|[6][0-3][0-9]{3}|64000)G|([1-9]||[1-5][0-7]|58)Ti|([1-9]||[1-5][0-9]|6[0-3]|64)T)$
+                            type: string
+                          volumeType:
+                            description: |-
+                              VolumeType of the block device.
+                              For more information, see Amazon EBS volume types (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html)
+                              in the Amazon Elastic Compute Cloud User Guide.
+                            enum:
+                              - standard
+                              - io1
+                              - io2
+                              - gp2
+                              - sc1
+                              - st1
+                              - gp3
+                            type: string
+                        type: object
+                        x-kubernetes-validations:
+                          - message: snapshotID or volumeSize must be defined
+                            rule: has(self.snapshotID) || has(self.volumeSize)
+                      rootVolume:
+                        description: |-
+                          RootVolume is a flag indicating if this device is mounted as kubelet root dir. You can
+                          configure at most one root volume in BlockDeviceMappings.
+                        type: boolean
+                    type: object
+                  maxItems: 50
+                  type: array
+                  x-kubernetes-validations:
+                    - message: must have only one blockDeviceMappings with rootVolume
+                      rule: self.filter(x, has(x.rootVolume)?x.rootVolume==true:false).size() <= 1
+                context:
+                  description: |-
+                    Context is a Reserved field in EC2 APIs
+                    https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet.html
+                  type: string
+                detailedMonitoring:
+                  description: DetailedMonitoring controls if detailed monitoring is enabled for instances that are launched
+                  type: boolean
+                instanceProfile:
+                  description: |-
+                    InstanceProfile is the AWS entity that instances use.
+                    This field is mutually exclusive from role.
+                    The instance profile should already have a role assigned to it that Karpenter
+                     has PassRole permission on for instance launch using this instanceProfile to succeed.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: instanceProfile cannot be empty
+                      rule: self != ''
+                instanceStorePolicy:
+                  description: InstanceStorePolicy specifies how to handle instance-store disks.
+                  enum:
+                    - RAID0
+                  type: string
+                kubelet:
+                  description: |-
+                    Kubelet defines args to be used when configuring kubelet on provisioned nodes.
+                    They are a subset of the upstream types, recognizing not all options may be supported.
+                    Wherever possible, the types and names should reflect the upstream kubelet types.
+                  properties:
+                    clusterDNS:
+                      description: |-
+                        clusterDNS is a list of IP addresses for the cluster DNS server.
+                        Note that not all providers may use all addresses.
+                      items:
+                        type: string
+                      type: array
+                    cpuCFSQuota:
+                      description: CPUCFSQuota enables CPU CFS quota enforcement for containers that specify CPU limits.
+                      type: boolean
+                    evictionHard:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionHard is the map of signal names to quantities that define hard eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionHard are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionMaxPodGracePeriod:
+                      description: |-
+                        EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in
+                        response to soft eviction thresholds being met.
+                      format: int32
+                      type: integer
+                    evictionSoft:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionSoft is the map of signal names to quantities that define soft eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoft are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionSoftGracePeriod:
+                      additionalProperties:
+                        type: string
+                      description: EvictionSoftGracePeriod is the map of signal names to quantities that define grace periods for each eviction signal
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoftGracePeriod are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    imageGCHighThresholdPercent:
+                      description: |-
+                        ImageGCHighThresholdPercent is the percent of disk usage after which image
+                        garbage collection is always run. The percent is calculated by dividing this
+                        field value by 100, so this field must be between 0 and 100, inclusive.
+                        When specified, the value must be greater than ImageGCLowThresholdPercent.
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    imageGCLowThresholdPercent:
+                      description: |-
+                        ImageGCLowThresholdPercent is the percent of disk usage before which image
+                        garbage collection is never run. Lowest disk usage to garbage collect to.
+                        The percent is calculated by dividing this field value by 100,
+                        so the field value must be between 0 and 100, inclusive.
+                        When specified, the value must be less than imageGCHighThresholdPercent
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    kubeReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: KubeReserved contains resources reserved for Kubernetes system components.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for kubeReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: kubeReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                    maxPods:
+                      description: |-
+                        MaxPods is an override for the maximum number of pods that can run on
+                        a worker node instance.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    podsPerCore:
+                      description: |-
+                        PodsPerCore is an override for the number of pods that can run on a worker node
+                        instance based on the number of cpu cores. This value cannot exceed MaxPods, so, if
+                        MaxPods is a lower value, that value will be used.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    systemReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: SystemReserved contains resources reserved for OS system daemons and kernel memory.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for systemReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: systemReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                  type: object
+                  x-kubernetes-validations:
+                    - message: imageGCHighThresholdPercent must be greater than imageGCLowThresholdPercent
+                      rule: 'has(self.imageGCHighThresholdPercent) && has(self.imageGCLowThresholdPercent) ?  self.imageGCHighThresholdPercent > self.imageGCLowThresholdPercent  : true'
+                    - message: evictionSoft OwnerKey does not have a matching evictionSoftGracePeriod
+                      rule: has(self.evictionSoft) ? self.evictionSoft.all(e, (e in self.evictionSoftGracePeriod)):true
+                    - message: evictionSoftGracePeriod OwnerKey does not have a matching evictionSoft
+                      rule: has(self.evictionSoftGracePeriod) ? self.evictionSoftGracePeriod.all(e, (e in self.evictionSoft)):true
+                metadataOptions:
+                  default:
+                    httpEndpoint: enabled
+                    httpProtocolIPv6: disabled
+                    httpPutResponseHopLimit: 1
+                    httpTokens: required
+                  description: |-
+                    MetadataOptions for the generated launch template of provisioned nodes.
+
+                    This specifies the exposure of the Instance Metadata Service to
+                    provisioned EC2 nodes. For more information,
+                    see Instance Metadata and User Data
+                    (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
+                    in the Amazon Elastic Compute Cloud User Guide.
+
+                    Refer to recommended, security best practices
+                    (https://aws.github.io/aws-eks-best-practices/security/docs/iam/#restrict-access-to-the-instance-profile-assigned-to-the-worker-node)
+                    for limiting exposure of Instance Metadata and User Data to pods.
+                    If omitted, defaults to httpEndpoint enabled, with httpProtocolIPv6
+                    disabled, with httpPutResponseLimit of 1, and with httpTokens
+                    required.
+                  properties:
+                    httpEndpoint:
+                      default: enabled
+                      description: |-
+                        HTTPEndpoint enables or disables the HTTP metadata endpoint on provisioned
+                        nodes. If metadata options is non-nil, but this parameter is not specified,
+                        the default state is "enabled".
+
+                        If you specify a value of "disabled", instance metadata will not be accessible
+                        on the node.
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpProtocolIPv6:
+                      default: disabled
+                      description: |-
+                        HTTPProtocolIPv6 enables or disables the IPv6 endpoint for the instance metadata
+                        service on provisioned nodes. If metadata options is non-nil, but this parameter
+                        is not specified, the default state is "disabled".
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpPutResponseHopLimit:
+                      default: 1
+                      description: |-
+                        HTTPPutResponseHopLimit is the desired HTTP PUT response hop limit for
+                        instance metadata requests. The larger the number, the further instance
+                        metadata requests can travel. Possible values are integers from 1 to 64.
+                        If metadata options is non-nil, but this parameter is not specified, the
+                        default value is 1.
+                      format: int64
+                      maximum: 64
+                      minimum: 1
+                      type: integer
+                    httpTokens:
+                      default: required
+                      description: |-
+                        HTTPTokens determines the state of token usage for instance metadata
+                        requests. If metadata options is non-nil, but this parameter is not
+                        specified, the default state is "required".
+
+                        If the state is optional, one can choose to retrieve instance metadata with
+                        or without a signed token header on the request. If one retrieves the IAM
+                        role credentials without a token, the version 1.0 role credentials are
+                        returned. If one retrieves the IAM role credentials using a valid signed
+                        token, the version 2.0 role credentials are returned.
+
+                        If the state is "required", one must send a signed token header with any
+                        instance metadata retrieval requests. In this state, retrieving the IAM
+                        role credentials always returns the version 2.0 credentials; the version
+                        1.0 credentials are not available.
+                      enum:
+                        - required
+                        - optional
+                      type: string
+                  type: object
+                role:
+                  description: |-
+                    Role is the AWS identity that nodes use. This field is immutable.
+                    This field is mutually exclusive from instanceProfile.
+                    Marking this field as immutable avoids concerns around terminating managed instance profiles from running instances.
+                    This field may be made mutable in the future, assuming the correct garbage collection and drift handling is implemented
+                    for the old instance profiles on an update.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: role cannot be empty
+                      rule: self != ''
+                    - message: immutable field changed
+                      rule: self == oldSelf
+                securityGroupSelectorTerms:
+                  description: SecurityGroupSelectorTerms is a list of or security group selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SecurityGroupSelectorTerm defines selection logic for a security group used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the security group id in EC2
+                        pattern: sg-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the security group name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: securityGroupSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id', 'name']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && (has(x.tags) || has(x.name)))'
+                    - message: '''name'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.name) && (has(x.tags) || has(x.id)))'
+                subnetSelectorTerms:
+                  description: SubnetSelectorTerms is a list of or subnet selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SubnetSelectorTerm defines selection logic for a subnet used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the subnet id in EC2
+                        pattern: subnet-[0-9a-z]+
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: subnetSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id']
+                      rule: self.all(x, has(x.tags) || has(x.id))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in subnetSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && has(x.tags))'
+                tags:
+                  additionalProperties:
+                    type: string
+                  description: Tags to be applied on ec2 resources like instances and launch templates.
+                  type: object
+                  x-kubernetes-validations:
+                    - message: empty tag keys aren't supported
+                      rule: self.all(k, k != '')
+                    - message: tag contains a restricted tag matching eks:eks-cluster-name
+                      rule: self.all(k, k !='eks:eks-cluster-name')
+                    - message: tag contains a restricted tag matching kubernetes.io/cluster/
+                      rule: self.all(k, !k.startsWith('kubernetes.io/cluster') )
+                    - message: tag contains a restricted tag matching karpenter.sh/nodepool
+                      rule: self.all(k, k != 'karpenter.sh/nodepool')
+                    - message: tag contains a restricted tag matching karpenter.sh/nodeclaim
+                      rule: self.all(k, k !='karpenter.sh/nodeclaim')
+                    - message: tag contains a restricted tag matching karpenter.k8s.aws/ec2nodeclass
+                      rule: self.all(k, k !='karpenter.k8s.aws/ec2nodeclass')
+                userData:
+                  description: |-
+                    UserData to be applied to the provisioned nodes.
+                    It must be in the appropriate format based on the AMIFamily in use. Karpenter will merge certain fields into
+                    this UserData to ensure nodes are being provisioned with the correct configuration.
+                  type: string
+              required:
+                - amiSelectorTerms
+                - securityGroupSelectorTerms
+                - subnetSelectorTerms
+              type: object
+              x-kubernetes-validations:
+                - message: must specify exactly one of ['role', 'instanceProfile']
+                  rule: (has(self.role) && !has(self.instanceProfile)) || (!has(self.role) && has(self.instanceProfile))
+                - message: changing from 'instanceProfile' to 'role' is not supported. You must delete and recreate this node class if you want to change this.
+                  rule: (has(oldSelf.role) && has(self.role)) || (has(oldSelf.instanceProfile) && has(self.instanceProfile))
+                - message: if set, amiFamily must be 'AL2' or 'Custom' when using an AL2 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''al2'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''AL2'') : true)'
+                - message: if set, amiFamily must be 'AL2023' or 'Custom' when using an AL2023 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''al2023'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''AL2023'') : true)'
+                - message: if set, amiFamily must be 'Bottlerocket' or 'Custom' when using a Bottlerocket alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''bottlerocket'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Bottlerocket'') : true)'
+                - message: if set, amiFamily must be 'Windows2019' or 'Custom' when using a Windows2019 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''windows2019'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Windows2019'') : true)'
+                - message: if set, amiFamily must be 'Windows2022' or 'Custom' when using a Windows2022 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''windows2022'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Windows2022'') : true)'
+                - message: must specify amiFamily if amiSelectorTerms does not contain an alias
+                  rule: 'self.amiSelectorTerms.exists(x, has(x.alias)) ? true : has(self.amiFamily)'
+            status:
+              description: EC2NodeClassStatus contains the resolved state of the EC2NodeClass
+              properties:
+                amis:
+                  description: |-
+                    AMI contains the current AMI values that are available to the
+                    cluster under the AMI selectors.
+                  items:
+                    description: AMI contains resolved AMI selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the AMI
+                        type: string
+                      name:
+                        description: Name of the AMI
+                        type: string
+                      requirements:
+                        description: Requirements of the AMI to be utilized on an instance type
+                        items:
+                          description: |-
+                            A node selector requirement is a selector that contains values, a key, and an operator
+                            that relates the key and values.
+                          properties:
+                            key:
+                              description: The label key that the selector applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                Represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                              type: string
+                            values:
+                              description: |-
+                                An array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. If the operator is Gt or Lt, the values
+                                array must have a single element, which will be interpreted as an integer.
+                                This array is replaced during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                            - key
+                            - operator
+                          type: object
+                        type: array
+                    required:
+                      - id
+                      - requirements
+                    type: object
+                  type: array
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                instanceProfile:
+                  description: InstanceProfile contains the resolved instance profile for the role
+                  type: string
+                securityGroups:
+                  description: |-
+                    SecurityGroups contains the current Security Groups values that are available to the
+                    cluster under the SecurityGroups selectors.
+                  items:
+                    description: SecurityGroup contains resolved SecurityGroup selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the security group
+                        type: string
+                      name:
+                        description: Name of the security group
+                        type: string
+                    required:
+                      - id
+                    type: object
+                  type: array
+                subnets:
+                  description: |-
+                    Subnets contains the current Subnet values that are available to the
+                    cluster under the subnet selectors.
+                  items:
+                    description: Subnet contains resolved Subnet selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the subnet
+                        type: string
+                      zone:
+                        description: The associated availability zone
+                        type: string
+                      zoneID:
+                        description: The associated availability zone ID
+                        type: string
+                    required:
+                      - id
+                      - zone
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/content/projects/karpenter/v1.1.0/karpenter.sh_nodeclaims.yaml
+++ b/content/projects/karpenter/v1.1.0/karpenter.sh_nodeclaims.yaml
@@ -1,0 +1,391 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: nodeclaims.karpenter.sh
+spec:
+  group: karpenter.sh
+  names:
+    categories:
+      - karpenter
+    kind: NodeClaim
+    listKind: NodeClaimList
+    plural: nodeclaims
+    singular: nodeclaim
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.labels.node\.kubernetes\.io/instance-type
+          name: Type
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/capacity-type
+          name: Capacity
+          type: string
+        - jsonPath: .metadata.labels.topology\.kubernetes\.io/zone
+          name: Zone
+          type: string
+        - jsonPath: .status.nodeName
+          name: Node
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .status.providerID
+          name: ID
+          priority: 1
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/nodepool
+          name: NodePool
+          priority: 1
+          type: string
+        - jsonPath: .spec.nodeClassRef.name
+          name: NodeClass
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: NodeClaim is the Schema for the NodeClaims API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: NodeClaimSpec describes the desired state of the NodeClaim
+              properties:
+                expireAfter:
+                  default: 720h
+                  description: |-
+                    ExpireAfter is the duration the controller will wait
+                    before terminating a node, measured from when the node is created. This
+                    is useful to implement features like eventually consistent node upgrade,
+                    memory leak protection, and disruption testing.
+                  pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                  type: string
+                nodeClassRef:
+                  description: NodeClassRef is a reference to an object that defines provider specific configuration
+                  properties:
+                    group:
+                      description: API version of the referent
+                      pattern: ^[^/]*$
+                      type: string
+                      x-kubernetes-validations:
+                        - message: group may not be empty
+                          rule: self != ''
+                    kind:
+                      description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                      type: string
+                      x-kubernetes-validations:
+                        - message: kind may not be empty
+                          rule: self != ''
+                    name:
+                      description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                      type: string
+                      x-kubernetes-validations:
+                        - message: name may not be empty
+                          rule: self != ''
+                  required:
+                    - group
+                    - kind
+                    - name
+                  type: object
+                requirements:
+                  description: Requirements are layered with GetLabels and applied to every node.
+                  items:
+                    description: |-
+                      A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                      and minValues that represent the requirement to have at least that many values.
+                    properties:
+                      key:
+                        description: The label key that the selector applies to.
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                        x-kubernetes-validations:
+                          - message: label domain "kubernetes.io" is restricted
+                            rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                          - message: label domain "k8s.io" is restricted
+                            rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                          - message: label domain "karpenter.sh" is restricted
+                            rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                          - message: label "kubernetes.io/hostname" is restricted
+                            rule: self != "kubernetes.io/hostname"
+                          - message: label domain "karpenter.k8s.aws" is restricted
+                            rule: self in ["karpenter.k8s.aws/ec2nodeclass", "karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu", "karpenter.k8s.aws/instance-cpu-manufacturer", "karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz", "karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                      minValues:
+                        description: |-
+                          This field is ALPHA and can be dropped or replaced at any time
+                          MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                        maximum: 50
+                        minimum: 1
+                        type: integer
+                      operator:
+                        description: |-
+                          Represents a key's relationship to a set of values.
+                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                        type: string
+                        enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          - Gt
+                          - Lt
+                      values:
+                        description: |-
+                          An array of string values. If the operator is In or NotIn,
+                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                          the values array must be empty. If the operator is Gt or Lt, the values
+                          array must have a single element, which will be interpreted as an integer.
+                          This array is replaced during a strategic merge patch.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                        maxLength: 63
+                        pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                    required:
+                      - key
+                      - operator
+                    type: object
+                  maxItems: 100
+                  type: array
+                  x-kubernetes-validations:
+                    - message: requirements with operator 'In' must have a value defined
+                      rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                    - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                      rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                    - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                      rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                resources:
+                  description: Resources models the resource requirements for the NodeClaim to launch
+                  properties:
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: Requests describes the minimum required resources for the NodeClaim to launch
+                      type: object
+                  type: object
+                startupTaints:
+                  description: |-
+                    StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                    within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                    daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                    purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                taints:
+                  description: Taints will be applied to the NodeClaim's node.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                terminationGracePeriod:
+                  description: |-
+                    TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
+
+                    Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
+
+                    This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
+                    When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
+
+                    Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
+                    If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
+                    that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
+
+                    The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
+                    If left undefined, the controller will wait indefinitely for pods to be drained.
+                  pattern: ^([0-9]+(s|m|h))+$
+                  type: string
+              required:
+                - nodeClassRef
+                - requirements
+              type: object
+              x-kubernetes-validations:
+                - message: spec is immutable
+                  rule: self == oldSelf
+            status:
+              description: NodeClaimStatus defines the observed state of NodeClaim
+              properties:
+                allocatable:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Allocatable is the estimated allocatable capacity of the node
+                  type: object
+                capacity:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Capacity is the estimated full capacity of the node
+                  type: object
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        pattern: ^([A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?|)$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - status
+                      - type
+                    type: object
+                  type: array
+                imageID:
+                  description: ImageID is an identifier for the image that runs on the node
+                  type: string
+                lastPodEventTime:
+                  description: |-
+                    LastPodEventTime is updated with the last time a pod was scheduled
+                    or removed from the node. A pod going terminal or terminating
+                    is also considered as removed.
+                  format: date-time
+                  type: string
+                nodeName:
+                  description: NodeName is the name of the corresponding node object
+                  type: string
+                providerID:
+                  description: ProviderID of the corresponding node object
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/content/projects/karpenter/v1.1.0/karpenter.sh_nodepools.yaml
+++ b/content/projects/karpenter/v1.1.0/karpenter.sh_nodepools.yaml
@@ -1,0 +1,519 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: nodepools.karpenter.sh
+spec:
+  group: karpenter.sh
+  names:
+    categories:
+      - karpenter
+    kind: NodePool
+    listKind: NodePoolList
+    plural: nodepools
+    singular: nodepool
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.template.spec.nodeClassRef.name
+          name: NodeClass
+          type: string
+        - jsonPath: .status.resources.nodes
+          name: Nodes
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.weight
+          name: Weight
+          priority: 1
+          type: integer
+        - jsonPath: .status.resources.cpu
+          name: CPU
+          priority: 1
+          type: string
+        - jsonPath: .status.resources.memory
+          name: Memory
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: NodePool is the Schema for the NodePools API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                NodePoolSpec is the top level nodepool specification. Nodepools
+                launch nodes in response to pods that are unschedulable. A single nodepool
+                is capable of managing a diverse set of nodes. Node properties are determined
+                from a combination of nodepool and pod scheduling constraints.
+              properties:
+                disruption:
+                  default:
+                    consolidateAfter: 0s
+                  description: Disruption contains the parameters that relate to Karpenter's disruption logic
+                  properties:
+                    budgets:
+                      default:
+                        - nodes: 10%
+                      description: |-
+                        Budgets is a list of Budgets.
+                        If there are multiple active budgets, Karpenter uses
+                        the most restrictive value. If left undefined,
+                        this will default to one budget with a value to 10%.
+                      items:
+                        description: |-
+                          Budget defines when Karpenter will restrict the
+                          number of Node Claims that can be terminating simultaneously.
+                        properties:
+                          duration:
+                            description: |-
+                              Duration determines how long a Budget is active since each Schedule hit.
+                              Only minutes and hours are accepted, as cron does not work in seconds.
+                              If omitted, the budget is always active.
+                              This is required if Schedule is set.
+                              This regex has an optional 0s at the end since the duration.String() always adds
+                              a 0s at the end.
+                            pattern: ^((([0-9]+(h|m))|([0-9]+h[0-9]+m))(0s)?)$
+                            type: string
+                          nodes:
+                            default: 10%
+                            description: |-
+                              Nodes dictates the maximum number of NodeClaims owned by this NodePool
+                              that can be terminating at once. This is calculated by counting nodes that
+                              have a deletion timestamp set, or are actively being deleted by Karpenter.
+                              This field is required when specifying a budget.
+                              This cannot be of type intstr.IntOrString since kubebuilder doesn't support pattern
+                              checking for int nodes for IntOrString nodes.
+                              Ref: https://github.com/kubernetes-sigs/controller-tools/blob/55efe4be40394a288216dab63156b0a64fb82929/pkg/crd/markers/validation.go#L379-L388
+                            pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
+                            type: string
+                          reasons:
+                            description: |-
+                              Reasons is a list of disruption methods that this budget applies to. If Reasons is not set, this budget applies to all methods.
+                              Otherwise, this will apply to each reason defined.
+                              allowed reasons are Underutilized, Empty, and Drifted.
+                            items:
+                              description: DisruptionReason defines valid reasons for disruption budgets.
+                              enum:
+                                - Underutilized
+                                - Empty
+                                - Drifted
+                              type: string
+                            type: array
+                          schedule:
+                            description: |-
+                              Schedule specifies when a budget begins being active, following
+                              the upstream cronjob syntax. If omitted, the budget is always active.
+                              Timezones are not supported.
+                              This field is required if Duration is set.
+                            pattern: ^(@(annually|yearly|monthly|weekly|daily|midnight|hourly))|((.+)\s(.+)\s(.+)\s(.+)\s(.+))$
+                            type: string
+                        required:
+                          - nodes
+                        type: object
+                      maxItems: 50
+                      type: array
+                      x-kubernetes-validations:
+                        - message: '''schedule'' must be set with ''duration'''
+                          rule: self.all(x, has(x.schedule) == has(x.duration))
+                    consolidateAfter:
+                      description: |-
+                        ConsolidateAfter is the duration the controller will wait
+                        before attempting to terminate nodes that are underutilized.
+                        Refer to ConsolidationPolicy for how underutilization is considered.
+                      pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                      type: string
+                    consolidationPolicy:
+                      default: WhenEmptyOrUnderutilized
+                      description: |-
+                        ConsolidationPolicy describes which nodes Karpenter can disrupt through its consolidation
+                        algorithm. This policy defaults to "WhenEmptyOrUnderutilized" if not specified
+                      enum:
+                        - WhenEmpty
+                        - WhenEmptyOrUnderutilized
+                      type: string
+                  required:
+                    - consolidateAfter
+                  type: object
+                limits:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Limits define a set of bounds for provisioning capacity.
+                  type: object
+                template:
+                  description: |-
+                    Template contains the template of possibilities for the provisioning logic to launch a NodeClaim with.
+                    NodeClaims launched from this NodePool will often be further constrained than the template specifies.
+                  properties:
+                    metadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Annotations is an unstructured key value map stored with a resource that may be
+                            set by external tools to store and retrieve arbitrary metadata. They are not
+                            queryable and should be preserved when modifying objects.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                            maxLength: 63
+                            pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                          description: |-
+                            Map of string keys and values that can be used to organize and categorize
+                            (scope and select) objects. May match selectors of replication controllers
+                            and services.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
+                          type: object
+                          maxProperties: 100
+                          x-kubernetes-validations:
+                            - message: label domain "kubernetes.io" is restricted
+                              rule: self.all(x, x in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region",  "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || x.find("^([^/]+)").endsWith("node.kubernetes.io") || x.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !x.find("^([^/]+)").endsWith("kubernetes.io"))
+                            - message: label domain "k8s.io" is restricted
+                              rule: self.all(x, x.find("^([^/]+)").endsWith("kops.k8s.io") || !x.find("^([^/]+)").endsWith("k8s.io"))
+                            - message: label domain "karpenter.sh" is restricted
+                              rule: self.all(x, x in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !x.find("^([^/]+)").endsWith("karpenter.sh"))
+                            - message: label "karpenter.sh/nodepool" is restricted
+                              rule: self.all(x, x != "karpenter.sh/nodepool")
+                            - message: label "kubernetes.io/hostname" is restricted
+                              rule: self.all(x, x != "kubernetes.io/hostname")
+                            - message: label domain "karpenter.k8s.aws" is restricted
+                              rule: self.all(x, x in ["karpenter.k8s.aws/ec2nodeclass", "karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu", "karpenter.k8s.aws/instance-cpu-manufacturer", "karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz", "karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !x.find("^([^/]+)").endsWith("karpenter.k8s.aws"))
+                      type: object
+                    spec:
+                      description: |-
+                        NodeClaimTemplateSpec describes the desired state of the NodeClaim in the Nodepool
+                        NodeClaimTemplateSpec is used in the NodePool's NodeClaimTemplate, with the resource requests omitted since
+                        users are not able to set resource requests in the NodePool.
+                      properties:
+                        expireAfter:
+                          default: 720h
+                          description: |-
+                            ExpireAfter is the duration the controller will wait
+                            before terminating a node, measured from when the node is created. This
+                            is useful to implement features like eventually consistent node upgrade,
+                            memory leak protection, and disruption testing.
+                          pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                          type: string
+                        nodeClassRef:
+                          description: NodeClassRef is a reference to an object that defines provider specific configuration
+                          properties:
+                            group:
+                              description: API version of the referent
+                              pattern: ^[^/]*$
+                              type: string
+                              x-kubernetes-validations:
+                                - message: group may not be empty
+                                  rule: self != ''
+                            kind:
+                              description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                              type: string
+                              x-kubernetes-validations:
+                                - message: kind may not be empty
+                                  rule: self != ''
+                            name:
+                              description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                              x-kubernetes-validations:
+                                - message: name may not be empty
+                                  rule: self != ''
+                          required:
+                            - group
+                            - kind
+                            - name
+                          type: object
+                          x-kubernetes-validations:
+                            - message: nodeClassRef.group is immutable
+                              rule: self.group == oldSelf.group
+                            - message: nodeClassRef.kind is immutable
+                              rule: self.kind == oldSelf.kind
+                        requirements:
+                          description: Requirements are layered with GetLabels and applied to every node.
+                          items:
+                            description: |-
+                              A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                              and minValues that represent the requirement to have at least that many values.
+                            properties:
+                              key:
+                                description: The label key that the selector applies to.
+                                type: string
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                                x-kubernetes-validations:
+                                  - message: label domain "kubernetes.io" is restricted
+                                    rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                                  - message: label domain "k8s.io" is restricted
+                                    rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                                  - message: label domain "karpenter.sh" is restricted
+                                    rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                                  - message: label "karpenter.sh/nodepool" is restricted
+                                    rule: self != "karpenter.sh/nodepool"
+                                  - message: label "kubernetes.io/hostname" is restricted
+                                    rule: self != "kubernetes.io/hostname"
+                                  - message: label domain "karpenter.k8s.aws" is restricted
+                                    rule: self in ["karpenter.k8s.aws/ec2nodeclass", "karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu", "karpenter.k8s.aws/instance-cpu-manufacturer", "karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz", "karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                              minValues:
+                                description: |-
+                                  This field is ALPHA and can be dropped or replaced at any time
+                                  MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                                maximum: 50
+                                minimum: 1
+                                type: integer
+                              operator:
+                                description: |-
+                                  Represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                type: string
+                                enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  - Gt
+                                  - Lt
+                              values:
+                                description: |-
+                                  An array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                  array must have a single element, which will be interpreted as an integer.
+                                  This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          maxItems: 100
+                          type: array
+                          x-kubernetes-validations:
+                            - message: requirements with operator 'In' must have a value defined
+                              rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                            - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                              rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                            - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                              rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                        startupTaints:
+                          description: |-
+                            StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                            within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                            daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                            purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        taints:
+                          description: Taints will be applied to the NodeClaim's node.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        terminationGracePeriod:
+                          description: |-
+                            TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
+
+                            Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
+
+                            This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
+                            When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
+
+                            Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
+                            If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
+                            that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
+
+                            The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
+                            If left undefined, the controller will wait indefinitely for pods to be drained.
+                          pattern: ^([0-9]+(s|m|h))+$
+                          type: string
+                      required:
+                        - nodeClassRef
+                        - requirements
+                      type: object
+                  required:
+                    - spec
+                  type: object
+                weight:
+                  description: |-
+                    Weight is the priority given to the nodepool during scheduling. A higher
+                    numerical weight indicates that this nodepool will be ordered
+                    ahead of other nodepools with lower weights. A nodepool with no weight
+                    will be treated as if it is a nodepool with a weight of 0.
+                  format: int32
+                  maximum: 100
+                  minimum: 1
+                  type: integer
+              required:
+                - template
+              type: object
+            status:
+              description: NodePoolStatus defines the observed state of NodePool
+              properties:
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                resources:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Resources is the list of resources that have been provisioned.
+                  type: object
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/content/projects/karpenter/v1.1.1/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/content/projects/karpenter/v1.1.1/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -1,0 +1,742 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: ec2nodeclasses.karpenter.k8s.aws
+spec:
+  group: karpenter.k8s.aws
+  names:
+    categories:
+      - karpenter
+    kind: EC2NodeClass
+    listKind: EC2NodeClassList
+    plural: ec2nodeclasses
+    shortNames:
+      - ec2nc
+      - ec2ncs
+    singular: ec2nodeclass
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.role
+          name: Role
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: EC2NodeClass is the Schema for the EC2NodeClass API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                EC2NodeClassSpec is the top level specification for the AWS Karpenter Provider.
+                This will contain configuration necessary to launch instances in AWS.
+              properties:
+                amiFamily:
+                  description: |-
+                    AMIFamily dictates the UserData format and default BlockDeviceMappings used when generating launch templates.
+                    This field is optional when using an alias amiSelectorTerm, and the value will be inferred from the alias'
+                    family. When an alias is specified, this field may only be set to its corresponding family or 'Custom'. If no
+                    alias is specified, this field is required.
+                    NOTE: We ignore the AMIFamily for hashing here because we hash the AMIFamily dynamically by using the alias using
+                    the AMIFamily() helper function
+                  enum:
+                    - AL2
+                    - AL2023
+                    - Bottlerocket
+                    - Custom
+                    - Windows2019
+                    - Windows2022
+                  type: string
+                amiSelectorTerms:
+                  description: AMISelectorTerms is a list of or ami selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      AMISelectorTerm defines selection logic for an ami used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      alias:
+                        description: |-
+                          Alias specifies which EKS optimized AMI to select.
+                          Each alias consists of a family and an AMI version, specified as "family@version".
+                          Valid families include: al2, al2023, bottlerocket, windows2019, and windows2022.
+                          The version can either be pinned to a specific AMI release, with that AMIs version format (ex: "al2023@v20240625" or "bottlerocket@v1.10.0").
+                          The version can also be set to "latest" for any family. Setting the version to latest will result in drift when a new AMI is released. This is **not** recommended for production environments.
+                          Note: The Windows families do **not** support version pinning, and only latest may be used.
+                        maxLength: 30
+                        type: string
+                        x-kubernetes-validations:
+                          - message: '''alias'' is improperly formatted, must match the format ''family@version'''
+                            rule: self.matches('^[a-zA-Z0-9]+@.+$')
+                          - message: 'family is not supported, must be one of the following: ''al2'', ''al2023'', ''bottlerocket'', ''windows2019'', ''windows2022'''
+                            rule: self.split('@')[0] in ['al2','al2023','bottlerocket','windows2019','windows2022']
+                          - message: windows families may only specify version 'latest'
+                            rule: 'self.split(''@'')[0] in [''windows2019'',''windows2022''] ? self.split(''@'')[1] == ''latest'' : true'
+                      id:
+                        description: ID is the ami id in EC2
+                        pattern: ami-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the ami name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      owner:
+                        description: |-
+                          Owner is the owner for the ami.
+                          You can specify a combination of AWS account IDs, "self", "amazon", and "aws-marketplace"
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select amis.
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  minItems: 1
+                  type: array
+                  x-kubernetes-validations:
+                    - message: expected at least one, got none, ['tags', 'id', 'name', 'alias']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name) || has(x.alias))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.exists(x, has(x.id) && (has(x.alias) || has(x.tags) || has(x.name) || has(x.owner)))'
+                    - message: '''alias'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.exists(x, has(x.alias) && (has(x.id) || has(x.tags) || has(x.name) || has(x.owner)))'
+                    - message: '''alias'' is mutually exclusive, cannot be set with a combination of other amiSelectorTerms'
+                      rule: '!(self.exists(x, has(x.alias)) && self.size() != 1)'
+                associatePublicIPAddress:
+                  description: AssociatePublicIPAddress controls if public IP addresses are assigned to instances that are launched with the nodeclass.
+                  type: boolean
+                blockDeviceMappings:
+                  description: BlockDeviceMappings to be applied to provisioned nodes.
+                  items:
+                    properties:
+                      deviceName:
+                        description: The device name (for example, /dev/sdh or xvdh).
+                        type: string
+                      ebs:
+                        description: EBS contains parameters used to automatically set up EBS volumes when an instance is launched.
+                        properties:
+                          deleteOnTermination:
+                            description: DeleteOnTermination indicates whether the EBS volume is deleted on instance termination.
+                            type: boolean
+                          encrypted:
+                            description: |-
+                              Encrypted indicates whether the EBS volume is encrypted. Encrypted volumes can only
+                              be attached to instances that support Amazon EBS encryption. If you are creating
+                              a volume from a snapshot, you can't specify an encryption value.
+                            type: boolean
+                          iops:
+                            description: |-
+                              IOPS is the number of I/O operations per second (IOPS). For gp3, io1, and io2 volumes,
+                              this represents the number of IOPS that are provisioned for the volume. For
+                              gp2 volumes, this represents the baseline performance of the volume and the
+                              rate at which the volume accumulates I/O credits for bursting.
+
+                              The following are the supported values for each volume type:
+
+                                 * gp3: 3,000-16,000 IOPS
+
+                                 * io1: 100-64,000 IOPS
+
+                                 * io2: 100-64,000 IOPS
+
+                              For io1 and io2 volumes, we guarantee 64,000 IOPS only for Instances built
+                              on the Nitro System (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances).
+                              Other instance families guarantee performance up to 32,000 IOPS.
+
+                              This parameter is supported for io1, io2, and gp3 volumes only. This parameter
+                              is not supported for gp2, st1, sc1, or standard volumes.
+                            format: int64
+                            type: integer
+                          kmsKeyID:
+                            description: KMSKeyID (ARN) of the symmetric Key Management Service (KMS) CMK used for encryption.
+                            type: string
+                          snapshotID:
+                            description: SnapshotID is the ID of an EBS snapshot
+                            type: string
+                          throughput:
+                            description: |-
+                              Throughput to provision for a gp3 volume, with a maximum of 1,000 MiB/s.
+                              Valid Range: Minimum value of 125. Maximum value of 1000.
+                            format: int64
+                            type: integer
+                          volumeSize:
+                            description: |-
+                              VolumeSize in `Gi`, `G`, `Ti`, or `T`. You must specify either a snapshot ID or
+                              a volume size. The following are the supported volumes sizes for each volume
+                              type:
+
+                                 * gp2 and gp3: 1-16,384
+
+                                 * io1 and io2: 4-16,384
+
+                                 * st1 and sc1: 125-16,384
+
+                                 * standard: 1-1,024
+                            pattern: ^((?:[1-9][0-9]{0,3}|[1-4][0-9]{4}|[5][0-8][0-9]{3}|59000)Gi|(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|[6][0-3][0-9]{3}|64000)G|([1-9]||[1-5][0-7]|58)Ti|([1-9]||[1-5][0-9]|6[0-3]|64)T)$
+                            type: string
+                          volumeType:
+                            description: |-
+                              VolumeType of the block device.
+                              For more information, see Amazon EBS volume types (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html)
+                              in the Amazon Elastic Compute Cloud User Guide.
+                            enum:
+                              - standard
+                              - io1
+                              - io2
+                              - gp2
+                              - sc1
+                              - st1
+                              - gp3
+                            type: string
+                        type: object
+                        x-kubernetes-validations:
+                          - message: snapshotID or volumeSize must be defined
+                            rule: has(self.snapshotID) || has(self.volumeSize)
+                      rootVolume:
+                        description: |-
+                          RootVolume is a flag indicating if this device is mounted as kubelet root dir. You can
+                          configure at most one root volume in BlockDeviceMappings.
+                        type: boolean
+                    type: object
+                  maxItems: 50
+                  type: array
+                  x-kubernetes-validations:
+                    - message: must have only one blockDeviceMappings with rootVolume
+                      rule: self.filter(x, has(x.rootVolume)?x.rootVolume==true:false).size() <= 1
+                context:
+                  description: |-
+                    Context is a Reserved field in EC2 APIs
+                    https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet.html
+                  type: string
+                detailedMonitoring:
+                  description: DetailedMonitoring controls if detailed monitoring is enabled for instances that are launched
+                  type: boolean
+                instanceProfile:
+                  description: |-
+                    InstanceProfile is the AWS entity that instances use.
+                    This field is mutually exclusive from role.
+                    The instance profile should already have a role assigned to it that Karpenter
+                     has PassRole permission on for instance launch using this instanceProfile to succeed.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: instanceProfile cannot be empty
+                      rule: self != ''
+                instanceStorePolicy:
+                  description: InstanceStorePolicy specifies how to handle instance-store disks.
+                  enum:
+                    - RAID0
+                  type: string
+                kubelet:
+                  description: |-
+                    Kubelet defines args to be used when configuring kubelet on provisioned nodes.
+                    They are a subset of the upstream types, recognizing not all options may be supported.
+                    Wherever possible, the types and names should reflect the upstream kubelet types.
+                  properties:
+                    clusterDNS:
+                      description: |-
+                        clusterDNS is a list of IP addresses for the cluster DNS server.
+                        Note that not all providers may use all addresses.
+                      items:
+                        type: string
+                      type: array
+                    cpuCFSQuota:
+                      description: CPUCFSQuota enables CPU CFS quota enforcement for containers that specify CPU limits.
+                      type: boolean
+                    evictionHard:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionHard is the map of signal names to quantities that define hard eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionHard are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionMaxPodGracePeriod:
+                      description: |-
+                        EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in
+                        response to soft eviction thresholds being met.
+                      format: int32
+                      type: integer
+                    evictionSoft:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionSoft is the map of signal names to quantities that define soft eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoft are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionSoftGracePeriod:
+                      additionalProperties:
+                        type: string
+                      description: EvictionSoftGracePeriod is the map of signal names to quantities that define grace periods for each eviction signal
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoftGracePeriod are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    imageGCHighThresholdPercent:
+                      description: |-
+                        ImageGCHighThresholdPercent is the percent of disk usage after which image
+                        garbage collection is always run. The percent is calculated by dividing this
+                        field value by 100, so this field must be between 0 and 100, inclusive.
+                        When specified, the value must be greater than ImageGCLowThresholdPercent.
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    imageGCLowThresholdPercent:
+                      description: |-
+                        ImageGCLowThresholdPercent is the percent of disk usage before which image
+                        garbage collection is never run. Lowest disk usage to garbage collect to.
+                        The percent is calculated by dividing this field value by 100,
+                        so the field value must be between 0 and 100, inclusive.
+                        When specified, the value must be less than imageGCHighThresholdPercent
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    kubeReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: KubeReserved contains resources reserved for Kubernetes system components.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for kubeReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: kubeReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                    maxPods:
+                      description: |-
+                        MaxPods is an override for the maximum number of pods that can run on
+                        a worker node instance.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    podsPerCore:
+                      description: |-
+                        PodsPerCore is an override for the number of pods that can run on a worker node
+                        instance based on the number of cpu cores. This value cannot exceed MaxPods, so, if
+                        MaxPods is a lower value, that value will be used.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    systemReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: SystemReserved contains resources reserved for OS system daemons and kernel memory.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for systemReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: systemReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                  type: object
+                  x-kubernetes-validations:
+                    - message: imageGCHighThresholdPercent must be greater than imageGCLowThresholdPercent
+                      rule: 'has(self.imageGCHighThresholdPercent) && has(self.imageGCLowThresholdPercent) ?  self.imageGCHighThresholdPercent > self.imageGCLowThresholdPercent  : true'
+                    - message: evictionSoft OwnerKey does not have a matching evictionSoftGracePeriod
+                      rule: has(self.evictionSoft) ? self.evictionSoft.all(e, (e in self.evictionSoftGracePeriod)):true
+                    - message: evictionSoftGracePeriod OwnerKey does not have a matching evictionSoft
+                      rule: has(self.evictionSoftGracePeriod) ? self.evictionSoftGracePeriod.all(e, (e in self.evictionSoft)):true
+                metadataOptions:
+                  default:
+                    httpEndpoint: enabled
+                    httpProtocolIPv6: disabled
+                    httpPutResponseHopLimit: 1
+                    httpTokens: required
+                  description: |-
+                    MetadataOptions for the generated launch template of provisioned nodes.
+
+                    This specifies the exposure of the Instance Metadata Service to
+                    provisioned EC2 nodes. For more information,
+                    see Instance Metadata and User Data
+                    (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
+                    in the Amazon Elastic Compute Cloud User Guide.
+
+                    Refer to recommended, security best practices
+                    (https://aws.github.io/aws-eks-best-practices/security/docs/iam/#restrict-access-to-the-instance-profile-assigned-to-the-worker-node)
+                    for limiting exposure of Instance Metadata and User Data to pods.
+                    If omitted, defaults to httpEndpoint enabled, with httpProtocolIPv6
+                    disabled, with httpPutResponseLimit of 1, and with httpTokens
+                    required.
+                  properties:
+                    httpEndpoint:
+                      default: enabled
+                      description: |-
+                        HTTPEndpoint enables or disables the HTTP metadata endpoint on provisioned
+                        nodes. If metadata options is non-nil, but this parameter is not specified,
+                        the default state is "enabled".
+
+                        If you specify a value of "disabled", instance metadata will not be accessible
+                        on the node.
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpProtocolIPv6:
+                      default: disabled
+                      description: |-
+                        HTTPProtocolIPv6 enables or disables the IPv6 endpoint for the instance metadata
+                        service on provisioned nodes. If metadata options is non-nil, but this parameter
+                        is not specified, the default state is "disabled".
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpPutResponseHopLimit:
+                      default: 1
+                      description: |-
+                        HTTPPutResponseHopLimit is the desired HTTP PUT response hop limit for
+                        instance metadata requests. The larger the number, the further instance
+                        metadata requests can travel. Possible values are integers from 1 to 64.
+                        If metadata options is non-nil, but this parameter is not specified, the
+                        default value is 1.
+                      format: int64
+                      maximum: 64
+                      minimum: 1
+                      type: integer
+                    httpTokens:
+                      default: required
+                      description: |-
+                        HTTPTokens determines the state of token usage for instance metadata
+                        requests. If metadata options is non-nil, but this parameter is not
+                        specified, the default state is "required".
+
+                        If the state is optional, one can choose to retrieve instance metadata with
+                        or without a signed token header on the request. If one retrieves the IAM
+                        role credentials without a token, the version 1.0 role credentials are
+                        returned. If one retrieves the IAM role credentials using a valid signed
+                        token, the version 2.0 role credentials are returned.
+
+                        If the state is "required", one must send a signed token header with any
+                        instance metadata retrieval requests. In this state, retrieving the IAM
+                        role credentials always returns the version 2.0 credentials; the version
+                        1.0 credentials are not available.
+                      enum:
+                        - required
+                        - optional
+                      type: string
+                  type: object
+                role:
+                  description: |-
+                    Role is the AWS identity that nodes use. This field is immutable.
+                    This field is mutually exclusive from instanceProfile.
+                    Marking this field as immutable avoids concerns around terminating managed instance profiles from running instances.
+                    This field may be made mutable in the future, assuming the correct garbage collection and drift handling is implemented
+                    for the old instance profiles on an update.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: role cannot be empty
+                      rule: self != ''
+                    - message: immutable field changed
+                      rule: self == oldSelf
+                securityGroupSelectorTerms:
+                  description: SecurityGroupSelectorTerms is a list of or security group selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SecurityGroupSelectorTerm defines selection logic for a security group used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the security group id in EC2
+                        pattern: sg-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the security group name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select security groups.
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: securityGroupSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id', 'name']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && (has(x.tags) || has(x.name)))'
+                    - message: '''name'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.name) && (has(x.tags) || has(x.id)))'
+                subnetSelectorTerms:
+                  description: SubnetSelectorTerms is a list of or subnet selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SubnetSelectorTerm defines selection logic for a subnet used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the subnet id in EC2
+                        pattern: subnet-[0-9a-z]+
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: subnetSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id']
+                      rule: self.all(x, has(x.tags) || has(x.id))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in subnetSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && has(x.tags))'
+                tags:
+                  additionalProperties:
+                    type: string
+                  description: Tags to be applied on ec2 resources like instances and launch templates.
+                  type: object
+                  x-kubernetes-validations:
+                    - message: empty tag keys aren't supported
+                      rule: self.all(k, k != '')
+                    - message: tag contains a restricted tag matching eks:eks-cluster-name
+                      rule: self.all(k, k !='eks:eks-cluster-name')
+                    - message: tag contains a restricted tag matching kubernetes.io/cluster/
+                      rule: self.all(k, !k.startsWith('kubernetes.io/cluster') )
+                    - message: tag contains a restricted tag matching karpenter.sh/nodepool
+                      rule: self.all(k, k != 'karpenter.sh/nodepool')
+                    - message: tag contains a restricted tag matching karpenter.sh/nodeclaim
+                      rule: self.all(k, k !='karpenter.sh/nodeclaim')
+                    - message: tag contains a restricted tag matching karpenter.k8s.aws/ec2nodeclass
+                      rule: self.all(k, k !='karpenter.k8s.aws/ec2nodeclass')
+                userData:
+                  description: |-
+                    UserData to be applied to the provisioned nodes.
+                    It must be in the appropriate format based on the AMIFamily in use. Karpenter will merge certain fields into
+                    this UserData to ensure nodes are being provisioned with the correct configuration.
+                  type: string
+              required:
+                - amiSelectorTerms
+                - securityGroupSelectorTerms
+                - subnetSelectorTerms
+              type: object
+              x-kubernetes-validations:
+                - message: must specify exactly one of ['role', 'instanceProfile']
+                  rule: (has(self.role) && !has(self.instanceProfile)) || (!has(self.role) && has(self.instanceProfile))
+                - message: changing from 'instanceProfile' to 'role' is not supported. You must delete and recreate this node class if you want to change this.
+                  rule: (has(oldSelf.role) && has(self.role)) || (has(oldSelf.instanceProfile) && has(self.instanceProfile))
+                - message: if set, amiFamily must be 'AL2' or 'Custom' when using an AL2 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''al2'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''AL2'') : true)'
+                - message: if set, amiFamily must be 'AL2023' or 'Custom' when using an AL2023 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''al2023'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''AL2023'') : true)'
+                - message: if set, amiFamily must be 'Bottlerocket' or 'Custom' when using a Bottlerocket alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''bottlerocket'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Bottlerocket'') : true)'
+                - message: if set, amiFamily must be 'Windows2019' or 'Custom' when using a Windows2019 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''windows2019'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Windows2019'') : true)'
+                - message: if set, amiFamily must be 'Windows2022' or 'Custom' when using a Windows2022 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''windows2022'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Windows2022'') : true)'
+                - message: must specify amiFamily if amiSelectorTerms does not contain an alias
+                  rule: 'self.amiSelectorTerms.exists(x, has(x.alias)) ? true : has(self.amiFamily)'
+            status:
+              description: EC2NodeClassStatus contains the resolved state of the EC2NodeClass
+              properties:
+                amis:
+                  description: |-
+                    AMI contains the current AMI values that are available to the
+                    cluster under the AMI selectors.
+                  items:
+                    description: AMI contains resolved AMI selector values utilized for node launch
+                    properties:
+                      deprecated:
+                        description: Deprecation status of the AMI
+                        type: boolean
+                      id:
+                        description: ID of the AMI
+                        type: string
+                      name:
+                        description: Name of the AMI
+                        type: string
+                      requirements:
+                        description: Requirements of the AMI to be utilized on an instance type
+                        items:
+                          description: |-
+                            A node selector requirement is a selector that contains values, a key, and an operator
+                            that relates the key and values.
+                          properties:
+                            key:
+                              description: The label key that the selector applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                Represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                              type: string
+                            values:
+                              description: |-
+                                An array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. If the operator is Gt or Lt, the values
+                                array must have a single element, which will be interpreted as an integer.
+                                This array is replaced during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                            - key
+                            - operator
+                          type: object
+                        type: array
+                    required:
+                      - id
+                      - requirements
+                    type: object
+                  type: array
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                instanceProfile:
+                  description: InstanceProfile contains the resolved instance profile for the role
+                  type: string
+                securityGroups:
+                  description: |-
+                    SecurityGroups contains the current security group values that are available to the
+                    cluster under the SecurityGroups selectors.
+                  items:
+                    description: SecurityGroup contains resolved SecurityGroup selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the security group
+                        type: string
+                      name:
+                        description: Name of the security group
+                        type: string
+                    required:
+                      - id
+                    type: object
+                  type: array
+                subnets:
+                  description: |-
+                    Subnets contains the current subnet values that are available to the
+                    cluster under the subnet selectors.
+                  items:
+                    description: Subnet contains resolved Subnet selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the subnet
+                        type: string
+                      zone:
+                        description: The associated availability zone
+                        type: string
+                      zoneID:
+                        description: The associated availability zone ID
+                        type: string
+                    required:
+                      - id
+                      - zone
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/content/projects/karpenter/v1.1.1/karpenter.sh_nodeclaims.yaml
+++ b/content/projects/karpenter/v1.1.1/karpenter.sh_nodeclaims.yaml
@@ -1,0 +1,391 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: nodeclaims.karpenter.sh
+spec:
+  group: karpenter.sh
+  names:
+    categories:
+      - karpenter
+    kind: NodeClaim
+    listKind: NodeClaimList
+    plural: nodeclaims
+    singular: nodeclaim
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.labels.node\.kubernetes\.io/instance-type
+          name: Type
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/capacity-type
+          name: Capacity
+          type: string
+        - jsonPath: .metadata.labels.topology\.kubernetes\.io/zone
+          name: Zone
+          type: string
+        - jsonPath: .status.nodeName
+          name: Node
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .status.providerID
+          name: ID
+          priority: 1
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/nodepool
+          name: NodePool
+          priority: 1
+          type: string
+        - jsonPath: .spec.nodeClassRef.name
+          name: NodeClass
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: NodeClaim is the Schema for the NodeClaims API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: NodeClaimSpec describes the desired state of the NodeClaim
+              properties:
+                expireAfter:
+                  default: 720h
+                  description: |-
+                    ExpireAfter is the duration the controller will wait
+                    before terminating a node, measured from when the node is created. This
+                    is useful to implement features like eventually consistent node upgrade,
+                    memory leak protection, and disruption testing.
+                  pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                  type: string
+                nodeClassRef:
+                  description: NodeClassRef is a reference to an object that defines provider specific configuration
+                  properties:
+                    group:
+                      description: API version of the referent
+                      pattern: ^[^/]*$
+                      type: string
+                      x-kubernetes-validations:
+                        - message: group may not be empty
+                          rule: self != ''
+                    kind:
+                      description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                      type: string
+                      x-kubernetes-validations:
+                        - message: kind may not be empty
+                          rule: self != ''
+                    name:
+                      description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                      type: string
+                      x-kubernetes-validations:
+                        - message: name may not be empty
+                          rule: self != ''
+                  required:
+                    - group
+                    - kind
+                    - name
+                  type: object
+                requirements:
+                  description: Requirements are layered with GetLabels and applied to every node.
+                  items:
+                    description: |-
+                      A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                      and minValues that represent the requirement to have at least that many values.
+                    properties:
+                      key:
+                        description: The label key that the selector applies to.
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                        x-kubernetes-validations:
+                          - message: label domain "kubernetes.io" is restricted
+                            rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                          - message: label domain "k8s.io" is restricted
+                            rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                          - message: label domain "karpenter.sh" is restricted
+                            rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                          - message: label "kubernetes.io/hostname" is restricted
+                            rule: self != "kubernetes.io/hostname"
+                          - message: label domain "karpenter.k8s.aws" is restricted
+                            rule: self in ["karpenter.k8s.aws/ec2nodeclass", "karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu", "karpenter.k8s.aws/instance-cpu-manufacturer", "karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz", "karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                      minValues:
+                        description: |-
+                          This field is ALPHA and can be dropped or replaced at any time
+                          MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                        maximum: 50
+                        minimum: 1
+                        type: integer
+                      operator:
+                        description: |-
+                          Represents a key's relationship to a set of values.
+                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                        type: string
+                        enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          - Gt
+                          - Lt
+                      values:
+                        description: |-
+                          An array of string values. If the operator is In or NotIn,
+                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                          the values array must be empty. If the operator is Gt or Lt, the values
+                          array must have a single element, which will be interpreted as an integer.
+                          This array is replaced during a strategic merge patch.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                        maxLength: 63
+                        pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                    required:
+                      - key
+                      - operator
+                    type: object
+                  maxItems: 100
+                  type: array
+                  x-kubernetes-validations:
+                    - message: requirements with operator 'In' must have a value defined
+                      rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                    - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                      rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                    - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                      rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                resources:
+                  description: Resources models the resource requirements for the NodeClaim to launch
+                  properties:
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: Requests describes the minimum required resources for the NodeClaim to launch
+                      type: object
+                  type: object
+                startupTaints:
+                  description: |-
+                    StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                    within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                    daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                    purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                taints:
+                  description: Taints will be applied to the NodeClaim's node.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                terminationGracePeriod:
+                  description: |-
+                    TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
+
+                    Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
+
+                    This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
+                    When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
+
+                    Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
+                    If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
+                    that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
+
+                    The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
+                    If left undefined, the controller will wait indefinitely for pods to be drained.
+                  pattern: ^([0-9]+(s|m|h))+$
+                  type: string
+              required:
+                - nodeClassRef
+                - requirements
+              type: object
+              x-kubernetes-validations:
+                - message: spec is immutable
+                  rule: self == oldSelf
+            status:
+              description: NodeClaimStatus defines the observed state of NodeClaim
+              properties:
+                allocatable:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Allocatable is the estimated allocatable capacity of the node
+                  type: object
+                capacity:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Capacity is the estimated full capacity of the node
+                  type: object
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        pattern: ^([A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?|)$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - status
+                      - type
+                    type: object
+                  type: array
+                imageID:
+                  description: ImageID is an identifier for the image that runs on the node
+                  type: string
+                lastPodEventTime:
+                  description: |-
+                    LastPodEventTime is updated with the last time a pod was scheduled
+                    or removed from the node. A pod going terminal or terminating
+                    is also considered as removed.
+                  format: date-time
+                  type: string
+                nodeName:
+                  description: NodeName is the name of the corresponding node object
+                  type: string
+                providerID:
+                  description: ProviderID of the corresponding node object
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/content/projects/karpenter/v1.1.1/karpenter.sh_nodepools.yaml
+++ b/content/projects/karpenter/v1.1.1/karpenter.sh_nodepools.yaml
@@ -1,0 +1,519 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: nodepools.karpenter.sh
+spec:
+  group: karpenter.sh
+  names:
+    categories:
+      - karpenter
+    kind: NodePool
+    listKind: NodePoolList
+    plural: nodepools
+    singular: nodepool
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.template.spec.nodeClassRef.name
+          name: NodeClass
+          type: string
+        - jsonPath: .status.resources.nodes
+          name: Nodes
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.weight
+          name: Weight
+          priority: 1
+          type: integer
+        - jsonPath: .status.resources.cpu
+          name: CPU
+          priority: 1
+          type: string
+        - jsonPath: .status.resources.memory
+          name: Memory
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: NodePool is the Schema for the NodePools API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                NodePoolSpec is the top level nodepool specification. Nodepools
+                launch nodes in response to pods that are unschedulable. A single nodepool
+                is capable of managing a diverse set of nodes. Node properties are determined
+                from a combination of nodepool and pod scheduling constraints.
+              properties:
+                disruption:
+                  default:
+                    consolidateAfter: 0s
+                  description: Disruption contains the parameters that relate to Karpenter's disruption logic
+                  properties:
+                    budgets:
+                      default:
+                        - nodes: 10%
+                      description: |-
+                        Budgets is a list of Budgets.
+                        If there are multiple active budgets, Karpenter uses
+                        the most restrictive value. If left undefined,
+                        this will default to one budget with a value to 10%.
+                      items:
+                        description: |-
+                          Budget defines when Karpenter will restrict the
+                          number of Node Claims that can be terminating simultaneously.
+                        properties:
+                          duration:
+                            description: |-
+                              Duration determines how long a Budget is active since each Schedule hit.
+                              Only minutes and hours are accepted, as cron does not work in seconds.
+                              If omitted, the budget is always active.
+                              This is required if Schedule is set.
+                              This regex has an optional 0s at the end since the duration.String() always adds
+                              a 0s at the end.
+                            pattern: ^((([0-9]+(h|m))|([0-9]+h[0-9]+m))(0s)?)$
+                            type: string
+                          nodes:
+                            default: 10%
+                            description: |-
+                              Nodes dictates the maximum number of NodeClaims owned by this NodePool
+                              that can be terminating at once. This is calculated by counting nodes that
+                              have a deletion timestamp set, or are actively being deleted by Karpenter.
+                              This field is required when specifying a budget.
+                              This cannot be of type intstr.IntOrString since kubebuilder doesn't support pattern
+                              checking for int nodes for IntOrString nodes.
+                              Ref: https://github.com/kubernetes-sigs/controller-tools/blob/55efe4be40394a288216dab63156b0a64fb82929/pkg/crd/markers/validation.go#L379-L388
+                            pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
+                            type: string
+                          reasons:
+                            description: |-
+                              Reasons is a list of disruption methods that this budget applies to. If Reasons is not set, this budget applies to all methods.
+                              Otherwise, this will apply to each reason defined.
+                              allowed reasons are Underutilized, Empty, and Drifted.
+                            items:
+                              description: DisruptionReason defines valid reasons for disruption budgets.
+                              enum:
+                                - Underutilized
+                                - Empty
+                                - Drifted
+                              type: string
+                            type: array
+                          schedule:
+                            description: |-
+                              Schedule specifies when a budget begins being active, following
+                              the upstream cronjob syntax. If omitted, the budget is always active.
+                              Timezones are not supported.
+                              This field is required if Duration is set.
+                            pattern: ^(@(annually|yearly|monthly|weekly|daily|midnight|hourly))|((.+)\s(.+)\s(.+)\s(.+)\s(.+))$
+                            type: string
+                        required:
+                          - nodes
+                        type: object
+                      maxItems: 50
+                      type: array
+                      x-kubernetes-validations:
+                        - message: '''schedule'' must be set with ''duration'''
+                          rule: self.all(x, has(x.schedule) == has(x.duration))
+                    consolidateAfter:
+                      description: |-
+                        ConsolidateAfter is the duration the controller will wait
+                        before attempting to terminate nodes that are underutilized.
+                        Refer to ConsolidationPolicy for how underutilization is considered.
+                      pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                      type: string
+                    consolidationPolicy:
+                      default: WhenEmptyOrUnderutilized
+                      description: |-
+                        ConsolidationPolicy describes which nodes Karpenter can disrupt through its consolidation
+                        algorithm. This policy defaults to "WhenEmptyOrUnderutilized" if not specified
+                      enum:
+                        - WhenEmpty
+                        - WhenEmptyOrUnderutilized
+                      type: string
+                  required:
+                    - consolidateAfter
+                  type: object
+                limits:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Limits define a set of bounds for provisioning capacity.
+                  type: object
+                template:
+                  description: |-
+                    Template contains the template of possibilities for the provisioning logic to launch a NodeClaim with.
+                    NodeClaims launched from this NodePool will often be further constrained than the template specifies.
+                  properties:
+                    metadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Annotations is an unstructured key value map stored with a resource that may be
+                            set by external tools to store and retrieve arbitrary metadata. They are not
+                            queryable and should be preserved when modifying objects.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                            maxLength: 63
+                            pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                          description: |-
+                            Map of string keys and values that can be used to organize and categorize
+                            (scope and select) objects. May match selectors of replication controllers
+                            and services.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
+                          type: object
+                          maxProperties: 100
+                          x-kubernetes-validations:
+                            - message: label domain "kubernetes.io" is restricted
+                              rule: self.all(x, x in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region",  "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || x.find("^([^/]+)").endsWith("node.kubernetes.io") || x.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !x.find("^([^/]+)").endsWith("kubernetes.io"))
+                            - message: label domain "k8s.io" is restricted
+                              rule: self.all(x, x.find("^([^/]+)").endsWith("kops.k8s.io") || !x.find("^([^/]+)").endsWith("k8s.io"))
+                            - message: label domain "karpenter.sh" is restricted
+                              rule: self.all(x, x in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !x.find("^([^/]+)").endsWith("karpenter.sh"))
+                            - message: label "karpenter.sh/nodepool" is restricted
+                              rule: self.all(x, x != "karpenter.sh/nodepool")
+                            - message: label "kubernetes.io/hostname" is restricted
+                              rule: self.all(x, x != "kubernetes.io/hostname")
+                            - message: label domain "karpenter.k8s.aws" is restricted
+                              rule: self.all(x, x in ["karpenter.k8s.aws/ec2nodeclass", "karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu", "karpenter.k8s.aws/instance-cpu-manufacturer", "karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz", "karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !x.find("^([^/]+)").endsWith("karpenter.k8s.aws"))
+                      type: object
+                    spec:
+                      description: |-
+                        NodeClaimTemplateSpec describes the desired state of the NodeClaim in the Nodepool
+                        NodeClaimTemplateSpec is used in the NodePool's NodeClaimTemplate, with the resource requests omitted since
+                        users are not able to set resource requests in the NodePool.
+                      properties:
+                        expireAfter:
+                          default: 720h
+                          description: |-
+                            ExpireAfter is the duration the controller will wait
+                            before terminating a node, measured from when the node is created. This
+                            is useful to implement features like eventually consistent node upgrade,
+                            memory leak protection, and disruption testing.
+                          pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                          type: string
+                        nodeClassRef:
+                          description: NodeClassRef is a reference to an object that defines provider specific configuration
+                          properties:
+                            group:
+                              description: API version of the referent
+                              pattern: ^[^/]*$
+                              type: string
+                              x-kubernetes-validations:
+                                - message: group may not be empty
+                                  rule: self != ''
+                            kind:
+                              description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                              type: string
+                              x-kubernetes-validations:
+                                - message: kind may not be empty
+                                  rule: self != ''
+                            name:
+                              description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                              x-kubernetes-validations:
+                                - message: name may not be empty
+                                  rule: self != ''
+                          required:
+                            - group
+                            - kind
+                            - name
+                          type: object
+                          x-kubernetes-validations:
+                            - message: nodeClassRef.group is immutable
+                              rule: self.group == oldSelf.group
+                            - message: nodeClassRef.kind is immutable
+                              rule: self.kind == oldSelf.kind
+                        requirements:
+                          description: Requirements are layered with GetLabels and applied to every node.
+                          items:
+                            description: |-
+                              A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                              and minValues that represent the requirement to have at least that many values.
+                            properties:
+                              key:
+                                description: The label key that the selector applies to.
+                                type: string
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                                x-kubernetes-validations:
+                                  - message: label domain "kubernetes.io" is restricted
+                                    rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                                  - message: label domain "k8s.io" is restricted
+                                    rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                                  - message: label domain "karpenter.sh" is restricted
+                                    rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                                  - message: label "karpenter.sh/nodepool" is restricted
+                                    rule: self != "karpenter.sh/nodepool"
+                                  - message: label "kubernetes.io/hostname" is restricted
+                                    rule: self != "kubernetes.io/hostname"
+                                  - message: label domain "karpenter.k8s.aws" is restricted
+                                    rule: self in ["karpenter.k8s.aws/ec2nodeclass", "karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu", "karpenter.k8s.aws/instance-cpu-manufacturer", "karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz", "karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                              minValues:
+                                description: |-
+                                  This field is ALPHA and can be dropped or replaced at any time
+                                  MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                                maximum: 50
+                                minimum: 1
+                                type: integer
+                              operator:
+                                description: |-
+                                  Represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                type: string
+                                enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  - Gt
+                                  - Lt
+                              values:
+                                description: |-
+                                  An array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                  array must have a single element, which will be interpreted as an integer.
+                                  This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          maxItems: 100
+                          type: array
+                          x-kubernetes-validations:
+                            - message: requirements with operator 'In' must have a value defined
+                              rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                            - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                              rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                            - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                              rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                        startupTaints:
+                          description: |-
+                            StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                            within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                            daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                            purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        taints:
+                          description: Taints will be applied to the NodeClaim's node.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        terminationGracePeriod:
+                          description: |-
+                            TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
+
+                            Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
+
+                            This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
+                            When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
+
+                            Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
+                            If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
+                            that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
+
+                            The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
+                            If left undefined, the controller will wait indefinitely for pods to be drained.
+                          pattern: ^([0-9]+(s|m|h))+$
+                          type: string
+                      required:
+                        - nodeClassRef
+                        - requirements
+                      type: object
+                  required:
+                    - spec
+                  type: object
+                weight:
+                  description: |-
+                    Weight is the priority given to the nodepool during scheduling. A higher
+                    numerical weight indicates that this nodepool will be ordered
+                    ahead of other nodepools with lower weights. A nodepool with no weight
+                    will be treated as if it is a nodepool with a weight of 0.
+                  format: int32
+                  maximum: 100
+                  minimum: 1
+                  type: integer
+              required:
+                - template
+              type: object
+            status:
+              description: NodePoolStatus defines the observed state of NodePool
+              properties:
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                resources:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Resources is the list of resources that have been provisioned.
+                  type: object
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/content/projects/karpenter/v1.1.2/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/content/projects/karpenter/v1.1.2/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -1,0 +1,742 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: ec2nodeclasses.karpenter.k8s.aws
+spec:
+  group: karpenter.k8s.aws
+  names:
+    categories:
+      - karpenter
+    kind: EC2NodeClass
+    listKind: EC2NodeClassList
+    plural: ec2nodeclasses
+    shortNames:
+      - ec2nc
+      - ec2ncs
+    singular: ec2nodeclass
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.role
+          name: Role
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: EC2NodeClass is the Schema for the EC2NodeClass API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                EC2NodeClassSpec is the top level specification for the AWS Karpenter Provider.
+                This will contain configuration necessary to launch instances in AWS.
+              properties:
+                amiFamily:
+                  description: |-
+                    AMIFamily dictates the UserData format and default BlockDeviceMappings used when generating launch templates.
+                    This field is optional when using an alias amiSelectorTerm, and the value will be inferred from the alias'
+                    family. When an alias is specified, this field may only be set to its corresponding family or 'Custom'. If no
+                    alias is specified, this field is required.
+                    NOTE: We ignore the AMIFamily for hashing here because we hash the AMIFamily dynamically by using the alias using
+                    the AMIFamily() helper function
+                  enum:
+                    - AL2
+                    - AL2023
+                    - Bottlerocket
+                    - Custom
+                    - Windows2019
+                    - Windows2022
+                  type: string
+                amiSelectorTerms:
+                  description: AMISelectorTerms is a list of or ami selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      AMISelectorTerm defines selection logic for an ami used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      alias:
+                        description: |-
+                          Alias specifies which EKS optimized AMI to select.
+                          Each alias consists of a family and an AMI version, specified as "family@version".
+                          Valid families include: al2, al2023, bottlerocket, windows2019, and windows2022.
+                          The version can either be pinned to a specific AMI release, with that AMIs version format (ex: "al2023@v20240625" or "bottlerocket@v1.10.0").
+                          The version can also be set to "latest" for any family. Setting the version to latest will result in drift when a new AMI is released. This is **not** recommended for production environments.
+                          Note: The Windows families do **not** support version pinning, and only latest may be used.
+                        maxLength: 30
+                        type: string
+                        x-kubernetes-validations:
+                          - message: '''alias'' is improperly formatted, must match the format ''family@version'''
+                            rule: self.matches('^[a-zA-Z0-9]+@.+$')
+                          - message: 'family is not supported, must be one of the following: ''al2'', ''al2023'', ''bottlerocket'', ''windows2019'', ''windows2022'''
+                            rule: self.split('@')[0] in ['al2','al2023','bottlerocket','windows2019','windows2022']
+                          - message: windows families may only specify version 'latest'
+                            rule: 'self.split(''@'')[0] in [''windows2019'',''windows2022''] ? self.split(''@'')[1] == ''latest'' : true'
+                      id:
+                        description: ID is the ami id in EC2
+                        pattern: ami-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the ami name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      owner:
+                        description: |-
+                          Owner is the owner for the ami.
+                          You can specify a combination of AWS account IDs, "self", "amazon", and "aws-marketplace"
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select amis.
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  minItems: 1
+                  type: array
+                  x-kubernetes-validations:
+                    - message: expected at least one, got none, ['tags', 'id', 'name', 'alias']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name) || has(x.alias))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.exists(x, has(x.id) && (has(x.alias) || has(x.tags) || has(x.name) || has(x.owner)))'
+                    - message: '''alias'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.exists(x, has(x.alias) && (has(x.id) || has(x.tags) || has(x.name) || has(x.owner)))'
+                    - message: '''alias'' is mutually exclusive, cannot be set with a combination of other amiSelectorTerms'
+                      rule: '!(self.exists(x, has(x.alias)) && self.size() != 1)'
+                associatePublicIPAddress:
+                  description: AssociatePublicIPAddress controls if public IP addresses are assigned to instances that are launched with the nodeclass.
+                  type: boolean
+                blockDeviceMappings:
+                  description: BlockDeviceMappings to be applied to provisioned nodes.
+                  items:
+                    properties:
+                      deviceName:
+                        description: The device name (for example, /dev/sdh or xvdh).
+                        type: string
+                      ebs:
+                        description: EBS contains parameters used to automatically set up EBS volumes when an instance is launched.
+                        properties:
+                          deleteOnTermination:
+                            description: DeleteOnTermination indicates whether the EBS volume is deleted on instance termination.
+                            type: boolean
+                          encrypted:
+                            description: |-
+                              Encrypted indicates whether the EBS volume is encrypted. Encrypted volumes can only
+                              be attached to instances that support Amazon EBS encryption. If you are creating
+                              a volume from a snapshot, you can't specify an encryption value.
+                            type: boolean
+                          iops:
+                            description: |-
+                              IOPS is the number of I/O operations per second (IOPS). For gp3, io1, and io2 volumes,
+                              this represents the number of IOPS that are provisioned for the volume. For
+                              gp2 volumes, this represents the baseline performance of the volume and the
+                              rate at which the volume accumulates I/O credits for bursting.
+
+                              The following are the supported values for each volume type:
+
+                                 * gp3: 3,000-16,000 IOPS
+
+                                 * io1: 100-64,000 IOPS
+
+                                 * io2: 100-64,000 IOPS
+
+                              For io1 and io2 volumes, we guarantee 64,000 IOPS only for Instances built
+                              on the Nitro System (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances).
+                              Other instance families guarantee performance up to 32,000 IOPS.
+
+                              This parameter is supported for io1, io2, and gp3 volumes only. This parameter
+                              is not supported for gp2, st1, sc1, or standard volumes.
+                            format: int64
+                            type: integer
+                          kmsKeyID:
+                            description: KMSKeyID (ARN) of the symmetric Key Management Service (KMS) CMK used for encryption.
+                            type: string
+                          snapshotID:
+                            description: SnapshotID is the ID of an EBS snapshot
+                            type: string
+                          throughput:
+                            description: |-
+                              Throughput to provision for a gp3 volume, with a maximum of 1,000 MiB/s.
+                              Valid Range: Minimum value of 125. Maximum value of 1000.
+                            format: int64
+                            type: integer
+                          volumeSize:
+                            description: |-
+                              VolumeSize in `Gi`, `G`, `Ti`, or `T`. You must specify either a snapshot ID or
+                              a volume size. The following are the supported volumes sizes for each volume
+                              type:
+
+                                 * gp2 and gp3: 1-16,384
+
+                                 * io1 and io2: 4-16,384
+
+                                 * st1 and sc1: 125-16,384
+
+                                 * standard: 1-1,024
+                            pattern: ^((?:[1-9][0-9]{0,3}|[1-4][0-9]{4}|[5][0-8][0-9]{3}|59000)Gi|(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|[6][0-3][0-9]{3}|64000)G|([1-9]||[1-5][0-7]|58)Ti|([1-9]||[1-5][0-9]|6[0-3]|64)T)$
+                            type: string
+                          volumeType:
+                            description: |-
+                              VolumeType of the block device.
+                              For more information, see Amazon EBS volume types (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html)
+                              in the Amazon Elastic Compute Cloud User Guide.
+                            enum:
+                              - standard
+                              - io1
+                              - io2
+                              - gp2
+                              - sc1
+                              - st1
+                              - gp3
+                            type: string
+                        type: object
+                        x-kubernetes-validations:
+                          - message: snapshotID or volumeSize must be defined
+                            rule: has(self.snapshotID) || has(self.volumeSize)
+                      rootVolume:
+                        description: |-
+                          RootVolume is a flag indicating if this device is mounted as kubelet root dir. You can
+                          configure at most one root volume in BlockDeviceMappings.
+                        type: boolean
+                    type: object
+                  maxItems: 50
+                  type: array
+                  x-kubernetes-validations:
+                    - message: must have only one blockDeviceMappings with rootVolume
+                      rule: self.filter(x, has(x.rootVolume)?x.rootVolume==true:false).size() <= 1
+                context:
+                  description: |-
+                    Context is a Reserved field in EC2 APIs
+                    https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet.html
+                  type: string
+                detailedMonitoring:
+                  description: DetailedMonitoring controls if detailed monitoring is enabled for instances that are launched
+                  type: boolean
+                instanceProfile:
+                  description: |-
+                    InstanceProfile is the AWS entity that instances use.
+                    This field is mutually exclusive from role.
+                    The instance profile should already have a role assigned to it that Karpenter
+                     has PassRole permission on for instance launch using this instanceProfile to succeed.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: instanceProfile cannot be empty
+                      rule: self != ''
+                instanceStorePolicy:
+                  description: InstanceStorePolicy specifies how to handle instance-store disks.
+                  enum:
+                    - RAID0
+                  type: string
+                kubelet:
+                  description: |-
+                    Kubelet defines args to be used when configuring kubelet on provisioned nodes.
+                    They are a subset of the upstream types, recognizing not all options may be supported.
+                    Wherever possible, the types and names should reflect the upstream kubelet types.
+                  properties:
+                    clusterDNS:
+                      description: |-
+                        clusterDNS is a list of IP addresses for the cluster DNS server.
+                        Note that not all providers may use all addresses.
+                      items:
+                        type: string
+                      type: array
+                    cpuCFSQuota:
+                      description: CPUCFSQuota enables CPU CFS quota enforcement for containers that specify CPU limits.
+                      type: boolean
+                    evictionHard:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionHard is the map of signal names to quantities that define hard eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionHard are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionMaxPodGracePeriod:
+                      description: |-
+                        EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in
+                        response to soft eviction thresholds being met.
+                      format: int32
+                      type: integer
+                    evictionSoft:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionSoft is the map of signal names to quantities that define soft eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoft are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionSoftGracePeriod:
+                      additionalProperties:
+                        type: string
+                      description: EvictionSoftGracePeriod is the map of signal names to quantities that define grace periods for each eviction signal
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoftGracePeriod are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    imageGCHighThresholdPercent:
+                      description: |-
+                        ImageGCHighThresholdPercent is the percent of disk usage after which image
+                        garbage collection is always run. The percent is calculated by dividing this
+                        field value by 100, so this field must be between 0 and 100, inclusive.
+                        When specified, the value must be greater than ImageGCLowThresholdPercent.
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    imageGCLowThresholdPercent:
+                      description: |-
+                        ImageGCLowThresholdPercent is the percent of disk usage before which image
+                        garbage collection is never run. Lowest disk usage to garbage collect to.
+                        The percent is calculated by dividing this field value by 100,
+                        so the field value must be between 0 and 100, inclusive.
+                        When specified, the value must be less than imageGCHighThresholdPercent
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    kubeReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: KubeReserved contains resources reserved for Kubernetes system components.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for kubeReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: kubeReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                    maxPods:
+                      description: |-
+                        MaxPods is an override for the maximum number of pods that can run on
+                        a worker node instance.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    podsPerCore:
+                      description: |-
+                        PodsPerCore is an override for the number of pods that can run on a worker node
+                        instance based on the number of cpu cores. This value cannot exceed MaxPods, so, if
+                        MaxPods is a lower value, that value will be used.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    systemReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: SystemReserved contains resources reserved for OS system daemons and kernel memory.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for systemReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: systemReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                  type: object
+                  x-kubernetes-validations:
+                    - message: imageGCHighThresholdPercent must be greater than imageGCLowThresholdPercent
+                      rule: 'has(self.imageGCHighThresholdPercent) && has(self.imageGCLowThresholdPercent) ?  self.imageGCHighThresholdPercent > self.imageGCLowThresholdPercent  : true'
+                    - message: evictionSoft OwnerKey does not have a matching evictionSoftGracePeriod
+                      rule: has(self.evictionSoft) ? self.evictionSoft.all(e, (e in self.evictionSoftGracePeriod)):true
+                    - message: evictionSoftGracePeriod OwnerKey does not have a matching evictionSoft
+                      rule: has(self.evictionSoftGracePeriod) ? self.evictionSoftGracePeriod.all(e, (e in self.evictionSoft)):true
+                metadataOptions:
+                  default:
+                    httpEndpoint: enabled
+                    httpProtocolIPv6: disabled
+                    httpPutResponseHopLimit: 1
+                    httpTokens: required
+                  description: |-
+                    MetadataOptions for the generated launch template of provisioned nodes.
+
+                    This specifies the exposure of the Instance Metadata Service to
+                    provisioned EC2 nodes. For more information,
+                    see Instance Metadata and User Data
+                    (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
+                    in the Amazon Elastic Compute Cloud User Guide.
+
+                    Refer to recommended, security best practices
+                    (https://aws.github.io/aws-eks-best-practices/security/docs/iam/#restrict-access-to-the-instance-profile-assigned-to-the-worker-node)
+                    for limiting exposure of Instance Metadata and User Data to pods.
+                    If omitted, defaults to httpEndpoint enabled, with httpProtocolIPv6
+                    disabled, with httpPutResponseLimit of 1, and with httpTokens
+                    required.
+                  properties:
+                    httpEndpoint:
+                      default: enabled
+                      description: |-
+                        HTTPEndpoint enables or disables the HTTP metadata endpoint on provisioned
+                        nodes. If metadata options is non-nil, but this parameter is not specified,
+                        the default state is "enabled".
+
+                        If you specify a value of "disabled", instance metadata will not be accessible
+                        on the node.
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpProtocolIPv6:
+                      default: disabled
+                      description: |-
+                        HTTPProtocolIPv6 enables or disables the IPv6 endpoint for the instance metadata
+                        service on provisioned nodes. If metadata options is non-nil, but this parameter
+                        is not specified, the default state is "disabled".
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpPutResponseHopLimit:
+                      default: 1
+                      description: |-
+                        HTTPPutResponseHopLimit is the desired HTTP PUT response hop limit for
+                        instance metadata requests. The larger the number, the further instance
+                        metadata requests can travel. Possible values are integers from 1 to 64.
+                        If metadata options is non-nil, but this parameter is not specified, the
+                        default value is 1.
+                      format: int64
+                      maximum: 64
+                      minimum: 1
+                      type: integer
+                    httpTokens:
+                      default: required
+                      description: |-
+                        HTTPTokens determines the state of token usage for instance metadata
+                        requests. If metadata options is non-nil, but this parameter is not
+                        specified, the default state is "required".
+
+                        If the state is optional, one can choose to retrieve instance metadata with
+                        or without a signed token header on the request. If one retrieves the IAM
+                        role credentials without a token, the version 1.0 role credentials are
+                        returned. If one retrieves the IAM role credentials using a valid signed
+                        token, the version 2.0 role credentials are returned.
+
+                        If the state is "required", one must send a signed token header with any
+                        instance metadata retrieval requests. In this state, retrieving the IAM
+                        role credentials always returns the version 2.0 credentials; the version
+                        1.0 credentials are not available.
+                      enum:
+                        - required
+                        - optional
+                      type: string
+                  type: object
+                role:
+                  description: |-
+                    Role is the AWS identity that nodes use. This field is immutable.
+                    This field is mutually exclusive from instanceProfile.
+                    Marking this field as immutable avoids concerns around terminating managed instance profiles from running instances.
+                    This field may be made mutable in the future, assuming the correct garbage collection and drift handling is implemented
+                    for the old instance profiles on an update.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: role cannot be empty
+                      rule: self != ''
+                    - message: immutable field changed
+                      rule: self == oldSelf
+                securityGroupSelectorTerms:
+                  description: SecurityGroupSelectorTerms is a list of or security group selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SecurityGroupSelectorTerm defines selection logic for a security group used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the security group id in EC2
+                        pattern: sg-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the security group name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select security groups.
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: securityGroupSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id', 'name']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && (has(x.tags) || has(x.name)))'
+                    - message: '''name'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.name) && (has(x.tags) || has(x.id)))'
+                subnetSelectorTerms:
+                  description: SubnetSelectorTerms is a list of or subnet selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SubnetSelectorTerm defines selection logic for a subnet used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the subnet id in EC2
+                        pattern: subnet-[0-9a-z]+
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: subnetSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id']
+                      rule: self.all(x, has(x.tags) || has(x.id))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in subnetSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && has(x.tags))'
+                tags:
+                  additionalProperties:
+                    type: string
+                  description: Tags to be applied on ec2 resources like instances and launch templates.
+                  type: object
+                  x-kubernetes-validations:
+                    - message: empty tag keys aren't supported
+                      rule: self.all(k, k != '')
+                    - message: tag contains a restricted tag matching eks:eks-cluster-name
+                      rule: self.all(k, k !='eks:eks-cluster-name')
+                    - message: tag contains a restricted tag matching kubernetes.io/cluster/
+                      rule: self.all(k, !k.startsWith('kubernetes.io/cluster') )
+                    - message: tag contains a restricted tag matching karpenter.sh/nodepool
+                      rule: self.all(k, k != 'karpenter.sh/nodepool')
+                    - message: tag contains a restricted tag matching karpenter.sh/nodeclaim
+                      rule: self.all(k, k !='karpenter.sh/nodeclaim')
+                    - message: tag contains a restricted tag matching karpenter.k8s.aws/ec2nodeclass
+                      rule: self.all(k, k !='karpenter.k8s.aws/ec2nodeclass')
+                userData:
+                  description: |-
+                    UserData to be applied to the provisioned nodes.
+                    It must be in the appropriate format based on the AMIFamily in use. Karpenter will merge certain fields into
+                    this UserData to ensure nodes are being provisioned with the correct configuration.
+                  type: string
+              required:
+                - amiSelectorTerms
+                - securityGroupSelectorTerms
+                - subnetSelectorTerms
+              type: object
+              x-kubernetes-validations:
+                - message: must specify exactly one of ['role', 'instanceProfile']
+                  rule: (has(self.role) && !has(self.instanceProfile)) || (!has(self.role) && has(self.instanceProfile))
+                - message: changing from 'instanceProfile' to 'role' is not supported. You must delete and recreate this node class if you want to change this.
+                  rule: (has(oldSelf.role) && has(self.role)) || (has(oldSelf.instanceProfile) && has(self.instanceProfile))
+                - message: if set, amiFamily must be 'AL2' or 'Custom' when using an AL2 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''al2'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''AL2'') : true)'
+                - message: if set, amiFamily must be 'AL2023' or 'Custom' when using an AL2023 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''al2023'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''AL2023'') : true)'
+                - message: if set, amiFamily must be 'Bottlerocket' or 'Custom' when using a Bottlerocket alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''bottlerocket'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Bottlerocket'') : true)'
+                - message: if set, amiFamily must be 'Windows2019' or 'Custom' when using a Windows2019 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''windows2019'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Windows2019'') : true)'
+                - message: if set, amiFamily must be 'Windows2022' or 'Custom' when using a Windows2022 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''windows2022'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Windows2022'') : true)'
+                - message: must specify amiFamily if amiSelectorTerms does not contain an alias
+                  rule: 'self.amiSelectorTerms.exists(x, has(x.alias)) ? true : has(self.amiFamily)'
+            status:
+              description: EC2NodeClassStatus contains the resolved state of the EC2NodeClass
+              properties:
+                amis:
+                  description: |-
+                    AMI contains the current AMI values that are available to the
+                    cluster under the AMI selectors.
+                  items:
+                    description: AMI contains resolved AMI selector values utilized for node launch
+                    properties:
+                      deprecated:
+                        description: Deprecation status of the AMI
+                        type: boolean
+                      id:
+                        description: ID of the AMI
+                        type: string
+                      name:
+                        description: Name of the AMI
+                        type: string
+                      requirements:
+                        description: Requirements of the AMI to be utilized on an instance type
+                        items:
+                          description: |-
+                            A node selector requirement is a selector that contains values, a key, and an operator
+                            that relates the key and values.
+                          properties:
+                            key:
+                              description: The label key that the selector applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                Represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                              type: string
+                            values:
+                              description: |-
+                                An array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. If the operator is Gt or Lt, the values
+                                array must have a single element, which will be interpreted as an integer.
+                                This array is replaced during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                            - key
+                            - operator
+                          type: object
+                        type: array
+                    required:
+                      - id
+                      - requirements
+                    type: object
+                  type: array
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                instanceProfile:
+                  description: InstanceProfile contains the resolved instance profile for the role
+                  type: string
+                securityGroups:
+                  description: |-
+                    SecurityGroups contains the current security group values that are available to the
+                    cluster under the SecurityGroups selectors.
+                  items:
+                    description: SecurityGroup contains resolved SecurityGroup selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the security group
+                        type: string
+                      name:
+                        description: Name of the security group
+                        type: string
+                    required:
+                      - id
+                    type: object
+                  type: array
+                subnets:
+                  description: |-
+                    Subnets contains the current subnet values that are available to the
+                    cluster under the subnet selectors.
+                  items:
+                    description: Subnet contains resolved Subnet selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the subnet
+                        type: string
+                      zone:
+                        description: The associated availability zone
+                        type: string
+                      zoneID:
+                        description: The associated availability zone ID
+                        type: string
+                    required:
+                      - id
+                      - zone
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/content/projects/karpenter/v1.1.2/karpenter.sh_nodeclaims.yaml
+++ b/content/projects/karpenter/v1.1.2/karpenter.sh_nodeclaims.yaml
@@ -1,0 +1,391 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: nodeclaims.karpenter.sh
+spec:
+  group: karpenter.sh
+  names:
+    categories:
+      - karpenter
+    kind: NodeClaim
+    listKind: NodeClaimList
+    plural: nodeclaims
+    singular: nodeclaim
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.labels.node\.kubernetes\.io/instance-type
+          name: Type
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/capacity-type
+          name: Capacity
+          type: string
+        - jsonPath: .metadata.labels.topology\.kubernetes\.io/zone
+          name: Zone
+          type: string
+        - jsonPath: .status.nodeName
+          name: Node
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .status.providerID
+          name: ID
+          priority: 1
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/nodepool
+          name: NodePool
+          priority: 1
+          type: string
+        - jsonPath: .spec.nodeClassRef.name
+          name: NodeClass
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: NodeClaim is the Schema for the NodeClaims API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: NodeClaimSpec describes the desired state of the NodeClaim
+              properties:
+                expireAfter:
+                  default: 720h
+                  description: |-
+                    ExpireAfter is the duration the controller will wait
+                    before terminating a node, measured from when the node is created. This
+                    is useful to implement features like eventually consistent node upgrade,
+                    memory leak protection, and disruption testing.
+                  pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                  type: string
+                nodeClassRef:
+                  description: NodeClassRef is a reference to an object that defines provider specific configuration
+                  properties:
+                    group:
+                      description: API version of the referent
+                      pattern: ^[^/]*$
+                      type: string
+                      x-kubernetes-validations:
+                        - message: group may not be empty
+                          rule: self != ''
+                    kind:
+                      description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                      type: string
+                      x-kubernetes-validations:
+                        - message: kind may not be empty
+                          rule: self != ''
+                    name:
+                      description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                      type: string
+                      x-kubernetes-validations:
+                        - message: name may not be empty
+                          rule: self != ''
+                  required:
+                    - group
+                    - kind
+                    - name
+                  type: object
+                requirements:
+                  description: Requirements are layered with GetLabels and applied to every node.
+                  items:
+                    description: |-
+                      A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                      and minValues that represent the requirement to have at least that many values.
+                    properties:
+                      key:
+                        description: The label key that the selector applies to.
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                        x-kubernetes-validations:
+                          - message: label domain "kubernetes.io" is restricted
+                            rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                          - message: label domain "k8s.io" is restricted
+                            rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                          - message: label domain "karpenter.sh" is restricted
+                            rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                          - message: label "kubernetes.io/hostname" is restricted
+                            rule: self != "kubernetes.io/hostname"
+                          - message: label domain "karpenter.k8s.aws" is restricted
+                            rule: self in ["karpenter.k8s.aws/ec2nodeclass", "karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu", "karpenter.k8s.aws/instance-cpu-manufacturer", "karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz", "karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                      minValues:
+                        description: |-
+                          This field is ALPHA and can be dropped or replaced at any time
+                          MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                        maximum: 50
+                        minimum: 1
+                        type: integer
+                      operator:
+                        description: |-
+                          Represents a key's relationship to a set of values.
+                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                        type: string
+                        enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          - Gt
+                          - Lt
+                      values:
+                        description: |-
+                          An array of string values. If the operator is In or NotIn,
+                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                          the values array must be empty. If the operator is Gt or Lt, the values
+                          array must have a single element, which will be interpreted as an integer.
+                          This array is replaced during a strategic merge patch.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                        maxLength: 63
+                        pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                    required:
+                      - key
+                      - operator
+                    type: object
+                  maxItems: 100
+                  type: array
+                  x-kubernetes-validations:
+                    - message: requirements with operator 'In' must have a value defined
+                      rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                    - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                      rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                    - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                      rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                resources:
+                  description: Resources models the resource requirements for the NodeClaim to launch
+                  properties:
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: Requests describes the minimum required resources for the NodeClaim to launch
+                      type: object
+                  type: object
+                startupTaints:
+                  description: |-
+                    StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                    within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                    daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                    purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                taints:
+                  description: Taints will be applied to the NodeClaim's node.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                terminationGracePeriod:
+                  description: |-
+                    TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
+
+                    Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
+
+                    This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
+                    When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
+
+                    Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
+                    If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
+                    that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
+
+                    The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
+                    If left undefined, the controller will wait indefinitely for pods to be drained.
+                  pattern: ^([0-9]+(s|m|h))+$
+                  type: string
+              required:
+                - nodeClassRef
+                - requirements
+              type: object
+              x-kubernetes-validations:
+                - message: spec is immutable
+                  rule: self == oldSelf
+            status:
+              description: NodeClaimStatus defines the observed state of NodeClaim
+              properties:
+                allocatable:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Allocatable is the estimated allocatable capacity of the node
+                  type: object
+                capacity:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Capacity is the estimated full capacity of the node
+                  type: object
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        pattern: ^([A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?|)$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - status
+                      - type
+                    type: object
+                  type: array
+                imageID:
+                  description: ImageID is an identifier for the image that runs on the node
+                  type: string
+                lastPodEventTime:
+                  description: |-
+                    LastPodEventTime is updated with the last time a pod was scheduled
+                    or removed from the node. A pod going terminal or terminating
+                    is also considered as removed.
+                  format: date-time
+                  type: string
+                nodeName:
+                  description: NodeName is the name of the corresponding node object
+                  type: string
+                providerID:
+                  description: ProviderID of the corresponding node object
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/content/projects/karpenter/v1.1.2/karpenter.sh_nodepools.yaml
+++ b/content/projects/karpenter/v1.1.2/karpenter.sh_nodepools.yaml
@@ -1,0 +1,519 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: nodepools.karpenter.sh
+spec:
+  group: karpenter.sh
+  names:
+    categories:
+      - karpenter
+    kind: NodePool
+    listKind: NodePoolList
+    plural: nodepools
+    singular: nodepool
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.template.spec.nodeClassRef.name
+          name: NodeClass
+          type: string
+        - jsonPath: .status.resources.nodes
+          name: Nodes
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.weight
+          name: Weight
+          priority: 1
+          type: integer
+        - jsonPath: .status.resources.cpu
+          name: CPU
+          priority: 1
+          type: string
+        - jsonPath: .status.resources.memory
+          name: Memory
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: NodePool is the Schema for the NodePools API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                NodePoolSpec is the top level nodepool specification. Nodepools
+                launch nodes in response to pods that are unschedulable. A single nodepool
+                is capable of managing a diverse set of nodes. Node properties are determined
+                from a combination of nodepool and pod scheduling constraints.
+              properties:
+                disruption:
+                  default:
+                    consolidateAfter: 0s
+                  description: Disruption contains the parameters that relate to Karpenter's disruption logic
+                  properties:
+                    budgets:
+                      default:
+                        - nodes: 10%
+                      description: |-
+                        Budgets is a list of Budgets.
+                        If there are multiple active budgets, Karpenter uses
+                        the most restrictive value. If left undefined,
+                        this will default to one budget with a value to 10%.
+                      items:
+                        description: |-
+                          Budget defines when Karpenter will restrict the
+                          number of Node Claims that can be terminating simultaneously.
+                        properties:
+                          duration:
+                            description: |-
+                              Duration determines how long a Budget is active since each Schedule hit.
+                              Only minutes and hours are accepted, as cron does not work in seconds.
+                              If omitted, the budget is always active.
+                              This is required if Schedule is set.
+                              This regex has an optional 0s at the end since the duration.String() always adds
+                              a 0s at the end.
+                            pattern: ^((([0-9]+(h|m))|([0-9]+h[0-9]+m))(0s)?)$
+                            type: string
+                          nodes:
+                            default: 10%
+                            description: |-
+                              Nodes dictates the maximum number of NodeClaims owned by this NodePool
+                              that can be terminating at once. This is calculated by counting nodes that
+                              have a deletion timestamp set, or are actively being deleted by Karpenter.
+                              This field is required when specifying a budget.
+                              This cannot be of type intstr.IntOrString since kubebuilder doesn't support pattern
+                              checking for int nodes for IntOrString nodes.
+                              Ref: https://github.com/kubernetes-sigs/controller-tools/blob/55efe4be40394a288216dab63156b0a64fb82929/pkg/crd/markers/validation.go#L379-L388
+                            pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
+                            type: string
+                          reasons:
+                            description: |-
+                              Reasons is a list of disruption methods that this budget applies to. If Reasons is not set, this budget applies to all methods.
+                              Otherwise, this will apply to each reason defined.
+                              allowed reasons are Underutilized, Empty, and Drifted.
+                            items:
+                              description: DisruptionReason defines valid reasons for disruption budgets.
+                              enum:
+                                - Underutilized
+                                - Empty
+                                - Drifted
+                              type: string
+                            type: array
+                          schedule:
+                            description: |-
+                              Schedule specifies when a budget begins being active, following
+                              the upstream cronjob syntax. If omitted, the budget is always active.
+                              Timezones are not supported.
+                              This field is required if Duration is set.
+                            pattern: ^(@(annually|yearly|monthly|weekly|daily|midnight|hourly))|((.+)\s(.+)\s(.+)\s(.+)\s(.+))$
+                            type: string
+                        required:
+                          - nodes
+                        type: object
+                      maxItems: 50
+                      type: array
+                      x-kubernetes-validations:
+                        - message: '''schedule'' must be set with ''duration'''
+                          rule: self.all(x, has(x.schedule) == has(x.duration))
+                    consolidateAfter:
+                      description: |-
+                        ConsolidateAfter is the duration the controller will wait
+                        before attempting to terminate nodes that are underutilized.
+                        Refer to ConsolidationPolicy for how underutilization is considered.
+                      pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                      type: string
+                    consolidationPolicy:
+                      default: WhenEmptyOrUnderutilized
+                      description: |-
+                        ConsolidationPolicy describes which nodes Karpenter can disrupt through its consolidation
+                        algorithm. This policy defaults to "WhenEmptyOrUnderutilized" if not specified
+                      enum:
+                        - WhenEmpty
+                        - WhenEmptyOrUnderutilized
+                      type: string
+                  required:
+                    - consolidateAfter
+                  type: object
+                limits:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Limits define a set of bounds for provisioning capacity.
+                  type: object
+                template:
+                  description: |-
+                    Template contains the template of possibilities for the provisioning logic to launch a NodeClaim with.
+                    NodeClaims launched from this NodePool will often be further constrained than the template specifies.
+                  properties:
+                    metadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Annotations is an unstructured key value map stored with a resource that may be
+                            set by external tools to store and retrieve arbitrary metadata. They are not
+                            queryable and should be preserved when modifying objects.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                            maxLength: 63
+                            pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                          description: |-
+                            Map of string keys and values that can be used to organize and categorize
+                            (scope and select) objects. May match selectors of replication controllers
+                            and services.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
+                          type: object
+                          maxProperties: 100
+                          x-kubernetes-validations:
+                            - message: label domain "kubernetes.io" is restricted
+                              rule: self.all(x, x in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region",  "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || x.find("^([^/]+)").endsWith("node.kubernetes.io") || x.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !x.find("^([^/]+)").endsWith("kubernetes.io"))
+                            - message: label domain "k8s.io" is restricted
+                              rule: self.all(x, x.find("^([^/]+)").endsWith("kops.k8s.io") || !x.find("^([^/]+)").endsWith("k8s.io"))
+                            - message: label domain "karpenter.sh" is restricted
+                              rule: self.all(x, x in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !x.find("^([^/]+)").endsWith("karpenter.sh"))
+                            - message: label "karpenter.sh/nodepool" is restricted
+                              rule: self.all(x, x != "karpenter.sh/nodepool")
+                            - message: label "kubernetes.io/hostname" is restricted
+                              rule: self.all(x, x != "kubernetes.io/hostname")
+                            - message: label domain "karpenter.k8s.aws" is restricted
+                              rule: self.all(x, x in ["karpenter.k8s.aws/ec2nodeclass", "karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu", "karpenter.k8s.aws/instance-cpu-manufacturer", "karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz", "karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !x.find("^([^/]+)").endsWith("karpenter.k8s.aws"))
+                      type: object
+                    spec:
+                      description: |-
+                        NodeClaimTemplateSpec describes the desired state of the NodeClaim in the Nodepool
+                        NodeClaimTemplateSpec is used in the NodePool's NodeClaimTemplate, with the resource requests omitted since
+                        users are not able to set resource requests in the NodePool.
+                      properties:
+                        expireAfter:
+                          default: 720h
+                          description: |-
+                            ExpireAfter is the duration the controller will wait
+                            before terminating a node, measured from when the node is created. This
+                            is useful to implement features like eventually consistent node upgrade,
+                            memory leak protection, and disruption testing.
+                          pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                          type: string
+                        nodeClassRef:
+                          description: NodeClassRef is a reference to an object that defines provider specific configuration
+                          properties:
+                            group:
+                              description: API version of the referent
+                              pattern: ^[^/]*$
+                              type: string
+                              x-kubernetes-validations:
+                                - message: group may not be empty
+                                  rule: self != ''
+                            kind:
+                              description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                              type: string
+                              x-kubernetes-validations:
+                                - message: kind may not be empty
+                                  rule: self != ''
+                            name:
+                              description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                              x-kubernetes-validations:
+                                - message: name may not be empty
+                                  rule: self != ''
+                          required:
+                            - group
+                            - kind
+                            - name
+                          type: object
+                          x-kubernetes-validations:
+                            - message: nodeClassRef.group is immutable
+                              rule: self.group == oldSelf.group
+                            - message: nodeClassRef.kind is immutable
+                              rule: self.kind == oldSelf.kind
+                        requirements:
+                          description: Requirements are layered with GetLabels and applied to every node.
+                          items:
+                            description: |-
+                              A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                              and minValues that represent the requirement to have at least that many values.
+                            properties:
+                              key:
+                                description: The label key that the selector applies to.
+                                type: string
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                                x-kubernetes-validations:
+                                  - message: label domain "kubernetes.io" is restricted
+                                    rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                                  - message: label domain "k8s.io" is restricted
+                                    rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                                  - message: label domain "karpenter.sh" is restricted
+                                    rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                                  - message: label "karpenter.sh/nodepool" is restricted
+                                    rule: self != "karpenter.sh/nodepool"
+                                  - message: label "kubernetes.io/hostname" is restricted
+                                    rule: self != "kubernetes.io/hostname"
+                                  - message: label domain "karpenter.k8s.aws" is restricted
+                                    rule: self in ["karpenter.k8s.aws/ec2nodeclass", "karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu", "karpenter.k8s.aws/instance-cpu-manufacturer", "karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz", "karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                              minValues:
+                                description: |-
+                                  This field is ALPHA and can be dropped or replaced at any time
+                                  MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                                maximum: 50
+                                minimum: 1
+                                type: integer
+                              operator:
+                                description: |-
+                                  Represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                type: string
+                                enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  - Gt
+                                  - Lt
+                              values:
+                                description: |-
+                                  An array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                  array must have a single element, which will be interpreted as an integer.
+                                  This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          maxItems: 100
+                          type: array
+                          x-kubernetes-validations:
+                            - message: requirements with operator 'In' must have a value defined
+                              rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                            - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                              rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                            - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                              rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                        startupTaints:
+                          description: |-
+                            StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                            within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                            daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                            purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        taints:
+                          description: Taints will be applied to the NodeClaim's node.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        terminationGracePeriod:
+                          description: |-
+                            TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
+
+                            Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
+
+                            This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
+                            When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
+
+                            Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
+                            If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
+                            that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
+
+                            The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
+                            If left undefined, the controller will wait indefinitely for pods to be drained.
+                          pattern: ^([0-9]+(s|m|h))+$
+                          type: string
+                      required:
+                        - nodeClassRef
+                        - requirements
+                      type: object
+                  required:
+                    - spec
+                  type: object
+                weight:
+                  description: |-
+                    Weight is the priority given to the nodepool during scheduling. A higher
+                    numerical weight indicates that this nodepool will be ordered
+                    ahead of other nodepools with lower weights. A nodepool with no weight
+                    will be treated as if it is a nodepool with a weight of 0.
+                  format: int32
+                  maximum: 100
+                  minimum: 1
+                  type: integer
+              required:
+                - template
+              type: object
+            status:
+              description: NodePoolStatus defines the observed state of NodePool
+              properties:
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                resources:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Resources is the list of resources that have been provisioned.
+                  type: object
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/content/projects/karpenter/v1.1.3/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/content/projects/karpenter/v1.1.3/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -1,0 +1,742 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  name: ec2nodeclasses.karpenter.k8s.aws
+spec:
+  group: karpenter.k8s.aws
+  names:
+    categories:
+      - karpenter
+    kind: EC2NodeClass
+    listKind: EC2NodeClassList
+    plural: ec2nodeclasses
+    shortNames:
+      - ec2nc
+      - ec2ncs
+    singular: ec2nodeclass
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.role
+          name: Role
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: EC2NodeClass is the Schema for the EC2NodeClass API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                EC2NodeClassSpec is the top level specification for the AWS Karpenter Provider.
+                This will contain configuration necessary to launch instances in AWS.
+              properties:
+                amiFamily:
+                  description: |-
+                    AMIFamily dictates the UserData format and default BlockDeviceMappings used when generating launch templates.
+                    This field is optional when using an alias amiSelectorTerm, and the value will be inferred from the alias'
+                    family. When an alias is specified, this field may only be set to its corresponding family or 'Custom'. If no
+                    alias is specified, this field is required.
+                    NOTE: We ignore the AMIFamily for hashing here because we hash the AMIFamily dynamically by using the alias using
+                    the AMIFamily() helper function
+                  enum:
+                    - AL2
+                    - AL2023
+                    - Bottlerocket
+                    - Custom
+                    - Windows2019
+                    - Windows2022
+                  type: string
+                amiSelectorTerms:
+                  description: AMISelectorTerms is a list of or ami selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      AMISelectorTerm defines selection logic for an ami used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      alias:
+                        description: |-
+                          Alias specifies which EKS optimized AMI to select.
+                          Each alias consists of a family and an AMI version, specified as "family@version".
+                          Valid families include: al2, al2023, bottlerocket, windows2019, and windows2022.
+                          The version can either be pinned to a specific AMI release, with that AMIs version format (ex: "al2023@v20240625" or "bottlerocket@v1.10.0").
+                          The version can also be set to "latest" for any family. Setting the version to latest will result in drift when a new AMI is released. This is **not** recommended for production environments.
+                          Note: The Windows families do **not** support version pinning, and only latest may be used.
+                        maxLength: 30
+                        type: string
+                        x-kubernetes-validations:
+                          - message: '''alias'' is improperly formatted, must match the format ''family@version'''
+                            rule: self.matches('^[a-zA-Z0-9]+@.+$')
+                          - message: 'family is not supported, must be one of the following: ''al2'', ''al2023'', ''bottlerocket'', ''windows2019'', ''windows2022'''
+                            rule: self.split('@')[0] in ['al2','al2023','bottlerocket','windows2019','windows2022']
+                          - message: windows families may only specify version 'latest'
+                            rule: 'self.split(''@'')[0] in [''windows2019'',''windows2022''] ? self.split(''@'')[1] == ''latest'' : true'
+                      id:
+                        description: ID is the ami id in EC2
+                        pattern: ami-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the ami name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      owner:
+                        description: |-
+                          Owner is the owner for the ami.
+                          You can specify a combination of AWS account IDs, "self", "amazon", and "aws-marketplace"
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select amis.
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  minItems: 1
+                  type: array
+                  x-kubernetes-validations:
+                    - message: expected at least one, got none, ['tags', 'id', 'name', 'alias']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name) || has(x.alias))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.exists(x, has(x.id) && (has(x.alias) || has(x.tags) || has(x.name) || has(x.owner)))'
+                    - message: '''alias'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.exists(x, has(x.alias) && (has(x.id) || has(x.tags) || has(x.name) || has(x.owner)))'
+                    - message: '''alias'' is mutually exclusive, cannot be set with a combination of other amiSelectorTerms'
+                      rule: '!(self.exists(x, has(x.alias)) && self.size() != 1)'
+                associatePublicIPAddress:
+                  description: AssociatePublicIPAddress controls if public IP addresses are assigned to instances that are launched with the nodeclass.
+                  type: boolean
+                blockDeviceMappings:
+                  description: BlockDeviceMappings to be applied to provisioned nodes.
+                  items:
+                    properties:
+                      deviceName:
+                        description: The device name (for example, /dev/sdh or xvdh).
+                        type: string
+                      ebs:
+                        description: EBS contains parameters used to automatically set up EBS volumes when an instance is launched.
+                        properties:
+                          deleteOnTermination:
+                            description: DeleteOnTermination indicates whether the EBS volume is deleted on instance termination.
+                            type: boolean
+                          encrypted:
+                            description: |-
+                              Encrypted indicates whether the EBS volume is encrypted. Encrypted volumes can only
+                              be attached to instances that support Amazon EBS encryption. If you are creating
+                              a volume from a snapshot, you can't specify an encryption value.
+                            type: boolean
+                          iops:
+                            description: |-
+                              IOPS is the number of I/O operations per second (IOPS). For gp3, io1, and io2 volumes,
+                              this represents the number of IOPS that are provisioned for the volume. For
+                              gp2 volumes, this represents the baseline performance of the volume and the
+                              rate at which the volume accumulates I/O credits for bursting.
+
+                              The following are the supported values for each volume type:
+
+                                 * gp3: 3,000-16,000 IOPS
+
+                                 * io1: 100-64,000 IOPS
+
+                                 * io2: 100-64,000 IOPS
+
+                              For io1 and io2 volumes, we guarantee 64,000 IOPS only for Instances built
+                              on the Nitro System (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances).
+                              Other instance families guarantee performance up to 32,000 IOPS.
+
+                              This parameter is supported for io1, io2, and gp3 volumes only. This parameter
+                              is not supported for gp2, st1, sc1, or standard volumes.
+                            format: int64
+                            type: integer
+                          kmsKeyID:
+                            description: KMSKeyID (ARN) of the symmetric Key Management Service (KMS) CMK used for encryption.
+                            type: string
+                          snapshotID:
+                            description: SnapshotID is the ID of an EBS snapshot
+                            type: string
+                          throughput:
+                            description: |-
+                              Throughput to provision for a gp3 volume, with a maximum of 1,000 MiB/s.
+                              Valid Range: Minimum value of 125. Maximum value of 1000.
+                            format: int64
+                            type: integer
+                          volumeSize:
+                            description: |-
+                              VolumeSize in `Gi`, `G`, `Ti`, or `T`. You must specify either a snapshot ID or
+                              a volume size. The following are the supported volumes sizes for each volume
+                              type:
+
+                                 * gp2 and gp3: 1-16,384
+
+                                 * io1 and io2: 4-16,384
+
+                                 * st1 and sc1: 125-16,384
+
+                                 * standard: 1-1,024
+                            pattern: ^((?:[1-9][0-9]{0,3}|[1-4][0-9]{4}|[5][0-8][0-9]{3}|59000)Gi|(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|[6][0-3][0-9]{3}|64000)G|([1-9]||[1-5][0-7]|58)Ti|([1-9]||[1-5][0-9]|6[0-3]|64)T)$
+                            type: string
+                          volumeType:
+                            description: |-
+                              VolumeType of the block device.
+                              For more information, see Amazon EBS volume types (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html)
+                              in the Amazon Elastic Compute Cloud User Guide.
+                            enum:
+                              - standard
+                              - io1
+                              - io2
+                              - gp2
+                              - sc1
+                              - st1
+                              - gp3
+                            type: string
+                        type: object
+                        x-kubernetes-validations:
+                          - message: snapshotID or volumeSize must be defined
+                            rule: has(self.snapshotID) || has(self.volumeSize)
+                      rootVolume:
+                        description: |-
+                          RootVolume is a flag indicating if this device is mounted as kubelet root dir. You can
+                          configure at most one root volume in BlockDeviceMappings.
+                        type: boolean
+                    type: object
+                  maxItems: 50
+                  type: array
+                  x-kubernetes-validations:
+                    - message: must have only one blockDeviceMappings with rootVolume
+                      rule: self.filter(x, has(x.rootVolume)?x.rootVolume==true:false).size() <= 1
+                context:
+                  description: |-
+                    Context is a Reserved field in EC2 APIs
+                    https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet.html
+                  type: string
+                detailedMonitoring:
+                  description: DetailedMonitoring controls if detailed monitoring is enabled for instances that are launched
+                  type: boolean
+                instanceProfile:
+                  description: |-
+                    InstanceProfile is the AWS entity that instances use.
+                    This field is mutually exclusive from role.
+                    The instance profile should already have a role assigned to it that Karpenter
+                     has PassRole permission on for instance launch using this instanceProfile to succeed.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: instanceProfile cannot be empty
+                      rule: self != ''
+                instanceStorePolicy:
+                  description: InstanceStorePolicy specifies how to handle instance-store disks.
+                  enum:
+                    - RAID0
+                  type: string
+                kubelet:
+                  description: |-
+                    Kubelet defines args to be used when configuring kubelet on provisioned nodes.
+                    They are a subset of the upstream types, recognizing not all options may be supported.
+                    Wherever possible, the types and names should reflect the upstream kubelet types.
+                  properties:
+                    clusterDNS:
+                      description: |-
+                        clusterDNS is a list of IP addresses for the cluster DNS server.
+                        Note that not all providers may use all addresses.
+                      items:
+                        type: string
+                      type: array
+                    cpuCFSQuota:
+                      description: CPUCFSQuota enables CPU CFS quota enforcement for containers that specify CPU limits.
+                      type: boolean
+                    evictionHard:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionHard is the map of signal names to quantities that define hard eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionHard are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionMaxPodGracePeriod:
+                      description: |-
+                        EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in
+                        response to soft eviction thresholds being met.
+                      format: int32
+                      type: integer
+                    evictionSoft:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionSoft is the map of signal names to quantities that define soft eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoft are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionSoftGracePeriod:
+                      additionalProperties:
+                        type: string
+                      description: EvictionSoftGracePeriod is the map of signal names to quantities that define grace periods for each eviction signal
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoftGracePeriod are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    imageGCHighThresholdPercent:
+                      description: |-
+                        ImageGCHighThresholdPercent is the percent of disk usage after which image
+                        garbage collection is always run. The percent is calculated by dividing this
+                        field value by 100, so this field must be between 0 and 100, inclusive.
+                        When specified, the value must be greater than ImageGCLowThresholdPercent.
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    imageGCLowThresholdPercent:
+                      description: |-
+                        ImageGCLowThresholdPercent is the percent of disk usage before which image
+                        garbage collection is never run. Lowest disk usage to garbage collect to.
+                        The percent is calculated by dividing this field value by 100,
+                        so the field value must be between 0 and 100, inclusive.
+                        When specified, the value must be less than imageGCHighThresholdPercent
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    kubeReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: KubeReserved contains resources reserved for Kubernetes system components.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for kubeReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: kubeReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                    maxPods:
+                      description: |-
+                        MaxPods is an override for the maximum number of pods that can run on
+                        a worker node instance.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    podsPerCore:
+                      description: |-
+                        PodsPerCore is an override for the number of pods that can run on a worker node
+                        instance based on the number of cpu cores. This value cannot exceed MaxPods, so, if
+                        MaxPods is a lower value, that value will be used.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    systemReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: SystemReserved contains resources reserved for OS system daemons and kernel memory.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for systemReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: systemReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                  type: object
+                  x-kubernetes-validations:
+                    - message: imageGCHighThresholdPercent must be greater than imageGCLowThresholdPercent
+                      rule: 'has(self.imageGCHighThresholdPercent) && has(self.imageGCLowThresholdPercent) ?  self.imageGCHighThresholdPercent > self.imageGCLowThresholdPercent  : true'
+                    - message: evictionSoft OwnerKey does not have a matching evictionSoftGracePeriod
+                      rule: has(self.evictionSoft) ? self.evictionSoft.all(e, (e in self.evictionSoftGracePeriod)):true
+                    - message: evictionSoftGracePeriod OwnerKey does not have a matching evictionSoft
+                      rule: has(self.evictionSoftGracePeriod) ? self.evictionSoftGracePeriod.all(e, (e in self.evictionSoft)):true
+                metadataOptions:
+                  default:
+                    httpEndpoint: enabled
+                    httpProtocolIPv6: disabled
+                    httpPutResponseHopLimit: 1
+                    httpTokens: required
+                  description: |-
+                    MetadataOptions for the generated launch template of provisioned nodes.
+
+                    This specifies the exposure of the Instance Metadata Service to
+                    provisioned EC2 nodes. For more information,
+                    see Instance Metadata and User Data
+                    (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
+                    in the Amazon Elastic Compute Cloud User Guide.
+
+                    Refer to recommended, security best practices
+                    (https://aws.github.io/aws-eks-best-practices/security/docs/iam/#restrict-access-to-the-instance-profile-assigned-to-the-worker-node)
+                    for limiting exposure of Instance Metadata and User Data to pods.
+                    If omitted, defaults to httpEndpoint enabled, with httpProtocolIPv6
+                    disabled, with httpPutResponseLimit of 1, and with httpTokens
+                    required.
+                  properties:
+                    httpEndpoint:
+                      default: enabled
+                      description: |-
+                        HTTPEndpoint enables or disables the HTTP metadata endpoint on provisioned
+                        nodes. If metadata options is non-nil, but this parameter is not specified,
+                        the default state is "enabled".
+
+                        If you specify a value of "disabled", instance metadata will not be accessible
+                        on the node.
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpProtocolIPv6:
+                      default: disabled
+                      description: |-
+                        HTTPProtocolIPv6 enables or disables the IPv6 endpoint for the instance metadata
+                        service on provisioned nodes. If metadata options is non-nil, but this parameter
+                        is not specified, the default state is "disabled".
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpPutResponseHopLimit:
+                      default: 1
+                      description: |-
+                        HTTPPutResponseHopLimit is the desired HTTP PUT response hop limit for
+                        instance metadata requests. The larger the number, the further instance
+                        metadata requests can travel. Possible values are integers from 1 to 64.
+                        If metadata options is non-nil, but this parameter is not specified, the
+                        default value is 1.
+                      format: int64
+                      maximum: 64
+                      minimum: 1
+                      type: integer
+                    httpTokens:
+                      default: required
+                      description: |-
+                        HTTPTokens determines the state of token usage for instance metadata
+                        requests. If metadata options is non-nil, but this parameter is not
+                        specified, the default state is "required".
+
+                        If the state is optional, one can choose to retrieve instance metadata with
+                        or without a signed token header on the request. If one retrieves the IAM
+                        role credentials without a token, the version 1.0 role credentials are
+                        returned. If one retrieves the IAM role credentials using a valid signed
+                        token, the version 2.0 role credentials are returned.
+
+                        If the state is "required", one must send a signed token header with any
+                        instance metadata retrieval requests. In this state, retrieving the IAM
+                        role credentials always returns the version 2.0 credentials; the version
+                        1.0 credentials are not available.
+                      enum:
+                        - required
+                        - optional
+                      type: string
+                  type: object
+                role:
+                  description: |-
+                    Role is the AWS identity that nodes use. This field is immutable.
+                    This field is mutually exclusive from instanceProfile.
+                    Marking this field as immutable avoids concerns around terminating managed instance profiles from running instances.
+                    This field may be made mutable in the future, assuming the correct garbage collection and drift handling is implemented
+                    for the old instance profiles on an update.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: role cannot be empty
+                      rule: self != ''
+                    - message: immutable field changed
+                      rule: self == oldSelf
+                securityGroupSelectorTerms:
+                  description: SecurityGroupSelectorTerms is a list of or security group selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SecurityGroupSelectorTerm defines selection logic for a security group used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the security group id in EC2
+                        pattern: sg-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the security group name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select security groups.
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: securityGroupSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id', 'name']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && (has(x.tags) || has(x.name)))'
+                    - message: '''name'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.name) && (has(x.tags) || has(x.id)))'
+                subnetSelectorTerms:
+                  description: SubnetSelectorTerms is a list of or subnet selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SubnetSelectorTerm defines selection logic for a subnet used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the subnet id in EC2
+                        pattern: subnet-[0-9a-z]+
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: subnetSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id']
+                      rule: self.all(x, has(x.tags) || has(x.id))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in subnetSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && has(x.tags))'
+                tags:
+                  additionalProperties:
+                    type: string
+                  description: Tags to be applied on ec2 resources like instances and launch templates.
+                  type: object
+                  x-kubernetes-validations:
+                    - message: empty tag keys aren't supported
+                      rule: self.all(k, k != '')
+                    - message: tag contains a restricted tag matching eks:eks-cluster-name
+                      rule: self.all(k, k !='eks:eks-cluster-name')
+                    - message: tag contains a restricted tag matching kubernetes.io/cluster/
+                      rule: self.all(k, !k.startsWith('kubernetes.io/cluster') )
+                    - message: tag contains a restricted tag matching karpenter.sh/nodepool
+                      rule: self.all(k, k != 'karpenter.sh/nodepool')
+                    - message: tag contains a restricted tag matching karpenter.sh/nodeclaim
+                      rule: self.all(k, k !='karpenter.sh/nodeclaim')
+                    - message: tag contains a restricted tag matching karpenter.k8s.aws/ec2nodeclass
+                      rule: self.all(k, k !='karpenter.k8s.aws/ec2nodeclass')
+                userData:
+                  description: |-
+                    UserData to be applied to the provisioned nodes.
+                    It must be in the appropriate format based on the AMIFamily in use. Karpenter will merge certain fields into
+                    this UserData to ensure nodes are being provisioned with the correct configuration.
+                  type: string
+              required:
+                - amiSelectorTerms
+                - securityGroupSelectorTerms
+                - subnetSelectorTerms
+              type: object
+              x-kubernetes-validations:
+                - message: must specify exactly one of ['role', 'instanceProfile']
+                  rule: (has(self.role) && !has(self.instanceProfile)) || (!has(self.role) && has(self.instanceProfile))
+                - message: changing from 'instanceProfile' to 'role' is not supported. You must delete and recreate this node class if you want to change this.
+                  rule: (has(oldSelf.role) && has(self.role)) || (has(oldSelf.instanceProfile) && has(self.instanceProfile))
+                - message: if set, amiFamily must be 'AL2' or 'Custom' when using an AL2 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''al2'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''AL2'') : true)'
+                - message: if set, amiFamily must be 'AL2023' or 'Custom' when using an AL2023 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''al2023'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''AL2023'') : true)'
+                - message: if set, amiFamily must be 'Bottlerocket' or 'Custom' when using a Bottlerocket alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''bottlerocket'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Bottlerocket'') : true)'
+                - message: if set, amiFamily must be 'Windows2019' or 'Custom' when using a Windows2019 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''windows2019'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Windows2019'') : true)'
+                - message: if set, amiFamily must be 'Windows2022' or 'Custom' when using a Windows2022 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''windows2022'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Windows2022'') : true)'
+                - message: must specify amiFamily if amiSelectorTerms does not contain an alias
+                  rule: 'self.amiSelectorTerms.exists(x, has(x.alias)) ? true : has(self.amiFamily)'
+            status:
+              description: EC2NodeClassStatus contains the resolved state of the EC2NodeClass
+              properties:
+                amis:
+                  description: |-
+                    AMI contains the current AMI values that are available to the
+                    cluster under the AMI selectors.
+                  items:
+                    description: AMI contains resolved AMI selector values utilized for node launch
+                    properties:
+                      deprecated:
+                        description: Deprecation status of the AMI
+                        type: boolean
+                      id:
+                        description: ID of the AMI
+                        type: string
+                      name:
+                        description: Name of the AMI
+                        type: string
+                      requirements:
+                        description: Requirements of the AMI to be utilized on an instance type
+                        items:
+                          description: |-
+                            A node selector requirement is a selector that contains values, a key, and an operator
+                            that relates the key and values.
+                          properties:
+                            key:
+                              description: The label key that the selector applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                Represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                              type: string
+                            values:
+                              description: |-
+                                An array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. If the operator is Gt or Lt, the values
+                                array must have a single element, which will be interpreted as an integer.
+                                This array is replaced during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                            - key
+                            - operator
+                          type: object
+                        type: array
+                    required:
+                      - id
+                      - requirements
+                    type: object
+                  type: array
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                instanceProfile:
+                  description: InstanceProfile contains the resolved instance profile for the role
+                  type: string
+                securityGroups:
+                  description: |-
+                    SecurityGroups contains the current security group values that are available to the
+                    cluster under the SecurityGroups selectors.
+                  items:
+                    description: SecurityGroup contains resolved SecurityGroup selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the security group
+                        type: string
+                      name:
+                        description: Name of the security group
+                        type: string
+                    required:
+                      - id
+                    type: object
+                  type: array
+                subnets:
+                  description: |-
+                    Subnets contains the current subnet values that are available to the
+                    cluster under the subnet selectors.
+                  items:
+                    description: Subnet contains resolved Subnet selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the subnet
+                        type: string
+                      zone:
+                        description: The associated availability zone
+                        type: string
+                      zoneID:
+                        description: The associated availability zone ID
+                        type: string
+                    required:
+                      - id
+                      - zone
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/content/projects/karpenter/v1.1.3/karpenter.sh_nodeclaims.yaml
+++ b/content/projects/karpenter/v1.1.3/karpenter.sh_nodeclaims.yaml
@@ -1,0 +1,391 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: nodeclaims.karpenter.sh
+spec:
+  group: karpenter.sh
+  names:
+    categories:
+      - karpenter
+    kind: NodeClaim
+    listKind: NodeClaimList
+    plural: nodeclaims
+    singular: nodeclaim
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.labels.node\.kubernetes\.io/instance-type
+          name: Type
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/capacity-type
+          name: Capacity
+          type: string
+        - jsonPath: .metadata.labels.topology\.kubernetes\.io/zone
+          name: Zone
+          type: string
+        - jsonPath: .status.nodeName
+          name: Node
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .status.providerID
+          name: ID
+          priority: 1
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/nodepool
+          name: NodePool
+          priority: 1
+          type: string
+        - jsonPath: .spec.nodeClassRef.name
+          name: NodeClass
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: NodeClaim is the Schema for the NodeClaims API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: NodeClaimSpec describes the desired state of the NodeClaim
+              properties:
+                expireAfter:
+                  default: 720h
+                  description: |-
+                    ExpireAfter is the duration the controller will wait
+                    before terminating a node, measured from when the node is created. This
+                    is useful to implement features like eventually consistent node upgrade,
+                    memory leak protection, and disruption testing.
+                  pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                  type: string
+                nodeClassRef:
+                  description: NodeClassRef is a reference to an object that defines provider specific configuration
+                  properties:
+                    group:
+                      description: API version of the referent
+                      pattern: ^[^/]*$
+                      type: string
+                      x-kubernetes-validations:
+                        - message: group may not be empty
+                          rule: self != ''
+                    kind:
+                      description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                      type: string
+                      x-kubernetes-validations:
+                        - message: kind may not be empty
+                          rule: self != ''
+                    name:
+                      description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                      type: string
+                      x-kubernetes-validations:
+                        - message: name may not be empty
+                          rule: self != ''
+                  required:
+                    - group
+                    - kind
+                    - name
+                  type: object
+                requirements:
+                  description: Requirements are layered with GetLabels and applied to every node.
+                  items:
+                    description: |-
+                      A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                      and minValues that represent the requirement to have at least that many values.
+                    properties:
+                      key:
+                        description: The label key that the selector applies to.
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                        x-kubernetes-validations:
+                          - message: label domain "kubernetes.io" is restricted
+                            rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                          - message: label domain "k8s.io" is restricted
+                            rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                          - message: label domain "karpenter.sh" is restricted
+                            rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                          - message: label "kubernetes.io/hostname" is restricted
+                            rule: self != "kubernetes.io/hostname"
+                          - message: label domain "karpenter.k8s.aws" is restricted
+                            rule: self in ["karpenter.k8s.aws/ec2nodeclass", "karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu", "karpenter.k8s.aws/instance-cpu-manufacturer", "karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz", "karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                      minValues:
+                        description: |-
+                          This field is ALPHA and can be dropped or replaced at any time
+                          MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                        maximum: 50
+                        minimum: 1
+                        type: integer
+                      operator:
+                        description: |-
+                          Represents a key's relationship to a set of values.
+                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                        type: string
+                        enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          - Gt
+                          - Lt
+                      values:
+                        description: |-
+                          An array of string values. If the operator is In or NotIn,
+                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                          the values array must be empty. If the operator is Gt or Lt, the values
+                          array must have a single element, which will be interpreted as an integer.
+                          This array is replaced during a strategic merge patch.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                        maxLength: 63
+                        pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                    required:
+                      - key
+                      - operator
+                    type: object
+                  maxItems: 100
+                  type: array
+                  x-kubernetes-validations:
+                    - message: requirements with operator 'In' must have a value defined
+                      rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                    - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                      rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                    - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                      rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                resources:
+                  description: Resources models the resource requirements for the NodeClaim to launch
+                  properties:
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: Requests describes the minimum required resources for the NodeClaim to launch
+                      type: object
+                  type: object
+                startupTaints:
+                  description: |-
+                    StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                    within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                    daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                    purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                taints:
+                  description: Taints will be applied to the NodeClaim's node.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                terminationGracePeriod:
+                  description: |-
+                    TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
+
+                    Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
+
+                    This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
+                    When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
+
+                    Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
+                    If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
+                    that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
+
+                    The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
+                    If left undefined, the controller will wait indefinitely for pods to be drained.
+                  pattern: ^([0-9]+(s|m|h))+$
+                  type: string
+              required:
+                - nodeClassRef
+                - requirements
+              type: object
+              x-kubernetes-validations:
+                - message: spec is immutable
+                  rule: self == oldSelf
+            status:
+              description: NodeClaimStatus defines the observed state of NodeClaim
+              properties:
+                allocatable:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Allocatable is the estimated allocatable capacity of the node
+                  type: object
+                capacity:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Capacity is the estimated full capacity of the node
+                  type: object
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        pattern: ^([A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?|)$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - status
+                      - type
+                    type: object
+                  type: array
+                imageID:
+                  description: ImageID is an identifier for the image that runs on the node
+                  type: string
+                lastPodEventTime:
+                  description: |-
+                    LastPodEventTime is updated with the last time a pod was scheduled
+                    or removed from the node. A pod going terminal or terminating
+                    is also considered as removed.
+                  format: date-time
+                  type: string
+                nodeName:
+                  description: NodeName is the name of the corresponding node object
+                  type: string
+                providerID:
+                  description: ProviderID of the corresponding node object
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/content/projects/karpenter/v1.1.3/karpenter.sh_nodepools.yaml
+++ b/content/projects/karpenter/v1.1.3/karpenter.sh_nodepools.yaml
@@ -1,0 +1,519 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: nodepools.karpenter.sh
+spec:
+  group: karpenter.sh
+  names:
+    categories:
+      - karpenter
+    kind: NodePool
+    listKind: NodePoolList
+    plural: nodepools
+    singular: nodepool
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.template.spec.nodeClassRef.name
+          name: NodeClass
+          type: string
+        - jsonPath: .status.resources.nodes
+          name: Nodes
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.weight
+          name: Weight
+          priority: 1
+          type: integer
+        - jsonPath: .status.resources.cpu
+          name: CPU
+          priority: 1
+          type: string
+        - jsonPath: .status.resources.memory
+          name: Memory
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: NodePool is the Schema for the NodePools API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                NodePoolSpec is the top level nodepool specification. Nodepools
+                launch nodes in response to pods that are unschedulable. A single nodepool
+                is capable of managing a diverse set of nodes. Node properties are determined
+                from a combination of nodepool and pod scheduling constraints.
+              properties:
+                disruption:
+                  default:
+                    consolidateAfter: 0s
+                  description: Disruption contains the parameters that relate to Karpenter's disruption logic
+                  properties:
+                    budgets:
+                      default:
+                        - nodes: 10%
+                      description: |-
+                        Budgets is a list of Budgets.
+                        If there are multiple active budgets, Karpenter uses
+                        the most restrictive value. If left undefined,
+                        this will default to one budget with a value to 10%.
+                      items:
+                        description: |-
+                          Budget defines when Karpenter will restrict the
+                          number of Node Claims that can be terminating simultaneously.
+                        properties:
+                          duration:
+                            description: |-
+                              Duration determines how long a Budget is active since each Schedule hit.
+                              Only minutes and hours are accepted, as cron does not work in seconds.
+                              If omitted, the budget is always active.
+                              This is required if Schedule is set.
+                              This regex has an optional 0s at the end since the duration.String() always adds
+                              a 0s at the end.
+                            pattern: ^((([0-9]+(h|m))|([0-9]+h[0-9]+m))(0s)?)$
+                            type: string
+                          nodes:
+                            default: 10%
+                            description: |-
+                              Nodes dictates the maximum number of NodeClaims owned by this NodePool
+                              that can be terminating at once. This is calculated by counting nodes that
+                              have a deletion timestamp set, or are actively being deleted by Karpenter.
+                              This field is required when specifying a budget.
+                              This cannot be of type intstr.IntOrString since kubebuilder doesn't support pattern
+                              checking for int nodes for IntOrString nodes.
+                              Ref: https://github.com/kubernetes-sigs/controller-tools/blob/55efe4be40394a288216dab63156b0a64fb82929/pkg/crd/markers/validation.go#L379-L388
+                            pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
+                            type: string
+                          reasons:
+                            description: |-
+                              Reasons is a list of disruption methods that this budget applies to. If Reasons is not set, this budget applies to all methods.
+                              Otherwise, this will apply to each reason defined.
+                              allowed reasons are Underutilized, Empty, and Drifted.
+                            items:
+                              description: DisruptionReason defines valid reasons for disruption budgets.
+                              enum:
+                                - Underutilized
+                                - Empty
+                                - Drifted
+                              type: string
+                            type: array
+                          schedule:
+                            description: |-
+                              Schedule specifies when a budget begins being active, following
+                              the upstream cronjob syntax. If omitted, the budget is always active.
+                              Timezones are not supported.
+                              This field is required if Duration is set.
+                            pattern: ^(@(annually|yearly|monthly|weekly|daily|midnight|hourly))|((.+)\s(.+)\s(.+)\s(.+)\s(.+))$
+                            type: string
+                        required:
+                          - nodes
+                        type: object
+                      maxItems: 50
+                      type: array
+                      x-kubernetes-validations:
+                        - message: '''schedule'' must be set with ''duration'''
+                          rule: self.all(x, has(x.schedule) == has(x.duration))
+                    consolidateAfter:
+                      description: |-
+                        ConsolidateAfter is the duration the controller will wait
+                        before attempting to terminate nodes that are underutilized.
+                        Refer to ConsolidationPolicy for how underutilization is considered.
+                      pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                      type: string
+                    consolidationPolicy:
+                      default: WhenEmptyOrUnderutilized
+                      description: |-
+                        ConsolidationPolicy describes which nodes Karpenter can disrupt through its consolidation
+                        algorithm. This policy defaults to "WhenEmptyOrUnderutilized" if not specified
+                      enum:
+                        - WhenEmpty
+                        - WhenEmptyOrUnderutilized
+                      type: string
+                  required:
+                    - consolidateAfter
+                  type: object
+                limits:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Limits define a set of bounds for provisioning capacity.
+                  type: object
+                template:
+                  description: |-
+                    Template contains the template of possibilities for the provisioning logic to launch a NodeClaim with.
+                    NodeClaims launched from this NodePool will often be further constrained than the template specifies.
+                  properties:
+                    metadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Annotations is an unstructured key value map stored with a resource that may be
+                            set by external tools to store and retrieve arbitrary metadata. They are not
+                            queryable and should be preserved when modifying objects.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                            maxLength: 63
+                            pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                          description: |-
+                            Map of string keys and values that can be used to organize and categorize
+                            (scope and select) objects. May match selectors of replication controllers
+                            and services.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
+                          type: object
+                          maxProperties: 100
+                          x-kubernetes-validations:
+                            - message: label domain "kubernetes.io" is restricted
+                              rule: self.all(x, x in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region",  "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || x.find("^([^/]+)").endsWith("node.kubernetes.io") || x.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !x.find("^([^/]+)").endsWith("kubernetes.io"))
+                            - message: label domain "k8s.io" is restricted
+                              rule: self.all(x, x.find("^([^/]+)").endsWith("kops.k8s.io") || !x.find("^([^/]+)").endsWith("k8s.io"))
+                            - message: label domain "karpenter.sh" is restricted
+                              rule: self.all(x, x in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !x.find("^([^/]+)").endsWith("karpenter.sh"))
+                            - message: label "karpenter.sh/nodepool" is restricted
+                              rule: self.all(x, x != "karpenter.sh/nodepool")
+                            - message: label "kubernetes.io/hostname" is restricted
+                              rule: self.all(x, x != "kubernetes.io/hostname")
+                            - message: label domain "karpenter.k8s.aws" is restricted
+                              rule: self.all(x, x in ["karpenter.k8s.aws/ec2nodeclass", "karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu", "karpenter.k8s.aws/instance-cpu-manufacturer", "karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz", "karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !x.find("^([^/]+)").endsWith("karpenter.k8s.aws"))
+                      type: object
+                    spec:
+                      description: |-
+                        NodeClaimTemplateSpec describes the desired state of the NodeClaim in the Nodepool
+                        NodeClaimTemplateSpec is used in the NodePool's NodeClaimTemplate, with the resource requests omitted since
+                        users are not able to set resource requests in the NodePool.
+                      properties:
+                        expireAfter:
+                          default: 720h
+                          description: |-
+                            ExpireAfter is the duration the controller will wait
+                            before terminating a node, measured from when the node is created. This
+                            is useful to implement features like eventually consistent node upgrade,
+                            memory leak protection, and disruption testing.
+                          pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                          type: string
+                        nodeClassRef:
+                          description: NodeClassRef is a reference to an object that defines provider specific configuration
+                          properties:
+                            group:
+                              description: API version of the referent
+                              pattern: ^[^/]*$
+                              type: string
+                              x-kubernetes-validations:
+                                - message: group may not be empty
+                                  rule: self != ''
+                            kind:
+                              description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                              type: string
+                              x-kubernetes-validations:
+                                - message: kind may not be empty
+                                  rule: self != ''
+                            name:
+                              description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                              x-kubernetes-validations:
+                                - message: name may not be empty
+                                  rule: self != ''
+                          required:
+                            - group
+                            - kind
+                            - name
+                          type: object
+                          x-kubernetes-validations:
+                            - message: nodeClassRef.group is immutable
+                              rule: self.group == oldSelf.group
+                            - message: nodeClassRef.kind is immutable
+                              rule: self.kind == oldSelf.kind
+                        requirements:
+                          description: Requirements are layered with GetLabels and applied to every node.
+                          items:
+                            description: |-
+                              A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                              and minValues that represent the requirement to have at least that many values.
+                            properties:
+                              key:
+                                description: The label key that the selector applies to.
+                                type: string
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                                x-kubernetes-validations:
+                                  - message: label domain "kubernetes.io" is restricted
+                                    rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                                  - message: label domain "k8s.io" is restricted
+                                    rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                                  - message: label domain "karpenter.sh" is restricted
+                                    rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                                  - message: label "karpenter.sh/nodepool" is restricted
+                                    rule: self != "karpenter.sh/nodepool"
+                                  - message: label "kubernetes.io/hostname" is restricted
+                                    rule: self != "kubernetes.io/hostname"
+                                  - message: label domain "karpenter.k8s.aws" is restricted
+                                    rule: self in ["karpenter.k8s.aws/ec2nodeclass", "karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu", "karpenter.k8s.aws/instance-cpu-manufacturer", "karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz", "karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                              minValues:
+                                description: |-
+                                  This field is ALPHA and can be dropped or replaced at any time
+                                  MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                                maximum: 50
+                                minimum: 1
+                                type: integer
+                              operator:
+                                description: |-
+                                  Represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                type: string
+                                enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  - Gt
+                                  - Lt
+                              values:
+                                description: |-
+                                  An array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                  array must have a single element, which will be interpreted as an integer.
+                                  This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          maxItems: 100
+                          type: array
+                          x-kubernetes-validations:
+                            - message: requirements with operator 'In' must have a value defined
+                              rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                            - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                              rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                            - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                              rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                        startupTaints:
+                          description: |-
+                            StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                            within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                            daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                            purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        taints:
+                          description: Taints will be applied to the NodeClaim's node.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        terminationGracePeriod:
+                          description: |-
+                            TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
+
+                            Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
+
+                            This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
+                            When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
+
+                            Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
+                            If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
+                            that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
+
+                            The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
+                            If left undefined, the controller will wait indefinitely for pods to be drained.
+                          pattern: ^([0-9]+(s|m|h))+$
+                          type: string
+                      required:
+                        - nodeClassRef
+                        - requirements
+                      type: object
+                  required:
+                    - spec
+                  type: object
+                weight:
+                  description: |-
+                    Weight is the priority given to the nodepool during scheduling. A higher
+                    numerical weight indicates that this nodepool will be ordered
+                    ahead of other nodepools with lower weights. A nodepool with no weight
+                    will be treated as if it is a nodepool with a weight of 0.
+                  format: int32
+                  maximum: 100
+                  minimum: 1
+                  type: integer
+              required:
+                - template
+              type: object
+            status:
+              description: NodePoolStatus defines the observed state of NodePool
+              properties:
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                resources:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Resources is the list of resources that have been provisioned.
+                  type: object
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/content/projects/karpenter/v1.1.4/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/content/projects/karpenter/v1.1.4/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -1,0 +1,742 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: ec2nodeclasses.karpenter.k8s.aws
+spec:
+  group: karpenter.k8s.aws
+  names:
+    categories:
+      - karpenter
+    kind: EC2NodeClass
+    listKind: EC2NodeClassList
+    plural: ec2nodeclasses
+    shortNames:
+      - ec2nc
+      - ec2ncs
+    singular: ec2nodeclass
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.role
+          name: Role
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: EC2NodeClass is the Schema for the EC2NodeClass API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                EC2NodeClassSpec is the top level specification for the AWS Karpenter Provider.
+                This will contain configuration necessary to launch instances in AWS.
+              properties:
+                amiFamily:
+                  description: |-
+                    AMIFamily dictates the UserData format and default BlockDeviceMappings used when generating launch templates.
+                    This field is optional when using an alias amiSelectorTerm, and the value will be inferred from the alias'
+                    family. When an alias is specified, this field may only be set to its corresponding family or 'Custom'. If no
+                    alias is specified, this field is required.
+                    NOTE: We ignore the AMIFamily for hashing here because we hash the AMIFamily dynamically by using the alias using
+                    the AMIFamily() helper function
+                  enum:
+                    - AL2
+                    - AL2023
+                    - Bottlerocket
+                    - Custom
+                    - Windows2019
+                    - Windows2022
+                  type: string
+                amiSelectorTerms:
+                  description: AMISelectorTerms is a list of or ami selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      AMISelectorTerm defines selection logic for an ami used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      alias:
+                        description: |-
+                          Alias specifies which EKS optimized AMI to select.
+                          Each alias consists of a family and an AMI version, specified as "family@version".
+                          Valid families include: al2, al2023, bottlerocket, windows2019, and windows2022.
+                          The version can either be pinned to a specific AMI release, with that AMIs version format (ex: "al2023@v20240625" or "bottlerocket@v1.10.0").
+                          The version can also be set to "latest" for any family. Setting the version to latest will result in drift when a new AMI is released. This is **not** recommended for production environments.
+                          Note: The Windows families do **not** support version pinning, and only latest may be used.
+                        maxLength: 30
+                        type: string
+                        x-kubernetes-validations:
+                          - message: '''alias'' is improperly formatted, must match the format ''family@version'''
+                            rule: self.matches('^[a-zA-Z0-9]+@.+$')
+                          - message: 'family is not supported, must be one of the following: ''al2'', ''al2023'', ''bottlerocket'', ''windows2019'', ''windows2022'''
+                            rule: self.split('@')[0] in ['al2','al2023','bottlerocket','windows2019','windows2022']
+                          - message: windows families may only specify version 'latest'
+                            rule: 'self.split(''@'')[0] in [''windows2019'',''windows2022''] ? self.split(''@'')[1] == ''latest'' : true'
+                      id:
+                        description: ID is the ami id in EC2
+                        pattern: ami-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the ami name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      owner:
+                        description: |-
+                          Owner is the owner for the ami.
+                          You can specify a combination of AWS account IDs, "self", "amazon", and "aws-marketplace"
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select amis.
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  minItems: 1
+                  type: array
+                  x-kubernetes-validations:
+                    - message: expected at least one, got none, ['tags', 'id', 'name', 'alias']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name) || has(x.alias))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.exists(x, has(x.id) && (has(x.alias) || has(x.tags) || has(x.name) || has(x.owner)))'
+                    - message: '''alias'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.exists(x, has(x.alias) && (has(x.id) || has(x.tags) || has(x.name) || has(x.owner)))'
+                    - message: '''alias'' is mutually exclusive, cannot be set with a combination of other amiSelectorTerms'
+                      rule: '!(self.exists(x, has(x.alias)) && self.size() != 1)'
+                associatePublicIPAddress:
+                  description: AssociatePublicIPAddress controls if public IP addresses are assigned to instances that are launched with the nodeclass.
+                  type: boolean
+                blockDeviceMappings:
+                  description: BlockDeviceMappings to be applied to provisioned nodes.
+                  items:
+                    properties:
+                      deviceName:
+                        description: The device name (for example, /dev/sdh or xvdh).
+                        type: string
+                      ebs:
+                        description: EBS contains parameters used to automatically set up EBS volumes when an instance is launched.
+                        properties:
+                          deleteOnTermination:
+                            description: DeleteOnTermination indicates whether the EBS volume is deleted on instance termination.
+                            type: boolean
+                          encrypted:
+                            description: |-
+                              Encrypted indicates whether the EBS volume is encrypted. Encrypted volumes can only
+                              be attached to instances that support Amazon EBS encryption. If you are creating
+                              a volume from a snapshot, you can't specify an encryption value.
+                            type: boolean
+                          iops:
+                            description: |-
+                              IOPS is the number of I/O operations per second (IOPS). For gp3, io1, and io2 volumes,
+                              this represents the number of IOPS that are provisioned for the volume. For
+                              gp2 volumes, this represents the baseline performance of the volume and the
+                              rate at which the volume accumulates I/O credits for bursting.
+
+                              The following are the supported values for each volume type:
+
+                                 * gp3: 3,000-16,000 IOPS
+
+                                 * io1: 100-64,000 IOPS
+
+                                 * io2: 100-64,000 IOPS
+
+                              For io1 and io2 volumes, we guarantee 64,000 IOPS only for Instances built
+                              on the Nitro System (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances).
+                              Other instance families guarantee performance up to 32,000 IOPS.
+
+                              This parameter is supported for io1, io2, and gp3 volumes only. This parameter
+                              is not supported for gp2, st1, sc1, or standard volumes.
+                            format: int64
+                            type: integer
+                          kmsKeyID:
+                            description: KMSKeyID (ARN) of the symmetric Key Management Service (KMS) CMK used for encryption.
+                            type: string
+                          snapshotID:
+                            description: SnapshotID is the ID of an EBS snapshot
+                            type: string
+                          throughput:
+                            description: |-
+                              Throughput to provision for a gp3 volume, with a maximum of 1,000 MiB/s.
+                              Valid Range: Minimum value of 125. Maximum value of 1000.
+                            format: int64
+                            type: integer
+                          volumeSize:
+                            description: |-
+                              VolumeSize in `Gi`, `G`, `Ti`, or `T`. You must specify either a snapshot ID or
+                              a volume size. The following are the supported volumes sizes for each volume
+                              type:
+
+                                 * gp2 and gp3: 1-16,384
+
+                                 * io1 and io2: 4-16,384
+
+                                 * st1 and sc1: 125-16,384
+
+                                 * standard: 1-1,024
+                            pattern: ^((?:[1-9][0-9]{0,3}|[1-4][0-9]{4}|[5][0-8][0-9]{3}|59000)Gi|(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|[6][0-3][0-9]{3}|64000)G|([1-9]||[1-5][0-7]|58)Ti|([1-9]||[1-5][0-9]|6[0-3]|64)T)$
+                            type: string
+                          volumeType:
+                            description: |-
+                              VolumeType of the block device.
+                              For more information, see Amazon EBS volume types (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html)
+                              in the Amazon Elastic Compute Cloud User Guide.
+                            enum:
+                              - standard
+                              - io1
+                              - io2
+                              - gp2
+                              - sc1
+                              - st1
+                              - gp3
+                            type: string
+                        type: object
+                        x-kubernetes-validations:
+                          - message: snapshotID or volumeSize must be defined
+                            rule: has(self.snapshotID) || has(self.volumeSize)
+                      rootVolume:
+                        description: |-
+                          RootVolume is a flag indicating if this device is mounted as kubelet root dir. You can
+                          configure at most one root volume in BlockDeviceMappings.
+                        type: boolean
+                    type: object
+                  maxItems: 50
+                  type: array
+                  x-kubernetes-validations:
+                    - message: must have only one blockDeviceMappings with rootVolume
+                      rule: self.filter(x, has(x.rootVolume)?x.rootVolume==true:false).size() <= 1
+                context:
+                  description: |-
+                    Context is a Reserved field in EC2 APIs
+                    https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet.html
+                  type: string
+                detailedMonitoring:
+                  description: DetailedMonitoring controls if detailed monitoring is enabled for instances that are launched
+                  type: boolean
+                instanceProfile:
+                  description: |-
+                    InstanceProfile is the AWS entity that instances use.
+                    This field is mutually exclusive from role.
+                    The instance profile should already have a role assigned to it that Karpenter
+                     has PassRole permission on for instance launch using this instanceProfile to succeed.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: instanceProfile cannot be empty
+                      rule: self != ''
+                instanceStorePolicy:
+                  description: InstanceStorePolicy specifies how to handle instance-store disks.
+                  enum:
+                    - RAID0
+                  type: string
+                kubelet:
+                  description: |-
+                    Kubelet defines args to be used when configuring kubelet on provisioned nodes.
+                    They are a subset of the upstream types, recognizing not all options may be supported.
+                    Wherever possible, the types and names should reflect the upstream kubelet types.
+                  properties:
+                    clusterDNS:
+                      description: |-
+                        clusterDNS is a list of IP addresses for the cluster DNS server.
+                        Note that not all providers may use all addresses.
+                      items:
+                        type: string
+                      type: array
+                    cpuCFSQuota:
+                      description: CPUCFSQuota enables CPU CFS quota enforcement for containers that specify CPU limits.
+                      type: boolean
+                    evictionHard:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionHard is the map of signal names to quantities that define hard eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionHard are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionMaxPodGracePeriod:
+                      description: |-
+                        EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in
+                        response to soft eviction thresholds being met.
+                      format: int32
+                      type: integer
+                    evictionSoft:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionSoft is the map of signal names to quantities that define soft eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoft are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionSoftGracePeriod:
+                      additionalProperties:
+                        type: string
+                      description: EvictionSoftGracePeriod is the map of signal names to quantities that define grace periods for each eviction signal
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoftGracePeriod are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    imageGCHighThresholdPercent:
+                      description: |-
+                        ImageGCHighThresholdPercent is the percent of disk usage after which image
+                        garbage collection is always run. The percent is calculated by dividing this
+                        field value by 100, so this field must be between 0 and 100, inclusive.
+                        When specified, the value must be greater than ImageGCLowThresholdPercent.
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    imageGCLowThresholdPercent:
+                      description: |-
+                        ImageGCLowThresholdPercent is the percent of disk usage before which image
+                        garbage collection is never run. Lowest disk usage to garbage collect to.
+                        The percent is calculated by dividing this field value by 100,
+                        so the field value must be between 0 and 100, inclusive.
+                        When specified, the value must be less than imageGCHighThresholdPercent
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    kubeReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: KubeReserved contains resources reserved for Kubernetes system components.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for kubeReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: kubeReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                    maxPods:
+                      description: |-
+                        MaxPods is an override for the maximum number of pods that can run on
+                        a worker node instance.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    podsPerCore:
+                      description: |-
+                        PodsPerCore is an override for the number of pods that can run on a worker node
+                        instance based on the number of cpu cores. This value cannot exceed MaxPods, so, if
+                        MaxPods is a lower value, that value will be used.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    systemReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: SystemReserved contains resources reserved for OS system daemons and kernel memory.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for systemReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: systemReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                  type: object
+                  x-kubernetes-validations:
+                    - message: imageGCHighThresholdPercent must be greater than imageGCLowThresholdPercent
+                      rule: 'has(self.imageGCHighThresholdPercent) && has(self.imageGCLowThresholdPercent) ?  self.imageGCHighThresholdPercent > self.imageGCLowThresholdPercent  : true'
+                    - message: evictionSoft OwnerKey does not have a matching evictionSoftGracePeriod
+                      rule: has(self.evictionSoft) ? self.evictionSoft.all(e, (e in self.evictionSoftGracePeriod)):true
+                    - message: evictionSoftGracePeriod OwnerKey does not have a matching evictionSoft
+                      rule: has(self.evictionSoftGracePeriod) ? self.evictionSoftGracePeriod.all(e, (e in self.evictionSoft)):true
+                metadataOptions:
+                  default:
+                    httpEndpoint: enabled
+                    httpProtocolIPv6: disabled
+                    httpPutResponseHopLimit: 1
+                    httpTokens: required
+                  description: |-
+                    MetadataOptions for the generated launch template of provisioned nodes.
+
+                    This specifies the exposure of the Instance Metadata Service to
+                    provisioned EC2 nodes. For more information,
+                    see Instance Metadata and User Data
+                    (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
+                    in the Amazon Elastic Compute Cloud User Guide.
+
+                    Refer to recommended, security best practices
+                    (https://aws.github.io/aws-eks-best-practices/security/docs/iam/#restrict-access-to-the-instance-profile-assigned-to-the-worker-node)
+                    for limiting exposure of Instance Metadata and User Data to pods.
+                    If omitted, defaults to httpEndpoint enabled, with httpProtocolIPv6
+                    disabled, with httpPutResponseLimit of 1, and with httpTokens
+                    required.
+                  properties:
+                    httpEndpoint:
+                      default: enabled
+                      description: |-
+                        HTTPEndpoint enables or disables the HTTP metadata endpoint on provisioned
+                        nodes. If metadata options is non-nil, but this parameter is not specified,
+                        the default state is "enabled".
+
+                        If you specify a value of "disabled", instance metadata will not be accessible
+                        on the node.
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpProtocolIPv6:
+                      default: disabled
+                      description: |-
+                        HTTPProtocolIPv6 enables or disables the IPv6 endpoint for the instance metadata
+                        service on provisioned nodes. If metadata options is non-nil, but this parameter
+                        is not specified, the default state is "disabled".
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpPutResponseHopLimit:
+                      default: 1
+                      description: |-
+                        HTTPPutResponseHopLimit is the desired HTTP PUT response hop limit for
+                        instance metadata requests. The larger the number, the further instance
+                        metadata requests can travel. Possible values are integers from 1 to 64.
+                        If metadata options is non-nil, but this parameter is not specified, the
+                        default value is 1.
+                      format: int64
+                      maximum: 64
+                      minimum: 1
+                      type: integer
+                    httpTokens:
+                      default: required
+                      description: |-
+                        HTTPTokens determines the state of token usage for instance metadata
+                        requests. If metadata options is non-nil, but this parameter is not
+                        specified, the default state is "required".
+
+                        If the state is optional, one can choose to retrieve instance metadata with
+                        or without a signed token header on the request. If one retrieves the IAM
+                        role credentials without a token, the version 1.0 role credentials are
+                        returned. If one retrieves the IAM role credentials using a valid signed
+                        token, the version 2.0 role credentials are returned.
+
+                        If the state is "required", one must send a signed token header with any
+                        instance metadata retrieval requests. In this state, retrieving the IAM
+                        role credentials always returns the version 2.0 credentials; the version
+                        1.0 credentials are not available.
+                      enum:
+                        - required
+                        - optional
+                      type: string
+                  type: object
+                role:
+                  description: |-
+                    Role is the AWS identity that nodes use. This field is immutable.
+                    This field is mutually exclusive from instanceProfile.
+                    Marking this field as immutable avoids concerns around terminating managed instance profiles from running instances.
+                    This field may be made mutable in the future, assuming the correct garbage collection and drift handling is implemented
+                    for the old instance profiles on an update.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: role cannot be empty
+                      rule: self != ''
+                    - message: immutable field changed
+                      rule: self == oldSelf
+                securityGroupSelectorTerms:
+                  description: SecurityGroupSelectorTerms is a list of or security group selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SecurityGroupSelectorTerm defines selection logic for a security group used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the security group id in EC2
+                        pattern: sg-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the security group name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select security groups.
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: securityGroupSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id', 'name']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && (has(x.tags) || has(x.name)))'
+                    - message: '''name'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.name) && (has(x.tags) || has(x.id)))'
+                subnetSelectorTerms:
+                  description: SubnetSelectorTerms is a list of or subnet selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SubnetSelectorTerm defines selection logic for a subnet used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the subnet id in EC2
+                        pattern: subnet-[0-9a-z]+
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: subnetSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id']
+                      rule: self.all(x, has(x.tags) || has(x.id))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in subnetSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && has(x.tags))'
+                tags:
+                  additionalProperties:
+                    type: string
+                  description: Tags to be applied on ec2 resources like instances and launch templates.
+                  type: object
+                  x-kubernetes-validations:
+                    - message: empty tag keys aren't supported
+                      rule: self.all(k, k != '')
+                    - message: tag contains a restricted tag matching eks:eks-cluster-name
+                      rule: self.all(k, k !='eks:eks-cluster-name')
+                    - message: tag contains a restricted tag matching kubernetes.io/cluster/
+                      rule: self.all(k, !k.startsWith('kubernetes.io/cluster') )
+                    - message: tag contains a restricted tag matching karpenter.sh/nodepool
+                      rule: self.all(k, k != 'karpenter.sh/nodepool')
+                    - message: tag contains a restricted tag matching karpenter.sh/nodeclaim
+                      rule: self.all(k, k !='karpenter.sh/nodeclaim')
+                    - message: tag contains a restricted tag matching karpenter.k8s.aws/ec2nodeclass
+                      rule: self.all(k, k !='karpenter.k8s.aws/ec2nodeclass')
+                userData:
+                  description: |-
+                    UserData to be applied to the provisioned nodes.
+                    It must be in the appropriate format based on the AMIFamily in use. Karpenter will merge certain fields into
+                    this UserData to ensure nodes are being provisioned with the correct configuration.
+                  type: string
+              required:
+                - amiSelectorTerms
+                - securityGroupSelectorTerms
+                - subnetSelectorTerms
+              type: object
+              x-kubernetes-validations:
+                - message: must specify exactly one of ['role', 'instanceProfile']
+                  rule: (has(self.role) && !has(self.instanceProfile)) || (!has(self.role) && has(self.instanceProfile))
+                - message: changing from 'instanceProfile' to 'role' is not supported. You must delete and recreate this node class if you want to change this.
+                  rule: (has(oldSelf.role) && has(self.role)) || (has(oldSelf.instanceProfile) && has(self.instanceProfile))
+                - message: if set, amiFamily must be 'AL2' or 'Custom' when using an AL2 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''al2'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''AL2'') : true)'
+                - message: if set, amiFamily must be 'AL2023' or 'Custom' when using an AL2023 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''al2023'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''AL2023'') : true)'
+                - message: if set, amiFamily must be 'Bottlerocket' or 'Custom' when using a Bottlerocket alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''bottlerocket'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Bottlerocket'') : true)'
+                - message: if set, amiFamily must be 'Windows2019' or 'Custom' when using a Windows2019 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''windows2019'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Windows2019'') : true)'
+                - message: if set, amiFamily must be 'Windows2022' or 'Custom' when using a Windows2022 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''windows2022'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Windows2022'') : true)'
+                - message: must specify amiFamily if amiSelectorTerms does not contain an alias
+                  rule: 'self.amiSelectorTerms.exists(x, has(x.alias)) ? true : has(self.amiFamily)'
+            status:
+              description: EC2NodeClassStatus contains the resolved state of the EC2NodeClass
+              properties:
+                amis:
+                  description: |-
+                    AMI contains the current AMI values that are available to the
+                    cluster under the AMI selectors.
+                  items:
+                    description: AMI contains resolved AMI selector values utilized for node launch
+                    properties:
+                      deprecated:
+                        description: Deprecation status of the AMI
+                        type: boolean
+                      id:
+                        description: ID of the AMI
+                        type: string
+                      name:
+                        description: Name of the AMI
+                        type: string
+                      requirements:
+                        description: Requirements of the AMI to be utilized on an instance type
+                        items:
+                          description: |-
+                            A node selector requirement is a selector that contains values, a key, and an operator
+                            that relates the key and values.
+                          properties:
+                            key:
+                              description: The label key that the selector applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                Represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                              type: string
+                            values:
+                              description: |-
+                                An array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. If the operator is Gt or Lt, the values
+                                array must have a single element, which will be interpreted as an integer.
+                                This array is replaced during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                            - key
+                            - operator
+                          type: object
+                        type: array
+                    required:
+                      - id
+                      - requirements
+                    type: object
+                  type: array
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                instanceProfile:
+                  description: InstanceProfile contains the resolved instance profile for the role
+                  type: string
+                securityGroups:
+                  description: |-
+                    SecurityGroups contains the current security group values that are available to the
+                    cluster under the SecurityGroups selectors.
+                  items:
+                    description: SecurityGroup contains resolved SecurityGroup selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the security group
+                        type: string
+                      name:
+                        description: Name of the security group
+                        type: string
+                    required:
+                      - id
+                    type: object
+                  type: array
+                subnets:
+                  description: |-
+                    Subnets contains the current subnet values that are available to the
+                    cluster under the subnet selectors.
+                  items:
+                    description: Subnet contains resolved Subnet selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the subnet
+                        type: string
+                      zone:
+                        description: The associated availability zone
+                        type: string
+                      zoneID:
+                        description: The associated availability zone ID
+                        type: string
+                    required:
+                      - id
+                      - zone
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/content/projects/karpenter/v1.1.4/karpenter.sh_nodeclaims.yaml
+++ b/content/projects/karpenter/v1.1.4/karpenter.sh_nodeclaims.yaml
@@ -1,0 +1,391 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: nodeclaims.karpenter.sh
+spec:
+  group: karpenter.sh
+  names:
+    categories:
+      - karpenter
+    kind: NodeClaim
+    listKind: NodeClaimList
+    plural: nodeclaims
+    singular: nodeclaim
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.labels.node\.kubernetes\.io/instance-type
+          name: Type
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/capacity-type
+          name: Capacity
+          type: string
+        - jsonPath: .metadata.labels.topology\.kubernetes\.io/zone
+          name: Zone
+          type: string
+        - jsonPath: .status.nodeName
+          name: Node
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .status.providerID
+          name: ID
+          priority: 1
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/nodepool
+          name: NodePool
+          priority: 1
+          type: string
+        - jsonPath: .spec.nodeClassRef.name
+          name: NodeClass
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: NodeClaim is the Schema for the NodeClaims API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: NodeClaimSpec describes the desired state of the NodeClaim
+              properties:
+                expireAfter:
+                  default: 720h
+                  description: |-
+                    ExpireAfter is the duration the controller will wait
+                    before terminating a node, measured from when the node is created. This
+                    is useful to implement features like eventually consistent node upgrade,
+                    memory leak protection, and disruption testing.
+                  pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                  type: string
+                nodeClassRef:
+                  description: NodeClassRef is a reference to an object that defines provider specific configuration
+                  properties:
+                    group:
+                      description: API version of the referent
+                      pattern: ^[^/]*$
+                      type: string
+                      x-kubernetes-validations:
+                        - message: group may not be empty
+                          rule: self != ''
+                    kind:
+                      description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                      type: string
+                      x-kubernetes-validations:
+                        - message: kind may not be empty
+                          rule: self != ''
+                    name:
+                      description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                      type: string
+                      x-kubernetes-validations:
+                        - message: name may not be empty
+                          rule: self != ''
+                  required:
+                    - group
+                    - kind
+                    - name
+                  type: object
+                requirements:
+                  description: Requirements are layered with GetLabels and applied to every node.
+                  items:
+                    description: |-
+                      A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                      and minValues that represent the requirement to have at least that many values.
+                    properties:
+                      key:
+                        description: The label key that the selector applies to.
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                        x-kubernetes-validations:
+                          - message: label domain "kubernetes.io" is restricted
+                            rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                          - message: label domain "k8s.io" is restricted
+                            rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                          - message: label domain "karpenter.sh" is restricted
+                            rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                          - message: label "kubernetes.io/hostname" is restricted
+                            rule: self != "kubernetes.io/hostname"
+                          - message: label domain "karpenter.k8s.aws" is restricted
+                            rule: self in ["karpenter.k8s.aws/ec2nodeclass", "karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu", "karpenter.k8s.aws/instance-cpu-manufacturer", "karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz", "karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                      minValues:
+                        description: |-
+                          This field is ALPHA and can be dropped or replaced at any time
+                          MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                        maximum: 50
+                        minimum: 1
+                        type: integer
+                      operator:
+                        description: |-
+                          Represents a key's relationship to a set of values.
+                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                        type: string
+                        enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          - Gt
+                          - Lt
+                      values:
+                        description: |-
+                          An array of string values. If the operator is In or NotIn,
+                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                          the values array must be empty. If the operator is Gt or Lt, the values
+                          array must have a single element, which will be interpreted as an integer.
+                          This array is replaced during a strategic merge patch.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                        maxLength: 63
+                        pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                    required:
+                      - key
+                      - operator
+                    type: object
+                  maxItems: 100
+                  type: array
+                  x-kubernetes-validations:
+                    - message: requirements with operator 'In' must have a value defined
+                      rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                    - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                      rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                    - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                      rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                resources:
+                  description: Resources models the resource requirements for the NodeClaim to launch
+                  properties:
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: Requests describes the minimum required resources for the NodeClaim to launch
+                      type: object
+                  type: object
+                startupTaints:
+                  description: |-
+                    StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                    within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                    daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                    purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                taints:
+                  description: Taints will be applied to the NodeClaim's node.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                terminationGracePeriod:
+                  description: |-
+                    TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
+
+                    Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
+
+                    This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
+                    When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
+
+                    Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
+                    If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
+                    that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
+
+                    The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
+                    If left undefined, the controller will wait indefinitely for pods to be drained.
+                  pattern: ^([0-9]+(s|m|h))+$
+                  type: string
+              required:
+                - nodeClassRef
+                - requirements
+              type: object
+              x-kubernetes-validations:
+                - message: spec is immutable
+                  rule: self == oldSelf
+            status:
+              description: NodeClaimStatus defines the observed state of NodeClaim
+              properties:
+                allocatable:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Allocatable is the estimated allocatable capacity of the node
+                  type: object
+                capacity:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Capacity is the estimated full capacity of the node
+                  type: object
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        pattern: ^([A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?|)$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - status
+                      - type
+                    type: object
+                  type: array
+                imageID:
+                  description: ImageID is an identifier for the image that runs on the node
+                  type: string
+                lastPodEventTime:
+                  description: |-
+                    LastPodEventTime is updated with the last time a pod was scheduled
+                    or removed from the node. A pod going terminal or terminating
+                    is also considered as removed.
+                  format: date-time
+                  type: string
+                nodeName:
+                  description: NodeName is the name of the corresponding node object
+                  type: string
+                providerID:
+                  description: ProviderID of the corresponding node object
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/content/projects/karpenter/v1.1.4/karpenter.sh_nodepools.yaml
+++ b/content/projects/karpenter/v1.1.4/karpenter.sh_nodepools.yaml
@@ -1,0 +1,519 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: nodepools.karpenter.sh
+spec:
+  group: karpenter.sh
+  names:
+    categories:
+      - karpenter
+    kind: NodePool
+    listKind: NodePoolList
+    plural: nodepools
+    singular: nodepool
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.template.spec.nodeClassRef.name
+          name: NodeClass
+          type: string
+        - jsonPath: .status.resources.nodes
+          name: Nodes
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.weight
+          name: Weight
+          priority: 1
+          type: integer
+        - jsonPath: .status.resources.cpu
+          name: CPU
+          priority: 1
+          type: string
+        - jsonPath: .status.resources.memory
+          name: Memory
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: NodePool is the Schema for the NodePools API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                NodePoolSpec is the top level nodepool specification. Nodepools
+                launch nodes in response to pods that are unschedulable. A single nodepool
+                is capable of managing a diverse set of nodes. Node properties are determined
+                from a combination of nodepool and pod scheduling constraints.
+              properties:
+                disruption:
+                  default:
+                    consolidateAfter: 0s
+                  description: Disruption contains the parameters that relate to Karpenter's disruption logic
+                  properties:
+                    budgets:
+                      default:
+                        - nodes: 10%
+                      description: |-
+                        Budgets is a list of Budgets.
+                        If there are multiple active budgets, Karpenter uses
+                        the most restrictive value. If left undefined,
+                        this will default to one budget with a value to 10%.
+                      items:
+                        description: |-
+                          Budget defines when Karpenter will restrict the
+                          number of Node Claims that can be terminating simultaneously.
+                        properties:
+                          duration:
+                            description: |-
+                              Duration determines how long a Budget is active since each Schedule hit.
+                              Only minutes and hours are accepted, as cron does not work in seconds.
+                              If omitted, the budget is always active.
+                              This is required if Schedule is set.
+                              This regex has an optional 0s at the end since the duration.String() always adds
+                              a 0s at the end.
+                            pattern: ^((([0-9]+(h|m))|([0-9]+h[0-9]+m))(0s)?)$
+                            type: string
+                          nodes:
+                            default: 10%
+                            description: |-
+                              Nodes dictates the maximum number of NodeClaims owned by this NodePool
+                              that can be terminating at once. This is calculated by counting nodes that
+                              have a deletion timestamp set, or are actively being deleted by Karpenter.
+                              This field is required when specifying a budget.
+                              This cannot be of type intstr.IntOrString since kubebuilder doesn't support pattern
+                              checking for int nodes for IntOrString nodes.
+                              Ref: https://github.com/kubernetes-sigs/controller-tools/blob/55efe4be40394a288216dab63156b0a64fb82929/pkg/crd/markers/validation.go#L379-L388
+                            pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
+                            type: string
+                          reasons:
+                            description: |-
+                              Reasons is a list of disruption methods that this budget applies to. If Reasons is not set, this budget applies to all methods.
+                              Otherwise, this will apply to each reason defined.
+                              allowed reasons are Underutilized, Empty, and Drifted.
+                            items:
+                              description: DisruptionReason defines valid reasons for disruption budgets.
+                              enum:
+                                - Underutilized
+                                - Empty
+                                - Drifted
+                              type: string
+                            type: array
+                          schedule:
+                            description: |-
+                              Schedule specifies when a budget begins being active, following
+                              the upstream cronjob syntax. If omitted, the budget is always active.
+                              Timezones are not supported.
+                              This field is required if Duration is set.
+                            pattern: ^(@(annually|yearly|monthly|weekly|daily|midnight|hourly))|((.+)\s(.+)\s(.+)\s(.+)\s(.+))$
+                            type: string
+                        required:
+                          - nodes
+                        type: object
+                      maxItems: 50
+                      type: array
+                      x-kubernetes-validations:
+                        - message: '''schedule'' must be set with ''duration'''
+                          rule: self.all(x, has(x.schedule) == has(x.duration))
+                    consolidateAfter:
+                      description: |-
+                        ConsolidateAfter is the duration the controller will wait
+                        before attempting to terminate nodes that are underutilized.
+                        Refer to ConsolidationPolicy for how underutilization is considered.
+                      pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                      type: string
+                    consolidationPolicy:
+                      default: WhenEmptyOrUnderutilized
+                      description: |-
+                        ConsolidationPolicy describes which nodes Karpenter can disrupt through its consolidation
+                        algorithm. This policy defaults to "WhenEmptyOrUnderutilized" if not specified
+                      enum:
+                        - WhenEmpty
+                        - WhenEmptyOrUnderutilized
+                      type: string
+                  required:
+                    - consolidateAfter
+                  type: object
+                limits:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Limits define a set of bounds for provisioning capacity.
+                  type: object
+                template:
+                  description: |-
+                    Template contains the template of possibilities for the provisioning logic to launch a NodeClaim with.
+                    NodeClaims launched from this NodePool will often be further constrained than the template specifies.
+                  properties:
+                    metadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Annotations is an unstructured key value map stored with a resource that may be
+                            set by external tools to store and retrieve arbitrary metadata. They are not
+                            queryable and should be preserved when modifying objects.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                            maxLength: 63
+                            pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                          description: |-
+                            Map of string keys and values that can be used to organize and categorize
+                            (scope and select) objects. May match selectors of replication controllers
+                            and services.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
+                          type: object
+                          maxProperties: 100
+                          x-kubernetes-validations:
+                            - message: label domain "kubernetes.io" is restricted
+                              rule: self.all(x, x in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region",  "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || x.find("^([^/]+)").endsWith("node.kubernetes.io") || x.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !x.find("^([^/]+)").endsWith("kubernetes.io"))
+                            - message: label domain "k8s.io" is restricted
+                              rule: self.all(x, x.find("^([^/]+)").endsWith("kops.k8s.io") || !x.find("^([^/]+)").endsWith("k8s.io"))
+                            - message: label domain "karpenter.sh" is restricted
+                              rule: self.all(x, x in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !x.find("^([^/]+)").endsWith("karpenter.sh"))
+                            - message: label "karpenter.sh/nodepool" is restricted
+                              rule: self.all(x, x != "karpenter.sh/nodepool")
+                            - message: label "kubernetes.io/hostname" is restricted
+                              rule: self.all(x, x != "kubernetes.io/hostname")
+                            - message: label domain "karpenter.k8s.aws" is restricted
+                              rule: self.all(x, x in ["karpenter.k8s.aws/ec2nodeclass", "karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu", "karpenter.k8s.aws/instance-cpu-manufacturer", "karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz", "karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !x.find("^([^/]+)").endsWith("karpenter.k8s.aws"))
+                      type: object
+                    spec:
+                      description: |-
+                        NodeClaimTemplateSpec describes the desired state of the NodeClaim in the Nodepool
+                        NodeClaimTemplateSpec is used in the NodePool's NodeClaimTemplate, with the resource requests omitted since
+                        users are not able to set resource requests in the NodePool.
+                      properties:
+                        expireAfter:
+                          default: 720h
+                          description: |-
+                            ExpireAfter is the duration the controller will wait
+                            before terminating a node, measured from when the node is created. This
+                            is useful to implement features like eventually consistent node upgrade,
+                            memory leak protection, and disruption testing.
+                          pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                          type: string
+                        nodeClassRef:
+                          description: NodeClassRef is a reference to an object that defines provider specific configuration
+                          properties:
+                            group:
+                              description: API version of the referent
+                              pattern: ^[^/]*$
+                              type: string
+                              x-kubernetes-validations:
+                                - message: group may not be empty
+                                  rule: self != ''
+                            kind:
+                              description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                              type: string
+                              x-kubernetes-validations:
+                                - message: kind may not be empty
+                                  rule: self != ''
+                            name:
+                              description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                              x-kubernetes-validations:
+                                - message: name may not be empty
+                                  rule: self != ''
+                          required:
+                            - group
+                            - kind
+                            - name
+                          type: object
+                          x-kubernetes-validations:
+                            - message: nodeClassRef.group is immutable
+                              rule: self.group == oldSelf.group
+                            - message: nodeClassRef.kind is immutable
+                              rule: self.kind == oldSelf.kind
+                        requirements:
+                          description: Requirements are layered with GetLabels and applied to every node.
+                          items:
+                            description: |-
+                              A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                              and minValues that represent the requirement to have at least that many values.
+                            properties:
+                              key:
+                                description: The label key that the selector applies to.
+                                type: string
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                                x-kubernetes-validations:
+                                  - message: label domain "kubernetes.io" is restricted
+                                    rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                                  - message: label domain "k8s.io" is restricted
+                                    rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                                  - message: label domain "karpenter.sh" is restricted
+                                    rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                                  - message: label "karpenter.sh/nodepool" is restricted
+                                    rule: self != "karpenter.sh/nodepool"
+                                  - message: label "kubernetes.io/hostname" is restricted
+                                    rule: self != "kubernetes.io/hostname"
+                                  - message: label domain "karpenter.k8s.aws" is restricted
+                                    rule: self in ["karpenter.k8s.aws/ec2nodeclass", "karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu", "karpenter.k8s.aws/instance-cpu-manufacturer", "karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz", "karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                              minValues:
+                                description: |-
+                                  This field is ALPHA and can be dropped or replaced at any time
+                                  MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                                maximum: 50
+                                minimum: 1
+                                type: integer
+                              operator:
+                                description: |-
+                                  Represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                type: string
+                                enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  - Gt
+                                  - Lt
+                              values:
+                                description: |-
+                                  An array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                  array must have a single element, which will be interpreted as an integer.
+                                  This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          maxItems: 100
+                          type: array
+                          x-kubernetes-validations:
+                            - message: requirements with operator 'In' must have a value defined
+                              rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                            - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                              rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                            - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                              rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                        startupTaints:
+                          description: |-
+                            StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                            within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                            daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                            purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        taints:
+                          description: Taints will be applied to the NodeClaim's node.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        terminationGracePeriod:
+                          description: |-
+                            TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
+
+                            Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
+
+                            This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
+                            When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
+
+                            Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
+                            If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
+                            that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
+
+                            The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
+                            If left undefined, the controller will wait indefinitely for pods to be drained.
+                          pattern: ^([0-9]+(s|m|h))+$
+                          type: string
+                      required:
+                        - nodeClassRef
+                        - requirements
+                      type: object
+                  required:
+                    - spec
+                  type: object
+                weight:
+                  description: |-
+                    Weight is the priority given to the nodepool during scheduling. A higher
+                    numerical weight indicates that this nodepool will be ordered
+                    ahead of other nodepools with lower weights. A nodepool with no weight
+                    will be treated as if it is a nodepool with a weight of 0.
+                  format: int32
+                  maximum: 100
+                  minimum: 1
+                  type: integer
+              required:
+                - template
+              type: object
+            status:
+              description: NodePoolStatus defines the observed state of NodePool
+              properties:
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                resources:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Resources is the list of resources that have been provisioned.
+                  type: object
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/content/projects/karpenter/v1.1.5/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/content/projects/karpenter/v1.1.5/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -1,0 +1,742 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: ec2nodeclasses.karpenter.k8s.aws
+spec:
+  group: karpenter.k8s.aws
+  names:
+    categories:
+      - karpenter
+    kind: EC2NodeClass
+    listKind: EC2NodeClassList
+    plural: ec2nodeclasses
+    shortNames:
+      - ec2nc
+      - ec2ncs
+    singular: ec2nodeclass
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.role
+          name: Role
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: EC2NodeClass is the Schema for the EC2NodeClass API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                EC2NodeClassSpec is the top level specification for the AWS Karpenter Provider.
+                This will contain configuration necessary to launch instances in AWS.
+              properties:
+                amiFamily:
+                  description: |-
+                    AMIFamily dictates the UserData format and default BlockDeviceMappings used when generating launch templates.
+                    This field is optional when using an alias amiSelectorTerm, and the value will be inferred from the alias'
+                    family. When an alias is specified, this field may only be set to its corresponding family or 'Custom'. If no
+                    alias is specified, this field is required.
+                    NOTE: We ignore the AMIFamily for hashing here because we hash the AMIFamily dynamically by using the alias using
+                    the AMIFamily() helper function
+                  enum:
+                    - AL2
+                    - AL2023
+                    - Bottlerocket
+                    - Custom
+                    - Windows2019
+                    - Windows2022
+                  type: string
+                amiSelectorTerms:
+                  description: AMISelectorTerms is a list of or ami selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      AMISelectorTerm defines selection logic for an ami used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      alias:
+                        description: |-
+                          Alias specifies which EKS optimized AMI to select.
+                          Each alias consists of a family and an AMI version, specified as "family@version".
+                          Valid families include: al2, al2023, bottlerocket, windows2019, and windows2022.
+                          The version can either be pinned to a specific AMI release, with that AMIs version format (ex: "al2023@v20240625" or "bottlerocket@v1.10.0").
+                          The version can also be set to "latest" for any family. Setting the version to latest will result in drift when a new AMI is released. This is **not** recommended for production environments.
+                          Note: The Windows families do **not** support version pinning, and only latest may be used.
+                        maxLength: 30
+                        type: string
+                        x-kubernetes-validations:
+                          - message: '''alias'' is improperly formatted, must match the format ''family@version'''
+                            rule: self.matches('^[a-zA-Z0-9]+@.+$')
+                          - message: 'family is not supported, must be one of the following: ''al2'', ''al2023'', ''bottlerocket'', ''windows2019'', ''windows2022'''
+                            rule: self.split('@')[0] in ['al2','al2023','bottlerocket','windows2019','windows2022']
+                          - message: windows families may only specify version 'latest'
+                            rule: 'self.split(''@'')[0] in [''windows2019'',''windows2022''] ? self.split(''@'')[1] == ''latest'' : true'
+                      id:
+                        description: ID is the ami id in EC2
+                        pattern: ami-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the ami name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      owner:
+                        description: |-
+                          Owner is the owner for the ami.
+                          You can specify a combination of AWS account IDs, "self", "amazon", and "aws-marketplace"
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select amis.
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  minItems: 1
+                  type: array
+                  x-kubernetes-validations:
+                    - message: expected at least one, got none, ['tags', 'id', 'name', 'alias']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name) || has(x.alias))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.exists(x, has(x.id) && (has(x.alias) || has(x.tags) || has(x.name) || has(x.owner)))'
+                    - message: '''alias'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.exists(x, has(x.alias) && (has(x.id) || has(x.tags) || has(x.name) || has(x.owner)))'
+                    - message: '''alias'' is mutually exclusive, cannot be set with a combination of other amiSelectorTerms'
+                      rule: '!(self.exists(x, has(x.alias)) && self.size() != 1)'
+                associatePublicIPAddress:
+                  description: AssociatePublicIPAddress controls if public IP addresses are assigned to instances that are launched with the nodeclass.
+                  type: boolean
+                blockDeviceMappings:
+                  description: BlockDeviceMappings to be applied to provisioned nodes.
+                  items:
+                    properties:
+                      deviceName:
+                        description: The device name (for example, /dev/sdh or xvdh).
+                        type: string
+                      ebs:
+                        description: EBS contains parameters used to automatically set up EBS volumes when an instance is launched.
+                        properties:
+                          deleteOnTermination:
+                            description: DeleteOnTermination indicates whether the EBS volume is deleted on instance termination.
+                            type: boolean
+                          encrypted:
+                            description: |-
+                              Encrypted indicates whether the EBS volume is encrypted. Encrypted volumes can only
+                              be attached to instances that support Amazon EBS encryption. If you are creating
+                              a volume from a snapshot, you can't specify an encryption value.
+                            type: boolean
+                          iops:
+                            description: |-
+                              IOPS is the number of I/O operations per second (IOPS). For gp3, io1, and io2 volumes,
+                              this represents the number of IOPS that are provisioned for the volume. For
+                              gp2 volumes, this represents the baseline performance of the volume and the
+                              rate at which the volume accumulates I/O credits for bursting.
+
+                              The following are the supported values for each volume type:
+
+                                 * gp3: 3,000-16,000 IOPS
+
+                                 * io1: 100-64,000 IOPS
+
+                                 * io2: 100-64,000 IOPS
+
+                              For io1 and io2 volumes, we guarantee 64,000 IOPS only for Instances built
+                              on the Nitro System (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances).
+                              Other instance families guarantee performance up to 32,000 IOPS.
+
+                              This parameter is supported for io1, io2, and gp3 volumes only. This parameter
+                              is not supported for gp2, st1, sc1, or standard volumes.
+                            format: int64
+                            type: integer
+                          kmsKeyID:
+                            description: KMSKeyID (ARN) of the symmetric Key Management Service (KMS) CMK used for encryption.
+                            type: string
+                          snapshotID:
+                            description: SnapshotID is the ID of an EBS snapshot
+                            type: string
+                          throughput:
+                            description: |-
+                              Throughput to provision for a gp3 volume, with a maximum of 1,000 MiB/s.
+                              Valid Range: Minimum value of 125. Maximum value of 1000.
+                            format: int64
+                            type: integer
+                          volumeSize:
+                            description: |-
+                              VolumeSize in `Gi`, `G`, `Ti`, or `T`. You must specify either a snapshot ID or
+                              a volume size. The following are the supported volumes sizes for each volume
+                              type:
+
+                                 * gp2 and gp3: 1-16,384
+
+                                 * io1 and io2: 4-16,384
+
+                                 * st1 and sc1: 125-16,384
+
+                                 * standard: 1-1,024
+                            pattern: ^((?:[1-9][0-9]{0,3}|[1-4][0-9]{4}|[5][0-8][0-9]{3}|59000)Gi|(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|[6][0-3][0-9]{3}|64000)G|([1-9]||[1-5][0-7]|58)Ti|([1-9]||[1-5][0-9]|6[0-3]|64)T)$
+                            type: string
+                          volumeType:
+                            description: |-
+                              VolumeType of the block device.
+                              For more information, see Amazon EBS volume types (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html)
+                              in the Amazon Elastic Compute Cloud User Guide.
+                            enum:
+                              - standard
+                              - io1
+                              - io2
+                              - gp2
+                              - sc1
+                              - st1
+                              - gp3
+                            type: string
+                        type: object
+                        x-kubernetes-validations:
+                          - message: snapshotID or volumeSize must be defined
+                            rule: has(self.snapshotID) || has(self.volumeSize)
+                      rootVolume:
+                        description: |-
+                          RootVolume is a flag indicating if this device is mounted as kubelet root dir. You can
+                          configure at most one root volume in BlockDeviceMappings.
+                        type: boolean
+                    type: object
+                  maxItems: 50
+                  type: array
+                  x-kubernetes-validations:
+                    - message: must have only one blockDeviceMappings with rootVolume
+                      rule: self.filter(x, has(x.rootVolume)?x.rootVolume==true:false).size() <= 1
+                context:
+                  description: |-
+                    Context is a Reserved field in EC2 APIs
+                    https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet.html
+                  type: string
+                detailedMonitoring:
+                  description: DetailedMonitoring controls if detailed monitoring is enabled for instances that are launched
+                  type: boolean
+                instanceProfile:
+                  description: |-
+                    InstanceProfile is the AWS entity that instances use.
+                    This field is mutually exclusive from role.
+                    The instance profile should already have a role assigned to it that Karpenter
+                     has PassRole permission on for instance launch using this instanceProfile to succeed.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: instanceProfile cannot be empty
+                      rule: self != ''
+                instanceStorePolicy:
+                  description: InstanceStorePolicy specifies how to handle instance-store disks.
+                  enum:
+                    - RAID0
+                  type: string
+                kubelet:
+                  description: |-
+                    Kubelet defines args to be used when configuring kubelet on provisioned nodes.
+                    They are a subset of the upstream types, recognizing not all options may be supported.
+                    Wherever possible, the types and names should reflect the upstream kubelet types.
+                  properties:
+                    clusterDNS:
+                      description: |-
+                        clusterDNS is a list of IP addresses for the cluster DNS server.
+                        Note that not all providers may use all addresses.
+                      items:
+                        type: string
+                      type: array
+                    cpuCFSQuota:
+                      description: CPUCFSQuota enables CPU CFS quota enforcement for containers that specify CPU limits.
+                      type: boolean
+                    evictionHard:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionHard is the map of signal names to quantities that define hard eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionHard are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionMaxPodGracePeriod:
+                      description: |-
+                        EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in
+                        response to soft eviction thresholds being met.
+                      format: int32
+                      type: integer
+                    evictionSoft:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionSoft is the map of signal names to quantities that define soft eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoft are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionSoftGracePeriod:
+                      additionalProperties:
+                        type: string
+                      description: EvictionSoftGracePeriod is the map of signal names to quantities that define grace periods for each eviction signal
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoftGracePeriod are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    imageGCHighThresholdPercent:
+                      description: |-
+                        ImageGCHighThresholdPercent is the percent of disk usage after which image
+                        garbage collection is always run. The percent is calculated by dividing this
+                        field value by 100, so this field must be between 0 and 100, inclusive.
+                        When specified, the value must be greater than ImageGCLowThresholdPercent.
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    imageGCLowThresholdPercent:
+                      description: |-
+                        ImageGCLowThresholdPercent is the percent of disk usage before which image
+                        garbage collection is never run. Lowest disk usage to garbage collect to.
+                        The percent is calculated by dividing this field value by 100,
+                        so the field value must be between 0 and 100, inclusive.
+                        When specified, the value must be less than imageGCHighThresholdPercent
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    kubeReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: KubeReserved contains resources reserved for Kubernetes system components.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for kubeReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: kubeReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                    maxPods:
+                      description: |-
+                        MaxPods is an override for the maximum number of pods that can run on
+                        a worker node instance.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    podsPerCore:
+                      description: |-
+                        PodsPerCore is an override for the number of pods that can run on a worker node
+                        instance based on the number of cpu cores. This value cannot exceed MaxPods, so, if
+                        MaxPods is a lower value, that value will be used.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    systemReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: SystemReserved contains resources reserved for OS system daemons and kernel memory.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for systemReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: systemReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                  type: object
+                  x-kubernetes-validations:
+                    - message: imageGCHighThresholdPercent must be greater than imageGCLowThresholdPercent
+                      rule: 'has(self.imageGCHighThresholdPercent) && has(self.imageGCLowThresholdPercent) ?  self.imageGCHighThresholdPercent > self.imageGCLowThresholdPercent  : true'
+                    - message: evictionSoft OwnerKey does not have a matching evictionSoftGracePeriod
+                      rule: has(self.evictionSoft) ? self.evictionSoft.all(e, (e in self.evictionSoftGracePeriod)):true
+                    - message: evictionSoftGracePeriod OwnerKey does not have a matching evictionSoft
+                      rule: has(self.evictionSoftGracePeriod) ? self.evictionSoftGracePeriod.all(e, (e in self.evictionSoft)):true
+                metadataOptions:
+                  default:
+                    httpEndpoint: enabled
+                    httpProtocolIPv6: disabled
+                    httpPutResponseHopLimit: 1
+                    httpTokens: required
+                  description: |-
+                    MetadataOptions for the generated launch template of provisioned nodes.
+
+                    This specifies the exposure of the Instance Metadata Service to
+                    provisioned EC2 nodes. For more information,
+                    see Instance Metadata and User Data
+                    (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
+                    in the Amazon Elastic Compute Cloud User Guide.
+
+                    Refer to recommended, security best practices
+                    (https://aws.github.io/aws-eks-best-practices/security/docs/iam/#restrict-access-to-the-instance-profile-assigned-to-the-worker-node)
+                    for limiting exposure of Instance Metadata and User Data to pods.
+                    If omitted, defaults to httpEndpoint enabled, with httpProtocolIPv6
+                    disabled, with httpPutResponseLimit of 1, and with httpTokens
+                    required.
+                  properties:
+                    httpEndpoint:
+                      default: enabled
+                      description: |-
+                        HTTPEndpoint enables or disables the HTTP metadata endpoint on provisioned
+                        nodes. If metadata options is non-nil, but this parameter is not specified,
+                        the default state is "enabled".
+
+                        If you specify a value of "disabled", instance metadata will not be accessible
+                        on the node.
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpProtocolIPv6:
+                      default: disabled
+                      description: |-
+                        HTTPProtocolIPv6 enables or disables the IPv6 endpoint for the instance metadata
+                        service on provisioned nodes. If metadata options is non-nil, but this parameter
+                        is not specified, the default state is "disabled".
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpPutResponseHopLimit:
+                      default: 1
+                      description: |-
+                        HTTPPutResponseHopLimit is the desired HTTP PUT response hop limit for
+                        instance metadata requests. The larger the number, the further instance
+                        metadata requests can travel. Possible values are integers from 1 to 64.
+                        If metadata options is non-nil, but this parameter is not specified, the
+                        default value is 1.
+                      format: int64
+                      maximum: 64
+                      minimum: 1
+                      type: integer
+                    httpTokens:
+                      default: required
+                      description: |-
+                        HTTPTokens determines the state of token usage for instance metadata
+                        requests. If metadata options is non-nil, but this parameter is not
+                        specified, the default state is "required".
+
+                        If the state is optional, one can choose to retrieve instance metadata with
+                        or without a signed token header on the request. If one retrieves the IAM
+                        role credentials without a token, the version 1.0 role credentials are
+                        returned. If one retrieves the IAM role credentials using a valid signed
+                        token, the version 2.0 role credentials are returned.
+
+                        If the state is "required", one must send a signed token header with any
+                        instance metadata retrieval requests. In this state, retrieving the IAM
+                        role credentials always returns the version 2.0 credentials; the version
+                        1.0 credentials are not available.
+                      enum:
+                        - required
+                        - optional
+                      type: string
+                  type: object
+                role:
+                  description: |-
+                    Role is the AWS identity that nodes use. This field is immutable.
+                    This field is mutually exclusive from instanceProfile.
+                    Marking this field as immutable avoids concerns around terminating managed instance profiles from running instances.
+                    This field may be made mutable in the future, assuming the correct garbage collection and drift handling is implemented
+                    for the old instance profiles on an update.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: role cannot be empty
+                      rule: self != ''
+                    - message: immutable field changed
+                      rule: self == oldSelf
+                securityGroupSelectorTerms:
+                  description: SecurityGroupSelectorTerms is a list of or security group selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SecurityGroupSelectorTerm defines selection logic for a security group used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the security group id in EC2
+                        pattern: sg-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the security group name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select security groups.
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: securityGroupSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id', 'name']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && (has(x.tags) || has(x.name)))'
+                    - message: '''name'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.name) && (has(x.tags) || has(x.id)))'
+                subnetSelectorTerms:
+                  description: SubnetSelectorTerms is a list of or subnet selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SubnetSelectorTerm defines selection logic for a subnet used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the subnet id in EC2
+                        pattern: subnet-[0-9a-z]+
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: subnetSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id']
+                      rule: self.all(x, has(x.tags) || has(x.id))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in subnetSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && has(x.tags))'
+                tags:
+                  additionalProperties:
+                    type: string
+                  description: Tags to be applied on ec2 resources like instances and launch templates.
+                  type: object
+                  x-kubernetes-validations:
+                    - message: empty tag keys aren't supported
+                      rule: self.all(k, k != '')
+                    - message: tag contains a restricted tag matching eks:eks-cluster-name
+                      rule: self.all(k, k !='eks:eks-cluster-name')
+                    - message: tag contains a restricted tag matching kubernetes.io/cluster/
+                      rule: self.all(k, !k.startsWith('kubernetes.io/cluster') )
+                    - message: tag contains a restricted tag matching karpenter.sh/nodepool
+                      rule: self.all(k, k != 'karpenter.sh/nodepool')
+                    - message: tag contains a restricted tag matching karpenter.sh/nodeclaim
+                      rule: self.all(k, k !='karpenter.sh/nodeclaim')
+                    - message: tag contains a restricted tag matching karpenter.k8s.aws/ec2nodeclass
+                      rule: self.all(k, k !='karpenter.k8s.aws/ec2nodeclass')
+                userData:
+                  description: |-
+                    UserData to be applied to the provisioned nodes.
+                    It must be in the appropriate format based on the AMIFamily in use. Karpenter will merge certain fields into
+                    this UserData to ensure nodes are being provisioned with the correct configuration.
+                  type: string
+              required:
+                - amiSelectorTerms
+                - securityGroupSelectorTerms
+                - subnetSelectorTerms
+              type: object
+              x-kubernetes-validations:
+                - message: must specify exactly one of ['role', 'instanceProfile']
+                  rule: (has(self.role) && !has(self.instanceProfile)) || (!has(self.role) && has(self.instanceProfile))
+                - message: changing from 'instanceProfile' to 'role' is not supported. You must delete and recreate this node class if you want to change this.
+                  rule: (has(oldSelf.role) && has(self.role)) || (has(oldSelf.instanceProfile) && has(self.instanceProfile))
+                - message: if set, amiFamily must be 'AL2' or 'Custom' when using an AL2 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''al2'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''AL2'') : true)'
+                - message: if set, amiFamily must be 'AL2023' or 'Custom' when using an AL2023 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''al2023'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''AL2023'') : true)'
+                - message: if set, amiFamily must be 'Bottlerocket' or 'Custom' when using a Bottlerocket alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''bottlerocket'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Bottlerocket'') : true)'
+                - message: if set, amiFamily must be 'Windows2019' or 'Custom' when using a Windows2019 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''windows2019'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Windows2019'') : true)'
+                - message: if set, amiFamily must be 'Windows2022' or 'Custom' when using a Windows2022 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''windows2022'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Windows2022'') : true)'
+                - message: must specify amiFamily if amiSelectorTerms does not contain an alias
+                  rule: 'self.amiSelectorTerms.exists(x, has(x.alias)) ? true : has(self.amiFamily)'
+            status:
+              description: EC2NodeClassStatus contains the resolved state of the EC2NodeClass
+              properties:
+                amis:
+                  description: |-
+                    AMI contains the current AMI values that are available to the
+                    cluster under the AMI selectors.
+                  items:
+                    description: AMI contains resolved AMI selector values utilized for node launch
+                    properties:
+                      deprecated:
+                        description: Deprecation status of the AMI
+                        type: boolean
+                      id:
+                        description: ID of the AMI
+                        type: string
+                      name:
+                        description: Name of the AMI
+                        type: string
+                      requirements:
+                        description: Requirements of the AMI to be utilized on an instance type
+                        items:
+                          description: |-
+                            A node selector requirement is a selector that contains values, a key, and an operator
+                            that relates the key and values.
+                          properties:
+                            key:
+                              description: The label key that the selector applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                Represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                              type: string
+                            values:
+                              description: |-
+                                An array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. If the operator is Gt or Lt, the values
+                                array must have a single element, which will be interpreted as an integer.
+                                This array is replaced during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                            - key
+                            - operator
+                          type: object
+                        type: array
+                    required:
+                      - id
+                      - requirements
+                    type: object
+                  type: array
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                instanceProfile:
+                  description: InstanceProfile contains the resolved instance profile for the role
+                  type: string
+                securityGroups:
+                  description: |-
+                    SecurityGroups contains the current security group values that are available to the
+                    cluster under the SecurityGroups selectors.
+                  items:
+                    description: SecurityGroup contains resolved SecurityGroup selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the security group
+                        type: string
+                      name:
+                        description: Name of the security group
+                        type: string
+                    required:
+                      - id
+                    type: object
+                  type: array
+                subnets:
+                  description: |-
+                    Subnets contains the current subnet values that are available to the
+                    cluster under the subnet selectors.
+                  items:
+                    description: Subnet contains resolved Subnet selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the subnet
+                        type: string
+                      zone:
+                        description: The associated availability zone
+                        type: string
+                      zoneID:
+                        description: The associated availability zone ID
+                        type: string
+                    required:
+                      - id
+                      - zone
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/content/projects/karpenter/v1.1.5/karpenter.sh_nodeclaims.yaml
+++ b/content/projects/karpenter/v1.1.5/karpenter.sh_nodeclaims.yaml
@@ -1,0 +1,391 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: nodeclaims.karpenter.sh
+spec:
+  group: karpenter.sh
+  names:
+    categories:
+      - karpenter
+    kind: NodeClaim
+    listKind: NodeClaimList
+    plural: nodeclaims
+    singular: nodeclaim
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.labels.node\.kubernetes\.io/instance-type
+          name: Type
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/capacity-type
+          name: Capacity
+          type: string
+        - jsonPath: .metadata.labels.topology\.kubernetes\.io/zone
+          name: Zone
+          type: string
+        - jsonPath: .status.nodeName
+          name: Node
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .status.providerID
+          name: ID
+          priority: 1
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/nodepool
+          name: NodePool
+          priority: 1
+          type: string
+        - jsonPath: .spec.nodeClassRef.name
+          name: NodeClass
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: NodeClaim is the Schema for the NodeClaims API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: NodeClaimSpec describes the desired state of the NodeClaim
+              properties:
+                expireAfter:
+                  default: 720h
+                  description: |-
+                    ExpireAfter is the duration the controller will wait
+                    before terminating a node, measured from when the node is created. This
+                    is useful to implement features like eventually consistent node upgrade,
+                    memory leak protection, and disruption testing.
+                  pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                  type: string
+                nodeClassRef:
+                  description: NodeClassRef is a reference to an object that defines provider specific configuration
+                  properties:
+                    group:
+                      description: API version of the referent
+                      pattern: ^[^/]*$
+                      type: string
+                      x-kubernetes-validations:
+                        - message: group may not be empty
+                          rule: self != ''
+                    kind:
+                      description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                      type: string
+                      x-kubernetes-validations:
+                        - message: kind may not be empty
+                          rule: self != ''
+                    name:
+                      description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                      type: string
+                      x-kubernetes-validations:
+                        - message: name may not be empty
+                          rule: self != ''
+                  required:
+                    - group
+                    - kind
+                    - name
+                  type: object
+                requirements:
+                  description: Requirements are layered with GetLabels and applied to every node.
+                  items:
+                    description: |-
+                      A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                      and minValues that represent the requirement to have at least that many values.
+                    properties:
+                      key:
+                        description: The label key that the selector applies to.
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                        x-kubernetes-validations:
+                          - message: label domain "kubernetes.io" is restricted
+                            rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                          - message: label domain "k8s.io" is restricted
+                            rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                          - message: label domain "karpenter.sh" is restricted
+                            rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                          - message: label "kubernetes.io/hostname" is restricted
+                            rule: self != "kubernetes.io/hostname"
+                          - message: label domain "karpenter.k8s.aws" is restricted
+                            rule: self in ["karpenter.k8s.aws/ec2nodeclass", "karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu", "karpenter.k8s.aws/instance-cpu-manufacturer", "karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz", "karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                      minValues:
+                        description: |-
+                          This field is ALPHA and can be dropped or replaced at any time
+                          MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                        maximum: 50
+                        minimum: 1
+                        type: integer
+                      operator:
+                        description: |-
+                          Represents a key's relationship to a set of values.
+                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                        type: string
+                        enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          - Gt
+                          - Lt
+                      values:
+                        description: |-
+                          An array of string values. If the operator is In or NotIn,
+                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                          the values array must be empty. If the operator is Gt or Lt, the values
+                          array must have a single element, which will be interpreted as an integer.
+                          This array is replaced during a strategic merge patch.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                        maxLength: 63
+                        pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                    required:
+                      - key
+                      - operator
+                    type: object
+                  maxItems: 100
+                  type: array
+                  x-kubernetes-validations:
+                    - message: requirements with operator 'In' must have a value defined
+                      rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                    - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                      rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                    - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                      rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                resources:
+                  description: Resources models the resource requirements for the NodeClaim to launch
+                  properties:
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: Requests describes the minimum required resources for the NodeClaim to launch
+                      type: object
+                  type: object
+                startupTaints:
+                  description: |-
+                    StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                    within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                    daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                    purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                taints:
+                  description: Taints will be applied to the NodeClaim's node.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                terminationGracePeriod:
+                  description: |-
+                    TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
+
+                    Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
+
+                    This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
+                    When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
+
+                    Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
+                    If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
+                    that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
+
+                    The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
+                    If left undefined, the controller will wait indefinitely for pods to be drained.
+                  pattern: ^([0-9]+(s|m|h))+$
+                  type: string
+              required:
+                - nodeClassRef
+                - requirements
+              type: object
+              x-kubernetes-validations:
+                - message: spec is immutable
+                  rule: self == oldSelf
+            status:
+              description: NodeClaimStatus defines the observed state of NodeClaim
+              properties:
+                allocatable:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Allocatable is the estimated allocatable capacity of the node
+                  type: object
+                capacity:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Capacity is the estimated full capacity of the node
+                  type: object
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        pattern: ^([A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?|)$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - status
+                      - type
+                    type: object
+                  type: array
+                imageID:
+                  description: ImageID is an identifier for the image that runs on the node
+                  type: string
+                lastPodEventTime:
+                  description: |-
+                    LastPodEventTime is updated with the last time a pod was scheduled
+                    or removed from the node. A pod going terminal or terminating
+                    is also considered as removed.
+                  format: date-time
+                  type: string
+                nodeName:
+                  description: NodeName is the name of the corresponding node object
+                  type: string
+                providerID:
+                  description: ProviderID of the corresponding node object
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/content/projects/karpenter/v1.1.5/karpenter.sh_nodepools.yaml
+++ b/content/projects/karpenter/v1.1.5/karpenter.sh_nodepools.yaml
@@ -1,0 +1,519 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: nodepools.karpenter.sh
+spec:
+  group: karpenter.sh
+  names:
+    categories:
+      - karpenter
+    kind: NodePool
+    listKind: NodePoolList
+    plural: nodepools
+    singular: nodepool
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.template.spec.nodeClassRef.name
+          name: NodeClass
+          type: string
+        - jsonPath: .status.resources.nodes
+          name: Nodes
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.weight
+          name: Weight
+          priority: 1
+          type: integer
+        - jsonPath: .status.resources.cpu
+          name: CPU
+          priority: 1
+          type: string
+        - jsonPath: .status.resources.memory
+          name: Memory
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: NodePool is the Schema for the NodePools API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                NodePoolSpec is the top level nodepool specification. Nodepools
+                launch nodes in response to pods that are unschedulable. A single nodepool
+                is capable of managing a diverse set of nodes. Node properties are determined
+                from a combination of nodepool and pod scheduling constraints.
+              properties:
+                disruption:
+                  default:
+                    consolidateAfter: 0s
+                  description: Disruption contains the parameters that relate to Karpenter's disruption logic
+                  properties:
+                    budgets:
+                      default:
+                        - nodes: 10%
+                      description: |-
+                        Budgets is a list of Budgets.
+                        If there are multiple active budgets, Karpenter uses
+                        the most restrictive value. If left undefined,
+                        this will default to one budget with a value to 10%.
+                      items:
+                        description: |-
+                          Budget defines when Karpenter will restrict the
+                          number of Node Claims that can be terminating simultaneously.
+                        properties:
+                          duration:
+                            description: |-
+                              Duration determines how long a Budget is active since each Schedule hit.
+                              Only minutes and hours are accepted, as cron does not work in seconds.
+                              If omitted, the budget is always active.
+                              This is required if Schedule is set.
+                              This regex has an optional 0s at the end since the duration.String() always adds
+                              a 0s at the end.
+                            pattern: ^((([0-9]+(h|m))|([0-9]+h[0-9]+m))(0s)?)$
+                            type: string
+                          nodes:
+                            default: 10%
+                            description: |-
+                              Nodes dictates the maximum number of NodeClaims owned by this NodePool
+                              that can be terminating at once. This is calculated by counting nodes that
+                              have a deletion timestamp set, or are actively being deleted by Karpenter.
+                              This field is required when specifying a budget.
+                              This cannot be of type intstr.IntOrString since kubebuilder doesn't support pattern
+                              checking for int nodes for IntOrString nodes.
+                              Ref: https://github.com/kubernetes-sigs/controller-tools/blob/55efe4be40394a288216dab63156b0a64fb82929/pkg/crd/markers/validation.go#L379-L388
+                            pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
+                            type: string
+                          reasons:
+                            description: |-
+                              Reasons is a list of disruption methods that this budget applies to. If Reasons is not set, this budget applies to all methods.
+                              Otherwise, this will apply to each reason defined.
+                              allowed reasons are Underutilized, Empty, and Drifted.
+                            items:
+                              description: DisruptionReason defines valid reasons for disruption budgets.
+                              enum:
+                                - Underutilized
+                                - Empty
+                                - Drifted
+                              type: string
+                            type: array
+                          schedule:
+                            description: |-
+                              Schedule specifies when a budget begins being active, following
+                              the upstream cronjob syntax. If omitted, the budget is always active.
+                              Timezones are not supported.
+                              This field is required if Duration is set.
+                            pattern: ^(@(annually|yearly|monthly|weekly|daily|midnight|hourly))|((.+)\s(.+)\s(.+)\s(.+)\s(.+))$
+                            type: string
+                        required:
+                          - nodes
+                        type: object
+                      maxItems: 50
+                      type: array
+                      x-kubernetes-validations:
+                        - message: '''schedule'' must be set with ''duration'''
+                          rule: self.all(x, has(x.schedule) == has(x.duration))
+                    consolidateAfter:
+                      description: |-
+                        ConsolidateAfter is the duration the controller will wait
+                        before attempting to terminate nodes that are underutilized.
+                        Refer to ConsolidationPolicy for how underutilization is considered.
+                      pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                      type: string
+                    consolidationPolicy:
+                      default: WhenEmptyOrUnderutilized
+                      description: |-
+                        ConsolidationPolicy describes which nodes Karpenter can disrupt through its consolidation
+                        algorithm. This policy defaults to "WhenEmptyOrUnderutilized" if not specified
+                      enum:
+                        - WhenEmpty
+                        - WhenEmptyOrUnderutilized
+                      type: string
+                  required:
+                    - consolidateAfter
+                  type: object
+                limits:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Limits define a set of bounds for provisioning capacity.
+                  type: object
+                template:
+                  description: |-
+                    Template contains the template of possibilities for the provisioning logic to launch a NodeClaim with.
+                    NodeClaims launched from this NodePool will often be further constrained than the template specifies.
+                  properties:
+                    metadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Annotations is an unstructured key value map stored with a resource that may be
+                            set by external tools to store and retrieve arbitrary metadata. They are not
+                            queryable and should be preserved when modifying objects.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                            maxLength: 63
+                            pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                          description: |-
+                            Map of string keys and values that can be used to organize and categorize
+                            (scope and select) objects. May match selectors of replication controllers
+                            and services.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
+                          type: object
+                          maxProperties: 100
+                          x-kubernetes-validations:
+                            - message: label domain "kubernetes.io" is restricted
+                              rule: self.all(x, x in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region",  "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || x.find("^([^/]+)").endsWith("node.kubernetes.io") || x.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !x.find("^([^/]+)").endsWith("kubernetes.io"))
+                            - message: label domain "k8s.io" is restricted
+                              rule: self.all(x, x.find("^([^/]+)").endsWith("kops.k8s.io") || !x.find("^([^/]+)").endsWith("k8s.io"))
+                            - message: label domain "karpenter.sh" is restricted
+                              rule: self.all(x, x in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !x.find("^([^/]+)").endsWith("karpenter.sh"))
+                            - message: label "karpenter.sh/nodepool" is restricted
+                              rule: self.all(x, x != "karpenter.sh/nodepool")
+                            - message: label "kubernetes.io/hostname" is restricted
+                              rule: self.all(x, x != "kubernetes.io/hostname")
+                            - message: label domain "karpenter.k8s.aws" is restricted
+                              rule: self.all(x, x in ["karpenter.k8s.aws/ec2nodeclass", "karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu", "karpenter.k8s.aws/instance-cpu-manufacturer", "karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz", "karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !x.find("^([^/]+)").endsWith("karpenter.k8s.aws"))
+                      type: object
+                    spec:
+                      description: |-
+                        NodeClaimTemplateSpec describes the desired state of the NodeClaim in the Nodepool
+                        NodeClaimTemplateSpec is used in the NodePool's NodeClaimTemplate, with the resource requests omitted since
+                        users are not able to set resource requests in the NodePool.
+                      properties:
+                        expireAfter:
+                          default: 720h
+                          description: |-
+                            ExpireAfter is the duration the controller will wait
+                            before terminating a node, measured from when the node is created. This
+                            is useful to implement features like eventually consistent node upgrade,
+                            memory leak protection, and disruption testing.
+                          pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                          type: string
+                        nodeClassRef:
+                          description: NodeClassRef is a reference to an object that defines provider specific configuration
+                          properties:
+                            group:
+                              description: API version of the referent
+                              pattern: ^[^/]*$
+                              type: string
+                              x-kubernetes-validations:
+                                - message: group may not be empty
+                                  rule: self != ''
+                            kind:
+                              description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                              type: string
+                              x-kubernetes-validations:
+                                - message: kind may not be empty
+                                  rule: self != ''
+                            name:
+                              description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                              x-kubernetes-validations:
+                                - message: name may not be empty
+                                  rule: self != ''
+                          required:
+                            - group
+                            - kind
+                            - name
+                          type: object
+                          x-kubernetes-validations:
+                            - message: nodeClassRef.group is immutable
+                              rule: self.group == oldSelf.group
+                            - message: nodeClassRef.kind is immutable
+                              rule: self.kind == oldSelf.kind
+                        requirements:
+                          description: Requirements are layered with GetLabels and applied to every node.
+                          items:
+                            description: |-
+                              A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                              and minValues that represent the requirement to have at least that many values.
+                            properties:
+                              key:
+                                description: The label key that the selector applies to.
+                                type: string
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                                x-kubernetes-validations:
+                                  - message: label domain "kubernetes.io" is restricted
+                                    rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                                  - message: label domain "k8s.io" is restricted
+                                    rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                                  - message: label domain "karpenter.sh" is restricted
+                                    rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                                  - message: label "karpenter.sh/nodepool" is restricted
+                                    rule: self != "karpenter.sh/nodepool"
+                                  - message: label "kubernetes.io/hostname" is restricted
+                                    rule: self != "kubernetes.io/hostname"
+                                  - message: label domain "karpenter.k8s.aws" is restricted
+                                    rule: self in ["karpenter.k8s.aws/ec2nodeclass", "karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu", "karpenter.k8s.aws/instance-cpu-manufacturer", "karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz", "karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                              minValues:
+                                description: |-
+                                  This field is ALPHA and can be dropped or replaced at any time
+                                  MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                                maximum: 50
+                                minimum: 1
+                                type: integer
+                              operator:
+                                description: |-
+                                  Represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                type: string
+                                enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  - Gt
+                                  - Lt
+                              values:
+                                description: |-
+                                  An array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                  array must have a single element, which will be interpreted as an integer.
+                                  This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          maxItems: 100
+                          type: array
+                          x-kubernetes-validations:
+                            - message: requirements with operator 'In' must have a value defined
+                              rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                            - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                              rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                            - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                              rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                        startupTaints:
+                          description: |-
+                            StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                            within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                            daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                            purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        taints:
+                          description: Taints will be applied to the NodeClaim's node.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        terminationGracePeriod:
+                          description: |-
+                            TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
+
+                            Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
+
+                            This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
+                            When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
+
+                            Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
+                            If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
+                            that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
+
+                            The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
+                            If left undefined, the controller will wait indefinitely for pods to be drained.
+                          pattern: ^([0-9]+(s|m|h))+$
+                          type: string
+                      required:
+                        - nodeClassRef
+                        - requirements
+                      type: object
+                  required:
+                    - spec
+                  type: object
+                weight:
+                  description: |-
+                    Weight is the priority given to the nodepool during scheduling. A higher
+                    numerical weight indicates that this nodepool will be ordered
+                    ahead of other nodepools with lower weights. A nodepool with no weight
+                    will be treated as if it is a nodepool with a weight of 0.
+                  format: int32
+                  maximum: 100
+                  minimum: 1
+                  type: integer
+              required:
+                - template
+              type: object
+            status:
+              description: NodePoolStatus defines the observed state of NodePool
+              properties:
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                resources:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Resources is the list of resources that have been provisioned.
+                  type: object
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/content/projects/karpenter/v1.2.0/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/content/projects/karpenter/v1.2.0/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -1,0 +1,742 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  name: ec2nodeclasses.karpenter.k8s.aws
+spec:
+  group: karpenter.k8s.aws
+  names:
+    categories:
+      - karpenter
+    kind: EC2NodeClass
+    listKind: EC2NodeClassList
+    plural: ec2nodeclasses
+    shortNames:
+      - ec2nc
+      - ec2ncs
+    singular: ec2nodeclass
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.role
+          name: Role
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: EC2NodeClass is the Schema for the EC2NodeClass API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                EC2NodeClassSpec is the top level specification for the AWS Karpenter Provider.
+                This will contain configuration necessary to launch instances in AWS.
+              properties:
+                amiFamily:
+                  description: |-
+                    AMIFamily dictates the UserData format and default BlockDeviceMappings used when generating launch templates.
+                    This field is optional when using an alias amiSelectorTerm, and the value will be inferred from the alias'
+                    family. When an alias is specified, this field may only be set to its corresponding family or 'Custom'. If no
+                    alias is specified, this field is required.
+                    NOTE: We ignore the AMIFamily for hashing here because we hash the AMIFamily dynamically by using the alias using
+                    the AMIFamily() helper function
+                  enum:
+                    - AL2
+                    - AL2023
+                    - Bottlerocket
+                    - Custom
+                    - Windows2019
+                    - Windows2022
+                  type: string
+                amiSelectorTerms:
+                  description: AMISelectorTerms is a list of or ami selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      AMISelectorTerm defines selection logic for an ami used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      alias:
+                        description: |-
+                          Alias specifies which EKS optimized AMI to select.
+                          Each alias consists of a family and an AMI version, specified as "family@version".
+                          Valid families include: al2, al2023, bottlerocket, windows2019, and windows2022.
+                          The version can either be pinned to a specific AMI release, with that AMIs version format (ex: "al2023@v20240625" or "bottlerocket@v1.10.0").
+                          The version can also be set to "latest" for any family. Setting the version to latest will result in drift when a new AMI is released. This is **not** recommended for production environments.
+                          Note: The Windows families do **not** support version pinning, and only latest may be used.
+                        maxLength: 30
+                        type: string
+                        x-kubernetes-validations:
+                          - message: '''alias'' is improperly formatted, must match the format ''family@version'''
+                            rule: self.matches('^[a-zA-Z0-9]+@.+$')
+                          - message: 'family is not supported, must be one of the following: ''al2'', ''al2023'', ''bottlerocket'', ''windows2019'', ''windows2022'''
+                            rule: self.split('@')[0] in ['al2','al2023','bottlerocket','windows2019','windows2022']
+                          - message: windows families may only specify version 'latest'
+                            rule: 'self.split(''@'')[0] in [''windows2019'',''windows2022''] ? self.split(''@'')[1] == ''latest'' : true'
+                      id:
+                        description: ID is the ami id in EC2
+                        pattern: ami-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the ami name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      owner:
+                        description: |-
+                          Owner is the owner for the ami.
+                          You can specify a combination of AWS account IDs, "self", "amazon", and "aws-marketplace"
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select amis.
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  minItems: 1
+                  type: array
+                  x-kubernetes-validations:
+                    - message: expected at least one, got none, ['tags', 'id', 'name', 'alias']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name) || has(x.alias))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.exists(x, has(x.id) && (has(x.alias) || has(x.tags) || has(x.name) || has(x.owner)))'
+                    - message: '''alias'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.exists(x, has(x.alias) && (has(x.id) || has(x.tags) || has(x.name) || has(x.owner)))'
+                    - message: '''alias'' is mutually exclusive, cannot be set with a combination of other amiSelectorTerms'
+                      rule: '!(self.exists(x, has(x.alias)) && self.size() != 1)'
+                associatePublicIPAddress:
+                  description: AssociatePublicIPAddress controls if public IP addresses are assigned to instances that are launched with the nodeclass.
+                  type: boolean
+                blockDeviceMappings:
+                  description: BlockDeviceMappings to be applied to provisioned nodes.
+                  items:
+                    properties:
+                      deviceName:
+                        description: The device name (for example, /dev/sdh or xvdh).
+                        type: string
+                      ebs:
+                        description: EBS contains parameters used to automatically set up EBS volumes when an instance is launched.
+                        properties:
+                          deleteOnTermination:
+                            description: DeleteOnTermination indicates whether the EBS volume is deleted on instance termination.
+                            type: boolean
+                          encrypted:
+                            description: |-
+                              Encrypted indicates whether the EBS volume is encrypted. Encrypted volumes can only
+                              be attached to instances that support Amazon EBS encryption. If you are creating
+                              a volume from a snapshot, you can't specify an encryption value.
+                            type: boolean
+                          iops:
+                            description: |-
+                              IOPS is the number of I/O operations per second (IOPS). For gp3, io1, and io2 volumes,
+                              this represents the number of IOPS that are provisioned for the volume. For
+                              gp2 volumes, this represents the baseline performance of the volume and the
+                              rate at which the volume accumulates I/O credits for bursting.
+
+                              The following are the supported values for each volume type:
+
+                                 * gp3: 3,000-16,000 IOPS
+
+                                 * io1: 100-64,000 IOPS
+
+                                 * io2: 100-64,000 IOPS
+
+                              For io1 and io2 volumes, we guarantee 64,000 IOPS only for Instances built
+                              on the Nitro System (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances).
+                              Other instance families guarantee performance up to 32,000 IOPS.
+
+                              This parameter is supported for io1, io2, and gp3 volumes only. This parameter
+                              is not supported for gp2, st1, sc1, or standard volumes.
+                            format: int64
+                            type: integer
+                          kmsKeyID:
+                            description: KMSKeyID (ARN) of the symmetric Key Management Service (KMS) CMK used for encryption.
+                            type: string
+                          snapshotID:
+                            description: SnapshotID is the ID of an EBS snapshot
+                            type: string
+                          throughput:
+                            description: |-
+                              Throughput to provision for a gp3 volume, with a maximum of 1,000 MiB/s.
+                              Valid Range: Minimum value of 125. Maximum value of 1000.
+                            format: int64
+                            type: integer
+                          volumeSize:
+                            description: |-
+                              VolumeSize in `Gi`, `G`, `Ti`, or `T`. You must specify either a snapshot ID or
+                              a volume size. The following are the supported volumes sizes for each volume
+                              type:
+
+                                 * gp2 and gp3: 1-16,384
+
+                                 * io1 and io2: 4-16,384
+
+                                 * st1 and sc1: 125-16,384
+
+                                 * standard: 1-1,024
+                            pattern: ^((?:[1-9][0-9]{0,3}|[1-4][0-9]{4}|[5][0-8][0-9]{3}|59000)Gi|(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|[6][0-3][0-9]{3}|64000)G|([1-9]||[1-5][0-7]|58)Ti|([1-9]||[1-5][0-9]|6[0-3]|64)T)$
+                            type: string
+                          volumeType:
+                            description: |-
+                              VolumeType of the block device.
+                              For more information, see Amazon EBS volume types (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html)
+                              in the Amazon Elastic Compute Cloud User Guide.
+                            enum:
+                              - standard
+                              - io1
+                              - io2
+                              - gp2
+                              - sc1
+                              - st1
+                              - gp3
+                            type: string
+                        type: object
+                        x-kubernetes-validations:
+                          - message: snapshotID or volumeSize must be defined
+                            rule: has(self.snapshotID) || has(self.volumeSize)
+                      rootVolume:
+                        description: |-
+                          RootVolume is a flag indicating if this device is mounted as kubelet root dir. You can
+                          configure at most one root volume in BlockDeviceMappings.
+                        type: boolean
+                    type: object
+                  maxItems: 50
+                  type: array
+                  x-kubernetes-validations:
+                    - message: must have only one blockDeviceMappings with rootVolume
+                      rule: self.filter(x, has(x.rootVolume)?x.rootVolume==true:false).size() <= 1
+                context:
+                  description: |-
+                    Context is a Reserved field in EC2 APIs
+                    https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet.html
+                  type: string
+                detailedMonitoring:
+                  description: DetailedMonitoring controls if detailed monitoring is enabled for instances that are launched
+                  type: boolean
+                instanceProfile:
+                  description: |-
+                    InstanceProfile is the AWS entity that instances use.
+                    This field is mutually exclusive from role.
+                    The instance profile should already have a role assigned to it that Karpenter
+                     has PassRole permission on for instance launch using this instanceProfile to succeed.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: instanceProfile cannot be empty
+                      rule: self != ''
+                instanceStorePolicy:
+                  description: InstanceStorePolicy specifies how to handle instance-store disks.
+                  enum:
+                    - RAID0
+                  type: string
+                kubelet:
+                  description: |-
+                    Kubelet defines args to be used when configuring kubelet on provisioned nodes.
+                    They are a subset of the upstream types, recognizing not all options may be supported.
+                    Wherever possible, the types and names should reflect the upstream kubelet types.
+                  properties:
+                    clusterDNS:
+                      description: |-
+                        clusterDNS is a list of IP addresses for the cluster DNS server.
+                        Note that not all providers may use all addresses.
+                      items:
+                        type: string
+                      type: array
+                    cpuCFSQuota:
+                      description: CPUCFSQuota enables CPU CFS quota enforcement for containers that specify CPU limits.
+                      type: boolean
+                    evictionHard:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionHard is the map of signal names to quantities that define hard eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionHard are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionMaxPodGracePeriod:
+                      description: |-
+                        EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in
+                        response to soft eviction thresholds being met.
+                      format: int32
+                      type: integer
+                    evictionSoft:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionSoft is the map of signal names to quantities that define soft eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoft are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionSoftGracePeriod:
+                      additionalProperties:
+                        type: string
+                      description: EvictionSoftGracePeriod is the map of signal names to quantities that define grace periods for each eviction signal
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoftGracePeriod are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    imageGCHighThresholdPercent:
+                      description: |-
+                        ImageGCHighThresholdPercent is the percent of disk usage after which image
+                        garbage collection is always run. The percent is calculated by dividing this
+                        field value by 100, so this field must be between 0 and 100, inclusive.
+                        When specified, the value must be greater than ImageGCLowThresholdPercent.
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    imageGCLowThresholdPercent:
+                      description: |-
+                        ImageGCLowThresholdPercent is the percent of disk usage before which image
+                        garbage collection is never run. Lowest disk usage to garbage collect to.
+                        The percent is calculated by dividing this field value by 100,
+                        so the field value must be between 0 and 100, inclusive.
+                        When specified, the value must be less than imageGCHighThresholdPercent
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    kubeReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: KubeReserved contains resources reserved for Kubernetes system components.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for kubeReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: kubeReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                    maxPods:
+                      description: |-
+                        MaxPods is an override for the maximum number of pods that can run on
+                        a worker node instance.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    podsPerCore:
+                      description: |-
+                        PodsPerCore is an override for the number of pods that can run on a worker node
+                        instance based on the number of cpu cores. This value cannot exceed MaxPods, so, if
+                        MaxPods is a lower value, that value will be used.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    systemReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: SystemReserved contains resources reserved for OS system daemons and kernel memory.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for systemReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: systemReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                  type: object
+                  x-kubernetes-validations:
+                    - message: imageGCHighThresholdPercent must be greater than imageGCLowThresholdPercent
+                      rule: 'has(self.imageGCHighThresholdPercent) && has(self.imageGCLowThresholdPercent) ?  self.imageGCHighThresholdPercent > self.imageGCLowThresholdPercent  : true'
+                    - message: evictionSoft OwnerKey does not have a matching evictionSoftGracePeriod
+                      rule: has(self.evictionSoft) ? self.evictionSoft.all(e, (e in self.evictionSoftGracePeriod)):true
+                    - message: evictionSoftGracePeriod OwnerKey does not have a matching evictionSoft
+                      rule: has(self.evictionSoftGracePeriod) ? self.evictionSoftGracePeriod.all(e, (e in self.evictionSoft)):true
+                metadataOptions:
+                  default:
+                    httpEndpoint: enabled
+                    httpProtocolIPv6: disabled
+                    httpPutResponseHopLimit: 1
+                    httpTokens: required
+                  description: |-
+                    MetadataOptions for the generated launch template of provisioned nodes.
+
+                    This specifies the exposure of the Instance Metadata Service to
+                    provisioned EC2 nodes. For more information,
+                    see Instance Metadata and User Data
+                    (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
+                    in the Amazon Elastic Compute Cloud User Guide.
+
+                    Refer to recommended, security best practices
+                    (https://aws.github.io/aws-eks-best-practices/security/docs/iam/#restrict-access-to-the-instance-profile-assigned-to-the-worker-node)
+                    for limiting exposure of Instance Metadata and User Data to pods.
+                    If omitted, defaults to httpEndpoint enabled, with httpProtocolIPv6
+                    disabled, with httpPutResponseLimit of 1, and with httpTokens
+                    required.
+                  properties:
+                    httpEndpoint:
+                      default: enabled
+                      description: |-
+                        HTTPEndpoint enables or disables the HTTP metadata endpoint on provisioned
+                        nodes. If metadata options is non-nil, but this parameter is not specified,
+                        the default state is "enabled".
+
+                        If you specify a value of "disabled", instance metadata will not be accessible
+                        on the node.
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpProtocolIPv6:
+                      default: disabled
+                      description: |-
+                        HTTPProtocolIPv6 enables or disables the IPv6 endpoint for the instance metadata
+                        service on provisioned nodes. If metadata options is non-nil, but this parameter
+                        is not specified, the default state is "disabled".
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpPutResponseHopLimit:
+                      default: 1
+                      description: |-
+                        HTTPPutResponseHopLimit is the desired HTTP PUT response hop limit for
+                        instance metadata requests. The larger the number, the further instance
+                        metadata requests can travel. Possible values are integers from 1 to 64.
+                        If metadata options is non-nil, but this parameter is not specified, the
+                        default value is 1.
+                      format: int64
+                      maximum: 64
+                      minimum: 1
+                      type: integer
+                    httpTokens:
+                      default: required
+                      description: |-
+                        HTTPTokens determines the state of token usage for instance metadata
+                        requests. If metadata options is non-nil, but this parameter is not
+                        specified, the default state is "required".
+
+                        If the state is optional, one can choose to retrieve instance metadata with
+                        or without a signed token header on the request. If one retrieves the IAM
+                        role credentials without a token, the version 1.0 role credentials are
+                        returned. If one retrieves the IAM role credentials using a valid signed
+                        token, the version 2.0 role credentials are returned.
+
+                        If the state is "required", one must send a signed token header with any
+                        instance metadata retrieval requests. In this state, retrieving the IAM
+                        role credentials always returns the version 2.0 credentials; the version
+                        1.0 credentials are not available.
+                      enum:
+                        - required
+                        - optional
+                      type: string
+                  type: object
+                role:
+                  description: |-
+                    Role is the AWS identity that nodes use. This field is immutable.
+                    This field is mutually exclusive from instanceProfile.
+                    Marking this field as immutable avoids concerns around terminating managed instance profiles from running instances.
+                    This field may be made mutable in the future, assuming the correct garbage collection and drift handling is implemented
+                    for the old instance profiles on an update.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: role cannot be empty
+                      rule: self != ''
+                    - message: immutable field changed
+                      rule: self == oldSelf
+                securityGroupSelectorTerms:
+                  description: SecurityGroupSelectorTerms is a list of or security group selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SecurityGroupSelectorTerm defines selection logic for a security group used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the security group id in EC2
+                        pattern: sg-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the security group name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select security groups.
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: securityGroupSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id', 'name']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && (has(x.tags) || has(x.name)))'
+                    - message: '''name'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.name) && (has(x.tags) || has(x.id)))'
+                subnetSelectorTerms:
+                  description: SubnetSelectorTerms is a list of or subnet selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SubnetSelectorTerm defines selection logic for a subnet used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the subnet id in EC2
+                        pattern: subnet-[0-9a-z]+
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: subnetSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id']
+                      rule: self.all(x, has(x.tags) || has(x.id))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in subnetSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && has(x.tags))'
+                tags:
+                  additionalProperties:
+                    type: string
+                  description: Tags to be applied on ec2 resources like instances and launch templates.
+                  type: object
+                  x-kubernetes-validations:
+                    - message: empty tag keys aren't supported
+                      rule: self.all(k, k != '')
+                    - message: tag contains a restricted tag matching eks:eks-cluster-name
+                      rule: self.all(k, k !='eks:eks-cluster-name')
+                    - message: tag contains a restricted tag matching kubernetes.io/cluster/
+                      rule: self.all(k, !k.startsWith('kubernetes.io/cluster') )
+                    - message: tag contains a restricted tag matching karpenter.sh/nodepool
+                      rule: self.all(k, k != 'karpenter.sh/nodepool')
+                    - message: tag contains a restricted tag matching karpenter.sh/nodeclaim
+                      rule: self.all(k, k !='karpenter.sh/nodeclaim')
+                    - message: tag contains a restricted tag matching karpenter.k8s.aws/ec2nodeclass
+                      rule: self.all(k, k !='karpenter.k8s.aws/ec2nodeclass')
+                userData:
+                  description: |-
+                    UserData to be applied to the provisioned nodes.
+                    It must be in the appropriate format based on the AMIFamily in use. Karpenter will merge certain fields into
+                    this UserData to ensure nodes are being provisioned with the correct configuration.
+                  type: string
+              required:
+                - amiSelectorTerms
+                - securityGroupSelectorTerms
+                - subnetSelectorTerms
+              type: object
+              x-kubernetes-validations:
+                - message: must specify exactly one of ['role', 'instanceProfile']
+                  rule: (has(self.role) && !has(self.instanceProfile)) || (!has(self.role) && has(self.instanceProfile))
+                - message: changing from 'instanceProfile' to 'role' is not supported. You must delete and recreate this node class if you want to change this.
+                  rule: (has(oldSelf.role) && has(self.role)) || (has(oldSelf.instanceProfile) && has(self.instanceProfile))
+                - message: if set, amiFamily must be 'AL2' or 'Custom' when using an AL2 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''al2'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''AL2'') : true)'
+                - message: if set, amiFamily must be 'AL2023' or 'Custom' when using an AL2023 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''al2023'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''AL2023'') : true)'
+                - message: if set, amiFamily must be 'Bottlerocket' or 'Custom' when using a Bottlerocket alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''bottlerocket'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Bottlerocket'') : true)'
+                - message: if set, amiFamily must be 'Windows2019' or 'Custom' when using a Windows2019 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''windows2019'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Windows2019'') : true)'
+                - message: if set, amiFamily must be 'Windows2022' or 'Custom' when using a Windows2022 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''windows2022'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Windows2022'') : true)'
+                - message: must specify amiFamily if amiSelectorTerms does not contain an alias
+                  rule: 'self.amiSelectorTerms.exists(x, has(x.alias)) ? true : has(self.amiFamily)'
+            status:
+              description: EC2NodeClassStatus contains the resolved state of the EC2NodeClass
+              properties:
+                amis:
+                  description: |-
+                    AMI contains the current AMI values that are available to the
+                    cluster under the AMI selectors.
+                  items:
+                    description: AMI contains resolved AMI selector values utilized for node launch
+                    properties:
+                      deprecated:
+                        description: Deprecation status of the AMI
+                        type: boolean
+                      id:
+                        description: ID of the AMI
+                        type: string
+                      name:
+                        description: Name of the AMI
+                        type: string
+                      requirements:
+                        description: Requirements of the AMI to be utilized on an instance type
+                        items:
+                          description: |-
+                            A node selector requirement is a selector that contains values, a key, and an operator
+                            that relates the key and values.
+                          properties:
+                            key:
+                              description: The label key that the selector applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                Represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                              type: string
+                            values:
+                              description: |-
+                                An array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. If the operator is Gt or Lt, the values
+                                array must have a single element, which will be interpreted as an integer.
+                                This array is replaced during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                            - key
+                            - operator
+                          type: object
+                        type: array
+                    required:
+                      - id
+                      - requirements
+                    type: object
+                  type: array
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                instanceProfile:
+                  description: InstanceProfile contains the resolved instance profile for the role
+                  type: string
+                securityGroups:
+                  description: |-
+                    SecurityGroups contains the current security group values that are available to the
+                    cluster under the SecurityGroups selectors.
+                  items:
+                    description: SecurityGroup contains resolved SecurityGroup selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the security group
+                        type: string
+                      name:
+                        description: Name of the security group
+                        type: string
+                    required:
+                      - id
+                    type: object
+                  type: array
+                subnets:
+                  description: |-
+                    Subnets contains the current subnet values that are available to the
+                    cluster under the subnet selectors.
+                  items:
+                    description: Subnet contains resolved Subnet selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the subnet
+                        type: string
+                      zone:
+                        description: The associated availability zone
+                        type: string
+                      zoneID:
+                        description: The associated availability zone ID
+                        type: string
+                    required:
+                      - id
+                      - zone
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/content/projects/karpenter/v1.2.0/karpenter.sh_nodeclaims.yaml
+++ b/content/projects/karpenter/v1.2.0/karpenter.sh_nodeclaims.yaml
@@ -1,0 +1,395 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  name: nodeclaims.karpenter.sh
+spec:
+  group: karpenter.sh
+  names:
+    categories:
+      - karpenter
+    kind: NodeClaim
+    listKind: NodeClaimList
+    plural: nodeclaims
+    singular: nodeclaim
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.labels.node\.kubernetes\.io/instance-type
+          name: Type
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/capacity-type
+          name: Capacity
+          type: string
+        - jsonPath: .metadata.labels.topology\.kubernetes\.io/zone
+          name: Zone
+          type: string
+        - jsonPath: .status.nodeName
+          name: Node
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .status.imageID
+          name: ImageID
+          priority: 1
+          type: string
+        - jsonPath: .status.providerID
+          name: ID
+          priority: 1
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/nodepool
+          name: NodePool
+          priority: 1
+          type: string
+        - jsonPath: .spec.nodeClassRef.name
+          name: NodeClass
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: NodeClaim is the Schema for the NodeClaims API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: NodeClaimSpec describes the desired state of the NodeClaim
+              properties:
+                expireAfter:
+                  default: 720h
+                  description: |-
+                    ExpireAfter is the duration the controller will wait
+                    before terminating a node, measured from when the node is created. This
+                    is useful to implement features like eventually consistent node upgrade,
+                    memory leak protection, and disruption testing.
+                  pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                  type: string
+                nodeClassRef:
+                  description: NodeClassRef is a reference to an object that defines provider specific configuration
+                  properties:
+                    group:
+                      description: API version of the referent
+                      pattern: ^[^/]*$
+                      type: string
+                      x-kubernetes-validations:
+                        - message: group may not be empty
+                          rule: self != ''
+                    kind:
+                      description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                      type: string
+                      x-kubernetes-validations:
+                        - message: kind may not be empty
+                          rule: self != ''
+                    name:
+                      description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                      type: string
+                      x-kubernetes-validations:
+                        - message: name may not be empty
+                          rule: self != ''
+                  required:
+                    - group
+                    - kind
+                    - name
+                  type: object
+                requirements:
+                  description: Requirements are layered with GetLabels and applied to every node.
+                  items:
+                    description: |-
+                      A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                      and minValues that represent the requirement to have at least that many values.
+                    properties:
+                      key:
+                        description: The label key that the selector applies to.
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                        x-kubernetes-validations:
+                          - message: label domain "kubernetes.io" is restricted
+                            rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                          - message: label domain "k8s.io" is restricted
+                            rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                          - message: label domain "karpenter.sh" is restricted
+                            rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                          - message: label "kubernetes.io/hostname" is restricted
+                            rule: self != "kubernetes.io/hostname"
+                          - message: label domain "karpenter.k8s.aws" is restricted
+                            rule: self in ["karpenter.k8s.aws/ec2nodeclass", "karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu", "karpenter.k8s.aws/instance-cpu-manufacturer", "karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz", "karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                      minValues:
+                        description: |-
+                          This field is ALPHA and can be dropped or replaced at any time
+                          MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                        maximum: 50
+                        minimum: 1
+                        type: integer
+                      operator:
+                        description: |-
+                          Represents a key's relationship to a set of values.
+                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                        type: string
+                        enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          - Gt
+                          - Lt
+                      values:
+                        description: |-
+                          An array of string values. If the operator is In or NotIn,
+                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                          the values array must be empty. If the operator is Gt or Lt, the values
+                          array must have a single element, which will be interpreted as an integer.
+                          This array is replaced during a strategic merge patch.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                        maxLength: 63
+                        pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                    required:
+                      - key
+                      - operator
+                    type: object
+                  maxItems: 100
+                  type: array
+                  x-kubernetes-validations:
+                    - message: requirements with operator 'In' must have a value defined
+                      rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                    - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                      rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                    - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                      rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                resources:
+                  description: Resources models the resource requirements for the NodeClaim to launch
+                  properties:
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: Requests describes the minimum required resources for the NodeClaim to launch
+                      type: object
+                  type: object
+                startupTaints:
+                  description: |-
+                    StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                    within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                    daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                    purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                taints:
+                  description: Taints will be applied to the NodeClaim's node.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                terminationGracePeriod:
+                  description: |-
+                    TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
+
+                    Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
+
+                    This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
+                    When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
+
+                    Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
+                    If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
+                    that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
+
+                    The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
+                    If left undefined, the controller will wait indefinitely for pods to be drained.
+                  pattern: ^([0-9]+(s|m|h))+$
+                  type: string
+              required:
+                - nodeClassRef
+                - requirements
+              type: object
+              x-kubernetes-validations:
+                - message: spec is immutable
+                  rule: self == oldSelf
+            status:
+              description: NodeClaimStatus defines the observed state of NodeClaim
+              properties:
+                allocatable:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Allocatable is the estimated allocatable capacity of the node
+                  type: object
+                capacity:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Capacity is the estimated full capacity of the node
+                  type: object
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        pattern: ^([A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?|)$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - status
+                      - type
+                    type: object
+                  type: array
+                imageID:
+                  description: ImageID is an identifier for the image that runs on the node
+                  type: string
+                lastPodEventTime:
+                  description: |-
+                    LastPodEventTime is updated with the last time a pod was scheduled
+                    or removed from the node. A pod going terminal or terminating
+                    is also considered as removed.
+                  format: date-time
+                  type: string
+                nodeName:
+                  description: NodeName is the name of the corresponding node object
+                  type: string
+                providerID:
+                  description: ProviderID of the corresponding node object
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/content/projects/karpenter/v1.2.0/karpenter.sh_nodepools.yaml
+++ b/content/projects/karpenter/v1.2.0/karpenter.sh_nodepools.yaml
@@ -1,0 +1,519 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  name: nodepools.karpenter.sh
+spec:
+  group: karpenter.sh
+  names:
+    categories:
+      - karpenter
+    kind: NodePool
+    listKind: NodePoolList
+    plural: nodepools
+    singular: nodepool
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.template.spec.nodeClassRef.name
+          name: NodeClass
+          type: string
+        - jsonPath: .status.resources.nodes
+          name: Nodes
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.weight
+          name: Weight
+          priority: 1
+          type: integer
+        - jsonPath: .status.resources.cpu
+          name: CPU
+          priority: 1
+          type: string
+        - jsonPath: .status.resources.memory
+          name: Memory
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: NodePool is the Schema for the NodePools API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                NodePoolSpec is the top level nodepool specification. Nodepools
+                launch nodes in response to pods that are unschedulable. A single nodepool
+                is capable of managing a diverse set of nodes. Node properties are determined
+                from a combination of nodepool and pod scheduling constraints.
+              properties:
+                disruption:
+                  default:
+                    consolidateAfter: 0s
+                  description: Disruption contains the parameters that relate to Karpenter's disruption logic
+                  properties:
+                    budgets:
+                      default:
+                        - nodes: 10%
+                      description: |-
+                        Budgets is a list of Budgets.
+                        If there are multiple active budgets, Karpenter uses
+                        the most restrictive value. If left undefined,
+                        this will default to one budget with a value to 10%.
+                      items:
+                        description: |-
+                          Budget defines when Karpenter will restrict the
+                          number of Node Claims that can be terminating simultaneously.
+                        properties:
+                          duration:
+                            description: |-
+                              Duration determines how long a Budget is active since each Schedule hit.
+                              Only minutes and hours are accepted, as cron does not work in seconds.
+                              If omitted, the budget is always active.
+                              This is required if Schedule is set.
+                              This regex has an optional 0s at the end since the duration.String() always adds
+                              a 0s at the end.
+                            pattern: ^((([0-9]+(h|m))|([0-9]+h[0-9]+m))(0s)?)$
+                            type: string
+                          nodes:
+                            default: 10%
+                            description: |-
+                              Nodes dictates the maximum number of NodeClaims owned by this NodePool
+                              that can be terminating at once. This is calculated by counting nodes that
+                              have a deletion timestamp set, or are actively being deleted by Karpenter.
+                              This field is required when specifying a budget.
+                              This cannot be of type intstr.IntOrString since kubebuilder doesn't support pattern
+                              checking for int nodes for IntOrString nodes.
+                              Ref: https://github.com/kubernetes-sigs/controller-tools/blob/55efe4be40394a288216dab63156b0a64fb82929/pkg/crd/markers/validation.go#L379-L388
+                            pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
+                            type: string
+                          reasons:
+                            description: |-
+                              Reasons is a list of disruption methods that this budget applies to. If Reasons is not set, this budget applies to all methods.
+                              Otherwise, this will apply to each reason defined.
+                              allowed reasons are Underutilized, Empty, and Drifted.
+                            items:
+                              description: DisruptionReason defines valid reasons for disruption budgets.
+                              enum:
+                                - Underutilized
+                                - Empty
+                                - Drifted
+                              type: string
+                            type: array
+                          schedule:
+                            description: |-
+                              Schedule specifies when a budget begins being active, following
+                              the upstream cronjob syntax. If omitted, the budget is always active.
+                              Timezones are not supported.
+                              This field is required if Duration is set.
+                            pattern: ^(@(annually|yearly|monthly|weekly|daily|midnight|hourly))|((.+)\s(.+)\s(.+)\s(.+)\s(.+))$
+                            type: string
+                        required:
+                          - nodes
+                        type: object
+                      maxItems: 50
+                      type: array
+                      x-kubernetes-validations:
+                        - message: '''schedule'' must be set with ''duration'''
+                          rule: self.all(x, has(x.schedule) == has(x.duration))
+                    consolidateAfter:
+                      description: |-
+                        ConsolidateAfter is the duration the controller will wait
+                        before attempting to terminate nodes that are underutilized.
+                        Refer to ConsolidationPolicy for how underutilization is considered.
+                      pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                      type: string
+                    consolidationPolicy:
+                      default: WhenEmptyOrUnderutilized
+                      description: |-
+                        ConsolidationPolicy describes which nodes Karpenter can disrupt through its consolidation
+                        algorithm. This policy defaults to "WhenEmptyOrUnderutilized" if not specified
+                      enum:
+                        - WhenEmpty
+                        - WhenEmptyOrUnderutilized
+                      type: string
+                  required:
+                    - consolidateAfter
+                  type: object
+                limits:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Limits define a set of bounds for provisioning capacity.
+                  type: object
+                template:
+                  description: |-
+                    Template contains the template of possibilities for the provisioning logic to launch a NodeClaim with.
+                    NodeClaims launched from this NodePool will often be further constrained than the template specifies.
+                  properties:
+                    metadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Annotations is an unstructured key value map stored with a resource that may be
+                            set by external tools to store and retrieve arbitrary metadata. They are not
+                            queryable and should be preserved when modifying objects.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                            maxLength: 63
+                            pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                          description: |-
+                            Map of string keys and values that can be used to organize and categorize
+                            (scope and select) objects. May match selectors of replication controllers
+                            and services.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
+                          type: object
+                          maxProperties: 100
+                          x-kubernetes-validations:
+                            - message: label domain "kubernetes.io" is restricted
+                              rule: self.all(x, x in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region",  "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || x.find("^([^/]+)").endsWith("node.kubernetes.io") || x.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !x.find("^([^/]+)").endsWith("kubernetes.io"))
+                            - message: label domain "k8s.io" is restricted
+                              rule: self.all(x, x.find("^([^/]+)").endsWith("kops.k8s.io") || !x.find("^([^/]+)").endsWith("k8s.io"))
+                            - message: label domain "karpenter.sh" is restricted
+                              rule: self.all(x, x in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !x.find("^([^/]+)").endsWith("karpenter.sh"))
+                            - message: label "karpenter.sh/nodepool" is restricted
+                              rule: self.all(x, x != "karpenter.sh/nodepool")
+                            - message: label "kubernetes.io/hostname" is restricted
+                              rule: self.all(x, x != "kubernetes.io/hostname")
+                            - message: label domain "karpenter.k8s.aws" is restricted
+                              rule: self.all(x, x in ["karpenter.k8s.aws/ec2nodeclass", "karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu", "karpenter.k8s.aws/instance-cpu-manufacturer", "karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz", "karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !x.find("^([^/]+)").endsWith("karpenter.k8s.aws"))
+                      type: object
+                    spec:
+                      description: |-
+                        NodeClaimTemplateSpec describes the desired state of the NodeClaim in the Nodepool
+                        NodeClaimTemplateSpec is used in the NodePool's NodeClaimTemplate, with the resource requests omitted since
+                        users are not able to set resource requests in the NodePool.
+                      properties:
+                        expireAfter:
+                          default: 720h
+                          description: |-
+                            ExpireAfter is the duration the controller will wait
+                            before terminating a node, measured from when the node is created. This
+                            is useful to implement features like eventually consistent node upgrade,
+                            memory leak protection, and disruption testing.
+                          pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                          type: string
+                        nodeClassRef:
+                          description: NodeClassRef is a reference to an object that defines provider specific configuration
+                          properties:
+                            group:
+                              description: API version of the referent
+                              pattern: ^[^/]*$
+                              type: string
+                              x-kubernetes-validations:
+                                - message: group may not be empty
+                                  rule: self != ''
+                            kind:
+                              description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                              type: string
+                              x-kubernetes-validations:
+                                - message: kind may not be empty
+                                  rule: self != ''
+                            name:
+                              description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                              x-kubernetes-validations:
+                                - message: name may not be empty
+                                  rule: self != ''
+                          required:
+                            - group
+                            - kind
+                            - name
+                          type: object
+                          x-kubernetes-validations:
+                            - message: nodeClassRef.group is immutable
+                              rule: self.group == oldSelf.group
+                            - message: nodeClassRef.kind is immutable
+                              rule: self.kind == oldSelf.kind
+                        requirements:
+                          description: Requirements are layered with GetLabels and applied to every node.
+                          items:
+                            description: |-
+                              A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                              and minValues that represent the requirement to have at least that many values.
+                            properties:
+                              key:
+                                description: The label key that the selector applies to.
+                                type: string
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                                x-kubernetes-validations:
+                                  - message: label domain "kubernetes.io" is restricted
+                                    rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                                  - message: label domain "k8s.io" is restricted
+                                    rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                                  - message: label domain "karpenter.sh" is restricted
+                                    rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                                  - message: label "karpenter.sh/nodepool" is restricted
+                                    rule: self != "karpenter.sh/nodepool"
+                                  - message: label "kubernetes.io/hostname" is restricted
+                                    rule: self != "kubernetes.io/hostname"
+                                  - message: label domain "karpenter.k8s.aws" is restricted
+                                    rule: self in ["karpenter.k8s.aws/ec2nodeclass", "karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu", "karpenter.k8s.aws/instance-cpu-manufacturer", "karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz", "karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                              minValues:
+                                description: |-
+                                  This field is ALPHA and can be dropped or replaced at any time
+                                  MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                                maximum: 50
+                                minimum: 1
+                                type: integer
+                              operator:
+                                description: |-
+                                  Represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                type: string
+                                enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  - Gt
+                                  - Lt
+                              values:
+                                description: |-
+                                  An array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                  array must have a single element, which will be interpreted as an integer.
+                                  This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          maxItems: 100
+                          type: array
+                          x-kubernetes-validations:
+                            - message: requirements with operator 'In' must have a value defined
+                              rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                            - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                              rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                            - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                              rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                        startupTaints:
+                          description: |-
+                            StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                            within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                            daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                            purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        taints:
+                          description: Taints will be applied to the NodeClaim's node.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        terminationGracePeriod:
+                          description: |-
+                            TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
+
+                            Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
+
+                            This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
+                            When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
+
+                            Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
+                            If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
+                            that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
+
+                            The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
+                            If left undefined, the controller will wait indefinitely for pods to be drained.
+                          pattern: ^([0-9]+(s|m|h))+$
+                          type: string
+                      required:
+                        - nodeClassRef
+                        - requirements
+                      type: object
+                  required:
+                    - spec
+                  type: object
+                weight:
+                  description: |-
+                    Weight is the priority given to the nodepool during scheduling. A higher
+                    numerical weight indicates that this nodepool will be ordered
+                    ahead of other nodepools with lower weights. A nodepool with no weight
+                    will be treated as if it is a nodepool with a weight of 0.
+                  format: int32
+                  maximum: 100
+                  minimum: 1
+                  type: integer
+              required:
+                - template
+              type: object
+            status:
+              description: NodePoolStatus defines the observed state of NodePool
+              properties:
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                resources:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Resources is the list of resources that have been provisioned.
+                  type: object
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/content/projects/karpenter/v1.2.1/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/content/projects/karpenter/v1.2.1/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -1,0 +1,742 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  name: ec2nodeclasses.karpenter.k8s.aws
+spec:
+  group: karpenter.k8s.aws
+  names:
+    categories:
+      - karpenter
+    kind: EC2NodeClass
+    listKind: EC2NodeClassList
+    plural: ec2nodeclasses
+    shortNames:
+      - ec2nc
+      - ec2ncs
+    singular: ec2nodeclass
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.role
+          name: Role
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: EC2NodeClass is the Schema for the EC2NodeClass API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                EC2NodeClassSpec is the top level specification for the AWS Karpenter Provider.
+                This will contain configuration necessary to launch instances in AWS.
+              properties:
+                amiFamily:
+                  description: |-
+                    AMIFamily dictates the UserData format and default BlockDeviceMappings used when generating launch templates.
+                    This field is optional when using an alias amiSelectorTerm, and the value will be inferred from the alias'
+                    family. When an alias is specified, this field may only be set to its corresponding family or 'Custom'. If no
+                    alias is specified, this field is required.
+                    NOTE: We ignore the AMIFamily for hashing here because we hash the AMIFamily dynamically by using the alias using
+                    the AMIFamily() helper function
+                  enum:
+                    - AL2
+                    - AL2023
+                    - Bottlerocket
+                    - Custom
+                    - Windows2019
+                    - Windows2022
+                  type: string
+                amiSelectorTerms:
+                  description: AMISelectorTerms is a list of or ami selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      AMISelectorTerm defines selection logic for an ami used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      alias:
+                        description: |-
+                          Alias specifies which EKS optimized AMI to select.
+                          Each alias consists of a family and an AMI version, specified as "family@version".
+                          Valid families include: al2, al2023, bottlerocket, windows2019, and windows2022.
+                          The version can either be pinned to a specific AMI release, with that AMIs version format (ex: "al2023@v20240625" or "bottlerocket@v1.10.0").
+                          The version can also be set to "latest" for any family. Setting the version to latest will result in drift when a new AMI is released. This is **not** recommended for production environments.
+                          Note: The Windows families do **not** support version pinning, and only latest may be used.
+                        maxLength: 30
+                        type: string
+                        x-kubernetes-validations:
+                          - message: '''alias'' is improperly formatted, must match the format ''family@version'''
+                            rule: self.matches('^[a-zA-Z0-9]+@.+$')
+                          - message: 'family is not supported, must be one of the following: ''al2'', ''al2023'', ''bottlerocket'', ''windows2019'', ''windows2022'''
+                            rule: self.split('@')[0] in ['al2','al2023','bottlerocket','windows2019','windows2022']
+                          - message: windows families may only specify version 'latest'
+                            rule: 'self.split(''@'')[0] in [''windows2019'',''windows2022''] ? self.split(''@'')[1] == ''latest'' : true'
+                      id:
+                        description: ID is the ami id in EC2
+                        pattern: ami-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the ami name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      owner:
+                        description: |-
+                          Owner is the owner for the ami.
+                          You can specify a combination of AWS account IDs, "self", "amazon", and "aws-marketplace"
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select amis.
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  minItems: 1
+                  type: array
+                  x-kubernetes-validations:
+                    - message: expected at least one, got none, ['tags', 'id', 'name', 'alias']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name) || has(x.alias))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.exists(x, has(x.id) && (has(x.alias) || has(x.tags) || has(x.name) || has(x.owner)))'
+                    - message: '''alias'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.exists(x, has(x.alias) && (has(x.id) || has(x.tags) || has(x.name) || has(x.owner)))'
+                    - message: '''alias'' is mutually exclusive, cannot be set with a combination of other amiSelectorTerms'
+                      rule: '!(self.exists(x, has(x.alias)) && self.size() != 1)'
+                associatePublicIPAddress:
+                  description: AssociatePublicIPAddress controls if public IP addresses are assigned to instances that are launched with the nodeclass.
+                  type: boolean
+                blockDeviceMappings:
+                  description: BlockDeviceMappings to be applied to provisioned nodes.
+                  items:
+                    properties:
+                      deviceName:
+                        description: The device name (for example, /dev/sdh or xvdh).
+                        type: string
+                      ebs:
+                        description: EBS contains parameters used to automatically set up EBS volumes when an instance is launched.
+                        properties:
+                          deleteOnTermination:
+                            description: DeleteOnTermination indicates whether the EBS volume is deleted on instance termination.
+                            type: boolean
+                          encrypted:
+                            description: |-
+                              Encrypted indicates whether the EBS volume is encrypted. Encrypted volumes can only
+                              be attached to instances that support Amazon EBS encryption. If you are creating
+                              a volume from a snapshot, you can't specify an encryption value.
+                            type: boolean
+                          iops:
+                            description: |-
+                              IOPS is the number of I/O operations per second (IOPS). For gp3, io1, and io2 volumes,
+                              this represents the number of IOPS that are provisioned for the volume. For
+                              gp2 volumes, this represents the baseline performance of the volume and the
+                              rate at which the volume accumulates I/O credits for bursting.
+
+                              The following are the supported values for each volume type:
+
+                                 * gp3: 3,000-16,000 IOPS
+
+                                 * io1: 100-64,000 IOPS
+
+                                 * io2: 100-64,000 IOPS
+
+                              For io1 and io2 volumes, we guarantee 64,000 IOPS only for Instances built
+                              on the Nitro System (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances).
+                              Other instance families guarantee performance up to 32,000 IOPS.
+
+                              This parameter is supported for io1, io2, and gp3 volumes only. This parameter
+                              is not supported for gp2, st1, sc1, or standard volumes.
+                            format: int64
+                            type: integer
+                          kmsKeyID:
+                            description: KMSKeyID (ARN) of the symmetric Key Management Service (KMS) CMK used for encryption.
+                            type: string
+                          snapshotID:
+                            description: SnapshotID is the ID of an EBS snapshot
+                            type: string
+                          throughput:
+                            description: |-
+                              Throughput to provision for a gp3 volume, with a maximum of 1,000 MiB/s.
+                              Valid Range: Minimum value of 125. Maximum value of 1000.
+                            format: int64
+                            type: integer
+                          volumeSize:
+                            description: |-
+                              VolumeSize in `Gi`, `G`, `Ti`, or `T`. You must specify either a snapshot ID or
+                              a volume size. The following are the supported volumes sizes for each volume
+                              type:
+
+                                 * gp2 and gp3: 1-16,384
+
+                                 * io1 and io2: 4-16,384
+
+                                 * st1 and sc1: 125-16,384
+
+                                 * standard: 1-1,024
+                            pattern: ^((?:[1-9][0-9]{0,3}|[1-4][0-9]{4}|[5][0-8][0-9]{3}|59000)Gi|(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|[6][0-3][0-9]{3}|64000)G|([1-9]||[1-5][0-7]|58)Ti|([1-9]||[1-5][0-9]|6[0-3]|64)T)$
+                            type: string
+                          volumeType:
+                            description: |-
+                              VolumeType of the block device.
+                              For more information, see Amazon EBS volume types (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html)
+                              in the Amazon Elastic Compute Cloud User Guide.
+                            enum:
+                              - standard
+                              - io1
+                              - io2
+                              - gp2
+                              - sc1
+                              - st1
+                              - gp3
+                            type: string
+                        type: object
+                        x-kubernetes-validations:
+                          - message: snapshotID or volumeSize must be defined
+                            rule: has(self.snapshotID) || has(self.volumeSize)
+                      rootVolume:
+                        description: |-
+                          RootVolume is a flag indicating if this device is mounted as kubelet root dir. You can
+                          configure at most one root volume in BlockDeviceMappings.
+                        type: boolean
+                    type: object
+                  maxItems: 50
+                  type: array
+                  x-kubernetes-validations:
+                    - message: must have only one blockDeviceMappings with rootVolume
+                      rule: self.filter(x, has(x.rootVolume)?x.rootVolume==true:false).size() <= 1
+                context:
+                  description: |-
+                    Context is a Reserved field in EC2 APIs
+                    https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet.html
+                  type: string
+                detailedMonitoring:
+                  description: DetailedMonitoring controls if detailed monitoring is enabled for instances that are launched
+                  type: boolean
+                instanceProfile:
+                  description: |-
+                    InstanceProfile is the AWS entity that instances use.
+                    This field is mutually exclusive from role.
+                    The instance profile should already have a role assigned to it that Karpenter
+                     has PassRole permission on for instance launch using this instanceProfile to succeed.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: instanceProfile cannot be empty
+                      rule: self != ''
+                instanceStorePolicy:
+                  description: InstanceStorePolicy specifies how to handle instance-store disks.
+                  enum:
+                    - RAID0
+                  type: string
+                kubelet:
+                  description: |-
+                    Kubelet defines args to be used when configuring kubelet on provisioned nodes.
+                    They are a subset of the upstream types, recognizing not all options may be supported.
+                    Wherever possible, the types and names should reflect the upstream kubelet types.
+                  properties:
+                    clusterDNS:
+                      description: |-
+                        clusterDNS is a list of IP addresses for the cluster DNS server.
+                        Note that not all providers may use all addresses.
+                      items:
+                        type: string
+                      type: array
+                    cpuCFSQuota:
+                      description: CPUCFSQuota enables CPU CFS quota enforcement for containers that specify CPU limits.
+                      type: boolean
+                    evictionHard:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionHard is the map of signal names to quantities that define hard eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionHard are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionMaxPodGracePeriod:
+                      description: |-
+                        EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in
+                        response to soft eviction thresholds being met.
+                      format: int32
+                      type: integer
+                    evictionSoft:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionSoft is the map of signal names to quantities that define soft eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoft are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionSoftGracePeriod:
+                      additionalProperties:
+                        type: string
+                      description: EvictionSoftGracePeriod is the map of signal names to quantities that define grace periods for each eviction signal
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoftGracePeriod are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    imageGCHighThresholdPercent:
+                      description: |-
+                        ImageGCHighThresholdPercent is the percent of disk usage after which image
+                        garbage collection is always run. The percent is calculated by dividing this
+                        field value by 100, so this field must be between 0 and 100, inclusive.
+                        When specified, the value must be greater than ImageGCLowThresholdPercent.
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    imageGCLowThresholdPercent:
+                      description: |-
+                        ImageGCLowThresholdPercent is the percent of disk usage before which image
+                        garbage collection is never run. Lowest disk usage to garbage collect to.
+                        The percent is calculated by dividing this field value by 100,
+                        so the field value must be between 0 and 100, inclusive.
+                        When specified, the value must be less than imageGCHighThresholdPercent
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    kubeReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: KubeReserved contains resources reserved for Kubernetes system components.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for kubeReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: kubeReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                    maxPods:
+                      description: |-
+                        MaxPods is an override for the maximum number of pods that can run on
+                        a worker node instance.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    podsPerCore:
+                      description: |-
+                        PodsPerCore is an override for the number of pods that can run on a worker node
+                        instance based on the number of cpu cores. This value cannot exceed MaxPods, so, if
+                        MaxPods is a lower value, that value will be used.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    systemReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: SystemReserved contains resources reserved for OS system daemons and kernel memory.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for systemReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: systemReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                  type: object
+                  x-kubernetes-validations:
+                    - message: imageGCHighThresholdPercent must be greater than imageGCLowThresholdPercent
+                      rule: 'has(self.imageGCHighThresholdPercent) && has(self.imageGCLowThresholdPercent) ?  self.imageGCHighThresholdPercent > self.imageGCLowThresholdPercent  : true'
+                    - message: evictionSoft OwnerKey does not have a matching evictionSoftGracePeriod
+                      rule: has(self.evictionSoft) ? self.evictionSoft.all(e, (e in self.evictionSoftGracePeriod)):true
+                    - message: evictionSoftGracePeriod OwnerKey does not have a matching evictionSoft
+                      rule: has(self.evictionSoftGracePeriod) ? self.evictionSoftGracePeriod.all(e, (e in self.evictionSoft)):true
+                metadataOptions:
+                  default:
+                    httpEndpoint: enabled
+                    httpProtocolIPv6: disabled
+                    httpPutResponseHopLimit: 1
+                    httpTokens: required
+                  description: |-
+                    MetadataOptions for the generated launch template of provisioned nodes.
+
+                    This specifies the exposure of the Instance Metadata Service to
+                    provisioned EC2 nodes. For more information,
+                    see Instance Metadata and User Data
+                    (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
+                    in the Amazon Elastic Compute Cloud User Guide.
+
+                    Refer to recommended, security best practices
+                    (https://aws.github.io/aws-eks-best-practices/security/docs/iam/#restrict-access-to-the-instance-profile-assigned-to-the-worker-node)
+                    for limiting exposure of Instance Metadata and User Data to pods.
+                    If omitted, defaults to httpEndpoint enabled, with httpProtocolIPv6
+                    disabled, with httpPutResponseLimit of 1, and with httpTokens
+                    required.
+                  properties:
+                    httpEndpoint:
+                      default: enabled
+                      description: |-
+                        HTTPEndpoint enables or disables the HTTP metadata endpoint on provisioned
+                        nodes. If metadata options is non-nil, but this parameter is not specified,
+                        the default state is "enabled".
+
+                        If you specify a value of "disabled", instance metadata will not be accessible
+                        on the node.
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpProtocolIPv6:
+                      default: disabled
+                      description: |-
+                        HTTPProtocolIPv6 enables or disables the IPv6 endpoint for the instance metadata
+                        service on provisioned nodes. If metadata options is non-nil, but this parameter
+                        is not specified, the default state is "disabled".
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpPutResponseHopLimit:
+                      default: 1
+                      description: |-
+                        HTTPPutResponseHopLimit is the desired HTTP PUT response hop limit for
+                        instance metadata requests. The larger the number, the further instance
+                        metadata requests can travel. Possible values are integers from 1 to 64.
+                        If metadata options is non-nil, but this parameter is not specified, the
+                        default value is 1.
+                      format: int64
+                      maximum: 64
+                      minimum: 1
+                      type: integer
+                    httpTokens:
+                      default: required
+                      description: |-
+                        HTTPTokens determines the state of token usage for instance metadata
+                        requests. If metadata options is non-nil, but this parameter is not
+                        specified, the default state is "required".
+
+                        If the state is optional, one can choose to retrieve instance metadata with
+                        or without a signed token header on the request. If one retrieves the IAM
+                        role credentials without a token, the version 1.0 role credentials are
+                        returned. If one retrieves the IAM role credentials using a valid signed
+                        token, the version 2.0 role credentials are returned.
+
+                        If the state is "required", one must send a signed token header with any
+                        instance metadata retrieval requests. In this state, retrieving the IAM
+                        role credentials always returns the version 2.0 credentials; the version
+                        1.0 credentials are not available.
+                      enum:
+                        - required
+                        - optional
+                      type: string
+                  type: object
+                role:
+                  description: |-
+                    Role is the AWS identity that nodes use. This field is immutable.
+                    This field is mutually exclusive from instanceProfile.
+                    Marking this field as immutable avoids concerns around terminating managed instance profiles from running instances.
+                    This field may be made mutable in the future, assuming the correct garbage collection and drift handling is implemented
+                    for the old instance profiles on an update.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: role cannot be empty
+                      rule: self != ''
+                    - message: immutable field changed
+                      rule: self == oldSelf
+                securityGroupSelectorTerms:
+                  description: SecurityGroupSelectorTerms is a list of or security group selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SecurityGroupSelectorTerm defines selection logic for a security group used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the security group id in EC2
+                        pattern: sg-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the security group name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select security groups.
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: securityGroupSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id', 'name']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && (has(x.tags) || has(x.name)))'
+                    - message: '''name'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.name) && (has(x.tags) || has(x.id)))'
+                subnetSelectorTerms:
+                  description: SubnetSelectorTerms is a list of or subnet selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SubnetSelectorTerm defines selection logic for a subnet used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the subnet id in EC2
+                        pattern: subnet-[0-9a-z]+
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: subnetSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id']
+                      rule: self.all(x, has(x.tags) || has(x.id))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in subnetSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && has(x.tags))'
+                tags:
+                  additionalProperties:
+                    type: string
+                  description: Tags to be applied on ec2 resources like instances and launch templates.
+                  type: object
+                  x-kubernetes-validations:
+                    - message: empty tag keys aren't supported
+                      rule: self.all(k, k != '')
+                    - message: tag contains a restricted tag matching eks:eks-cluster-name
+                      rule: self.all(k, k !='eks:eks-cluster-name')
+                    - message: tag contains a restricted tag matching kubernetes.io/cluster/
+                      rule: self.all(k, !k.startsWith('kubernetes.io/cluster') )
+                    - message: tag contains a restricted tag matching karpenter.sh/nodepool
+                      rule: self.all(k, k != 'karpenter.sh/nodepool')
+                    - message: tag contains a restricted tag matching karpenter.sh/nodeclaim
+                      rule: self.all(k, k !='karpenter.sh/nodeclaim')
+                    - message: tag contains a restricted tag matching karpenter.k8s.aws/ec2nodeclass
+                      rule: self.all(k, k !='karpenter.k8s.aws/ec2nodeclass')
+                userData:
+                  description: |-
+                    UserData to be applied to the provisioned nodes.
+                    It must be in the appropriate format based on the AMIFamily in use. Karpenter will merge certain fields into
+                    this UserData to ensure nodes are being provisioned with the correct configuration.
+                  type: string
+              required:
+                - amiSelectorTerms
+                - securityGroupSelectorTerms
+                - subnetSelectorTerms
+              type: object
+              x-kubernetes-validations:
+                - message: must specify exactly one of ['role', 'instanceProfile']
+                  rule: (has(self.role) && !has(self.instanceProfile)) || (!has(self.role) && has(self.instanceProfile))
+                - message: changing from 'instanceProfile' to 'role' is not supported. You must delete and recreate this node class if you want to change this.
+                  rule: (has(oldSelf.role) && has(self.role)) || (has(oldSelf.instanceProfile) && has(self.instanceProfile))
+                - message: if set, amiFamily must be 'AL2' or 'Custom' when using an AL2 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''al2'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''AL2'') : true)'
+                - message: if set, amiFamily must be 'AL2023' or 'Custom' when using an AL2023 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''al2023'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''AL2023'') : true)'
+                - message: if set, amiFamily must be 'Bottlerocket' or 'Custom' when using a Bottlerocket alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''bottlerocket'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Bottlerocket'') : true)'
+                - message: if set, amiFamily must be 'Windows2019' or 'Custom' when using a Windows2019 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''windows2019'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Windows2019'') : true)'
+                - message: if set, amiFamily must be 'Windows2022' or 'Custom' when using a Windows2022 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''windows2022'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Windows2022'') : true)'
+                - message: must specify amiFamily if amiSelectorTerms does not contain an alias
+                  rule: 'self.amiSelectorTerms.exists(x, has(x.alias)) ? true : has(self.amiFamily)'
+            status:
+              description: EC2NodeClassStatus contains the resolved state of the EC2NodeClass
+              properties:
+                amis:
+                  description: |-
+                    AMI contains the current AMI values that are available to the
+                    cluster under the AMI selectors.
+                  items:
+                    description: AMI contains resolved AMI selector values utilized for node launch
+                    properties:
+                      deprecated:
+                        description: Deprecation status of the AMI
+                        type: boolean
+                      id:
+                        description: ID of the AMI
+                        type: string
+                      name:
+                        description: Name of the AMI
+                        type: string
+                      requirements:
+                        description: Requirements of the AMI to be utilized on an instance type
+                        items:
+                          description: |-
+                            A node selector requirement is a selector that contains values, a key, and an operator
+                            that relates the key and values.
+                          properties:
+                            key:
+                              description: The label key that the selector applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                Represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                              type: string
+                            values:
+                              description: |-
+                                An array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. If the operator is Gt or Lt, the values
+                                array must have a single element, which will be interpreted as an integer.
+                                This array is replaced during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                            - key
+                            - operator
+                          type: object
+                        type: array
+                    required:
+                      - id
+                      - requirements
+                    type: object
+                  type: array
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                instanceProfile:
+                  description: InstanceProfile contains the resolved instance profile for the role
+                  type: string
+                securityGroups:
+                  description: |-
+                    SecurityGroups contains the current security group values that are available to the
+                    cluster under the SecurityGroups selectors.
+                  items:
+                    description: SecurityGroup contains resolved SecurityGroup selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the security group
+                        type: string
+                      name:
+                        description: Name of the security group
+                        type: string
+                    required:
+                      - id
+                    type: object
+                  type: array
+                subnets:
+                  description: |-
+                    Subnets contains the current subnet values that are available to the
+                    cluster under the subnet selectors.
+                  items:
+                    description: Subnet contains resolved Subnet selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the subnet
+                        type: string
+                      zone:
+                        description: The associated availability zone
+                        type: string
+                      zoneID:
+                        description: The associated availability zone ID
+                        type: string
+                    required:
+                      - id
+                      - zone
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/content/projects/karpenter/v1.2.1/karpenter.sh_nodeclaims.yaml
+++ b/content/projects/karpenter/v1.2.1/karpenter.sh_nodeclaims.yaml
@@ -1,0 +1,395 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  name: nodeclaims.karpenter.sh
+spec:
+  group: karpenter.sh
+  names:
+    categories:
+      - karpenter
+    kind: NodeClaim
+    listKind: NodeClaimList
+    plural: nodeclaims
+    singular: nodeclaim
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.labels.node\.kubernetes\.io/instance-type
+          name: Type
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/capacity-type
+          name: Capacity
+          type: string
+        - jsonPath: .metadata.labels.topology\.kubernetes\.io/zone
+          name: Zone
+          type: string
+        - jsonPath: .status.nodeName
+          name: Node
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .status.imageID
+          name: ImageID
+          priority: 1
+          type: string
+        - jsonPath: .status.providerID
+          name: ID
+          priority: 1
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/nodepool
+          name: NodePool
+          priority: 1
+          type: string
+        - jsonPath: .spec.nodeClassRef.name
+          name: NodeClass
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: NodeClaim is the Schema for the NodeClaims API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: NodeClaimSpec describes the desired state of the NodeClaim
+              properties:
+                expireAfter:
+                  default: 720h
+                  description: |-
+                    ExpireAfter is the duration the controller will wait
+                    before terminating a node, measured from when the node is created. This
+                    is useful to implement features like eventually consistent node upgrade,
+                    memory leak protection, and disruption testing.
+                  pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                  type: string
+                nodeClassRef:
+                  description: NodeClassRef is a reference to an object that defines provider specific configuration
+                  properties:
+                    group:
+                      description: API version of the referent
+                      pattern: ^[^/]*$
+                      type: string
+                      x-kubernetes-validations:
+                        - message: group may not be empty
+                          rule: self != ''
+                    kind:
+                      description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                      type: string
+                      x-kubernetes-validations:
+                        - message: kind may not be empty
+                          rule: self != ''
+                    name:
+                      description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                      type: string
+                      x-kubernetes-validations:
+                        - message: name may not be empty
+                          rule: self != ''
+                  required:
+                    - group
+                    - kind
+                    - name
+                  type: object
+                requirements:
+                  description: Requirements are layered with GetLabels and applied to every node.
+                  items:
+                    description: |-
+                      A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                      and minValues that represent the requirement to have at least that many values.
+                    properties:
+                      key:
+                        description: The label key that the selector applies to.
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                        x-kubernetes-validations:
+                          - message: label domain "kubernetes.io" is restricted
+                            rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                          - message: label domain "k8s.io" is restricted
+                            rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                          - message: label domain "karpenter.sh" is restricted
+                            rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                          - message: label "kubernetes.io/hostname" is restricted
+                            rule: self != "kubernetes.io/hostname"
+                          - message: label domain "karpenter.k8s.aws" is restricted
+                            rule: self in ["karpenter.k8s.aws/ec2nodeclass", "karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu", "karpenter.k8s.aws/instance-cpu-manufacturer", "karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz", "karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                      minValues:
+                        description: |-
+                          This field is ALPHA and can be dropped or replaced at any time
+                          MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                        maximum: 50
+                        minimum: 1
+                        type: integer
+                      operator:
+                        description: |-
+                          Represents a key's relationship to a set of values.
+                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                        type: string
+                        enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          - Gt
+                          - Lt
+                      values:
+                        description: |-
+                          An array of string values. If the operator is In or NotIn,
+                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                          the values array must be empty. If the operator is Gt or Lt, the values
+                          array must have a single element, which will be interpreted as an integer.
+                          This array is replaced during a strategic merge patch.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                        maxLength: 63
+                        pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                    required:
+                      - key
+                      - operator
+                    type: object
+                  maxItems: 100
+                  type: array
+                  x-kubernetes-validations:
+                    - message: requirements with operator 'In' must have a value defined
+                      rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                    - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                      rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                    - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                      rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                resources:
+                  description: Resources models the resource requirements for the NodeClaim to launch
+                  properties:
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: Requests describes the minimum required resources for the NodeClaim to launch
+                      type: object
+                  type: object
+                startupTaints:
+                  description: |-
+                    StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                    within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                    daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                    purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                taints:
+                  description: Taints will be applied to the NodeClaim's node.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                terminationGracePeriod:
+                  description: |-
+                    TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
+
+                    Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
+
+                    This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
+                    When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
+
+                    Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
+                    If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
+                    that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
+
+                    The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
+                    If left undefined, the controller will wait indefinitely for pods to be drained.
+                  pattern: ^([0-9]+(s|m|h))+$
+                  type: string
+              required:
+                - nodeClassRef
+                - requirements
+              type: object
+              x-kubernetes-validations:
+                - message: spec is immutable
+                  rule: self == oldSelf
+            status:
+              description: NodeClaimStatus defines the observed state of NodeClaim
+              properties:
+                allocatable:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Allocatable is the estimated allocatable capacity of the node
+                  type: object
+                capacity:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Capacity is the estimated full capacity of the node
+                  type: object
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        pattern: ^([A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?|)$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - status
+                      - type
+                    type: object
+                  type: array
+                imageID:
+                  description: ImageID is an identifier for the image that runs on the node
+                  type: string
+                lastPodEventTime:
+                  description: |-
+                    LastPodEventTime is updated with the last time a pod was scheduled
+                    or removed from the node. A pod going terminal or terminating
+                    is also considered as removed.
+                  format: date-time
+                  type: string
+                nodeName:
+                  description: NodeName is the name of the corresponding node object
+                  type: string
+                providerID:
+                  description: ProviderID of the corresponding node object
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/content/projects/karpenter/v1.2.1/karpenter.sh_nodepools.yaml
+++ b/content/projects/karpenter/v1.2.1/karpenter.sh_nodepools.yaml
@@ -1,0 +1,519 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  name: nodepools.karpenter.sh
+spec:
+  group: karpenter.sh
+  names:
+    categories:
+      - karpenter
+    kind: NodePool
+    listKind: NodePoolList
+    plural: nodepools
+    singular: nodepool
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.template.spec.nodeClassRef.name
+          name: NodeClass
+          type: string
+        - jsonPath: .status.resources.nodes
+          name: Nodes
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.weight
+          name: Weight
+          priority: 1
+          type: integer
+        - jsonPath: .status.resources.cpu
+          name: CPU
+          priority: 1
+          type: string
+        - jsonPath: .status.resources.memory
+          name: Memory
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: NodePool is the Schema for the NodePools API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                NodePoolSpec is the top level nodepool specification. Nodepools
+                launch nodes in response to pods that are unschedulable. A single nodepool
+                is capable of managing a diverse set of nodes. Node properties are determined
+                from a combination of nodepool and pod scheduling constraints.
+              properties:
+                disruption:
+                  default:
+                    consolidateAfter: 0s
+                  description: Disruption contains the parameters that relate to Karpenter's disruption logic
+                  properties:
+                    budgets:
+                      default:
+                        - nodes: 10%
+                      description: |-
+                        Budgets is a list of Budgets.
+                        If there are multiple active budgets, Karpenter uses
+                        the most restrictive value. If left undefined,
+                        this will default to one budget with a value to 10%.
+                      items:
+                        description: |-
+                          Budget defines when Karpenter will restrict the
+                          number of Node Claims that can be terminating simultaneously.
+                        properties:
+                          duration:
+                            description: |-
+                              Duration determines how long a Budget is active since each Schedule hit.
+                              Only minutes and hours are accepted, as cron does not work in seconds.
+                              If omitted, the budget is always active.
+                              This is required if Schedule is set.
+                              This regex has an optional 0s at the end since the duration.String() always adds
+                              a 0s at the end.
+                            pattern: ^((([0-9]+(h|m))|([0-9]+h[0-9]+m))(0s)?)$
+                            type: string
+                          nodes:
+                            default: 10%
+                            description: |-
+                              Nodes dictates the maximum number of NodeClaims owned by this NodePool
+                              that can be terminating at once. This is calculated by counting nodes that
+                              have a deletion timestamp set, or are actively being deleted by Karpenter.
+                              This field is required when specifying a budget.
+                              This cannot be of type intstr.IntOrString since kubebuilder doesn't support pattern
+                              checking for int nodes for IntOrString nodes.
+                              Ref: https://github.com/kubernetes-sigs/controller-tools/blob/55efe4be40394a288216dab63156b0a64fb82929/pkg/crd/markers/validation.go#L379-L388
+                            pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
+                            type: string
+                          reasons:
+                            description: |-
+                              Reasons is a list of disruption methods that this budget applies to. If Reasons is not set, this budget applies to all methods.
+                              Otherwise, this will apply to each reason defined.
+                              allowed reasons are Underutilized, Empty, and Drifted.
+                            items:
+                              description: DisruptionReason defines valid reasons for disruption budgets.
+                              enum:
+                                - Underutilized
+                                - Empty
+                                - Drifted
+                              type: string
+                            type: array
+                          schedule:
+                            description: |-
+                              Schedule specifies when a budget begins being active, following
+                              the upstream cronjob syntax. If omitted, the budget is always active.
+                              Timezones are not supported.
+                              This field is required if Duration is set.
+                            pattern: ^(@(annually|yearly|monthly|weekly|daily|midnight|hourly))|((.+)\s(.+)\s(.+)\s(.+)\s(.+))$
+                            type: string
+                        required:
+                          - nodes
+                        type: object
+                      maxItems: 50
+                      type: array
+                      x-kubernetes-validations:
+                        - message: '''schedule'' must be set with ''duration'''
+                          rule: self.all(x, has(x.schedule) == has(x.duration))
+                    consolidateAfter:
+                      description: |-
+                        ConsolidateAfter is the duration the controller will wait
+                        before attempting to terminate nodes that are underutilized.
+                        Refer to ConsolidationPolicy for how underutilization is considered.
+                      pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                      type: string
+                    consolidationPolicy:
+                      default: WhenEmptyOrUnderutilized
+                      description: |-
+                        ConsolidationPolicy describes which nodes Karpenter can disrupt through its consolidation
+                        algorithm. This policy defaults to "WhenEmptyOrUnderutilized" if not specified
+                      enum:
+                        - WhenEmpty
+                        - WhenEmptyOrUnderutilized
+                      type: string
+                  required:
+                    - consolidateAfter
+                  type: object
+                limits:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Limits define a set of bounds for provisioning capacity.
+                  type: object
+                template:
+                  description: |-
+                    Template contains the template of possibilities for the provisioning logic to launch a NodeClaim with.
+                    NodeClaims launched from this NodePool will often be further constrained than the template specifies.
+                  properties:
+                    metadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Annotations is an unstructured key value map stored with a resource that may be
+                            set by external tools to store and retrieve arbitrary metadata. They are not
+                            queryable and should be preserved when modifying objects.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                            maxLength: 63
+                            pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                          description: |-
+                            Map of string keys and values that can be used to organize and categorize
+                            (scope and select) objects. May match selectors of replication controllers
+                            and services.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
+                          type: object
+                          maxProperties: 100
+                          x-kubernetes-validations:
+                            - message: label domain "kubernetes.io" is restricted
+                              rule: self.all(x, x in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region",  "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || x.find("^([^/]+)").endsWith("node.kubernetes.io") || x.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !x.find("^([^/]+)").endsWith("kubernetes.io"))
+                            - message: label domain "k8s.io" is restricted
+                              rule: self.all(x, x.find("^([^/]+)").endsWith("kops.k8s.io") || !x.find("^([^/]+)").endsWith("k8s.io"))
+                            - message: label domain "karpenter.sh" is restricted
+                              rule: self.all(x, x in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !x.find("^([^/]+)").endsWith("karpenter.sh"))
+                            - message: label "karpenter.sh/nodepool" is restricted
+                              rule: self.all(x, x != "karpenter.sh/nodepool")
+                            - message: label "kubernetes.io/hostname" is restricted
+                              rule: self.all(x, x != "kubernetes.io/hostname")
+                            - message: label domain "karpenter.k8s.aws" is restricted
+                              rule: self.all(x, x in ["karpenter.k8s.aws/ec2nodeclass", "karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu", "karpenter.k8s.aws/instance-cpu-manufacturer", "karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz", "karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !x.find("^([^/]+)").endsWith("karpenter.k8s.aws"))
+                      type: object
+                    spec:
+                      description: |-
+                        NodeClaimTemplateSpec describes the desired state of the NodeClaim in the Nodepool
+                        NodeClaimTemplateSpec is used in the NodePool's NodeClaimTemplate, with the resource requests omitted since
+                        users are not able to set resource requests in the NodePool.
+                      properties:
+                        expireAfter:
+                          default: 720h
+                          description: |-
+                            ExpireAfter is the duration the controller will wait
+                            before terminating a node, measured from when the node is created. This
+                            is useful to implement features like eventually consistent node upgrade,
+                            memory leak protection, and disruption testing.
+                          pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                          type: string
+                        nodeClassRef:
+                          description: NodeClassRef is a reference to an object that defines provider specific configuration
+                          properties:
+                            group:
+                              description: API version of the referent
+                              pattern: ^[^/]*$
+                              type: string
+                              x-kubernetes-validations:
+                                - message: group may not be empty
+                                  rule: self != ''
+                            kind:
+                              description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                              type: string
+                              x-kubernetes-validations:
+                                - message: kind may not be empty
+                                  rule: self != ''
+                            name:
+                              description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                              x-kubernetes-validations:
+                                - message: name may not be empty
+                                  rule: self != ''
+                          required:
+                            - group
+                            - kind
+                            - name
+                          type: object
+                          x-kubernetes-validations:
+                            - message: nodeClassRef.group is immutable
+                              rule: self.group == oldSelf.group
+                            - message: nodeClassRef.kind is immutable
+                              rule: self.kind == oldSelf.kind
+                        requirements:
+                          description: Requirements are layered with GetLabels and applied to every node.
+                          items:
+                            description: |-
+                              A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                              and minValues that represent the requirement to have at least that many values.
+                            properties:
+                              key:
+                                description: The label key that the selector applies to.
+                                type: string
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                                x-kubernetes-validations:
+                                  - message: label domain "kubernetes.io" is restricted
+                                    rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                                  - message: label domain "k8s.io" is restricted
+                                    rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                                  - message: label domain "karpenter.sh" is restricted
+                                    rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                                  - message: label "karpenter.sh/nodepool" is restricted
+                                    rule: self != "karpenter.sh/nodepool"
+                                  - message: label "kubernetes.io/hostname" is restricted
+                                    rule: self != "kubernetes.io/hostname"
+                                  - message: label domain "karpenter.k8s.aws" is restricted
+                                    rule: self in ["karpenter.k8s.aws/ec2nodeclass", "karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu", "karpenter.k8s.aws/instance-cpu-manufacturer", "karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz", "karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                              minValues:
+                                description: |-
+                                  This field is ALPHA and can be dropped or replaced at any time
+                                  MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                                maximum: 50
+                                minimum: 1
+                                type: integer
+                              operator:
+                                description: |-
+                                  Represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                type: string
+                                enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  - Gt
+                                  - Lt
+                              values:
+                                description: |-
+                                  An array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                  array must have a single element, which will be interpreted as an integer.
+                                  This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          maxItems: 100
+                          type: array
+                          x-kubernetes-validations:
+                            - message: requirements with operator 'In' must have a value defined
+                              rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                            - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                              rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                            - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                              rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                        startupTaints:
+                          description: |-
+                            StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                            within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                            daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                            purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        taints:
+                          description: Taints will be applied to the NodeClaim's node.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        terminationGracePeriod:
+                          description: |-
+                            TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
+
+                            Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
+
+                            This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
+                            When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
+
+                            Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
+                            If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
+                            that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
+
+                            The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
+                            If left undefined, the controller will wait indefinitely for pods to be drained.
+                          pattern: ^([0-9]+(s|m|h))+$
+                          type: string
+                      required:
+                        - nodeClassRef
+                        - requirements
+                      type: object
+                  required:
+                    - spec
+                  type: object
+                weight:
+                  description: |-
+                    Weight is the priority given to the nodepool during scheduling. A higher
+                    numerical weight indicates that this nodepool will be ordered
+                    ahead of other nodepools with lower weights. A nodepool with no weight
+                    will be treated as if it is a nodepool with a weight of 0.
+                  format: int32
+                  maximum: 100
+                  minimum: 1
+                  type: integer
+              required:
+                - template
+              type: object
+            status:
+              description: NodePoolStatus defines the observed state of NodePool
+              properties:
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                resources:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Resources is the list of resources that have been provisioned.
+                  type: object
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/content/projects/karpenter/v1.2.2/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/content/projects/karpenter/v1.2.2/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -1,0 +1,742 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: ec2nodeclasses.karpenter.k8s.aws
+spec:
+  group: karpenter.k8s.aws
+  names:
+    categories:
+      - karpenter
+    kind: EC2NodeClass
+    listKind: EC2NodeClassList
+    plural: ec2nodeclasses
+    shortNames:
+      - ec2nc
+      - ec2ncs
+    singular: ec2nodeclass
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.role
+          name: Role
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: EC2NodeClass is the Schema for the EC2NodeClass API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                EC2NodeClassSpec is the top level specification for the AWS Karpenter Provider.
+                This will contain configuration necessary to launch instances in AWS.
+              properties:
+                amiFamily:
+                  description: |-
+                    AMIFamily dictates the UserData format and default BlockDeviceMappings used when generating launch templates.
+                    This field is optional when using an alias amiSelectorTerm, and the value will be inferred from the alias'
+                    family. When an alias is specified, this field may only be set to its corresponding family or 'Custom'. If no
+                    alias is specified, this field is required.
+                    NOTE: We ignore the AMIFamily for hashing here because we hash the AMIFamily dynamically by using the alias using
+                    the AMIFamily() helper function
+                  enum:
+                    - AL2
+                    - AL2023
+                    - Bottlerocket
+                    - Custom
+                    - Windows2019
+                    - Windows2022
+                  type: string
+                amiSelectorTerms:
+                  description: AMISelectorTerms is a list of or ami selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      AMISelectorTerm defines selection logic for an ami used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      alias:
+                        description: |-
+                          Alias specifies which EKS optimized AMI to select.
+                          Each alias consists of a family and an AMI version, specified as "family@version".
+                          Valid families include: al2, al2023, bottlerocket, windows2019, and windows2022.
+                          The version can either be pinned to a specific AMI release, with that AMIs version format (ex: "al2023@v20240625" or "bottlerocket@v1.10.0").
+                          The version can also be set to "latest" for any family. Setting the version to latest will result in drift when a new AMI is released. This is **not** recommended for production environments.
+                          Note: The Windows families do **not** support version pinning, and only latest may be used.
+                        maxLength: 30
+                        type: string
+                        x-kubernetes-validations:
+                          - message: '''alias'' is improperly formatted, must match the format ''family@version'''
+                            rule: self.matches('^[a-zA-Z0-9]+@.+$')
+                          - message: 'family is not supported, must be one of the following: ''al2'', ''al2023'', ''bottlerocket'', ''windows2019'', ''windows2022'''
+                            rule: self.split('@')[0] in ['al2','al2023','bottlerocket','windows2019','windows2022']
+                          - message: windows families may only specify version 'latest'
+                            rule: 'self.split(''@'')[0] in [''windows2019'',''windows2022''] ? self.split(''@'')[1] == ''latest'' : true'
+                      id:
+                        description: ID is the ami id in EC2
+                        pattern: ami-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the ami name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      owner:
+                        description: |-
+                          Owner is the owner for the ami.
+                          You can specify a combination of AWS account IDs, "self", "amazon", and "aws-marketplace"
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select amis.
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  minItems: 1
+                  type: array
+                  x-kubernetes-validations:
+                    - message: expected at least one, got none, ['tags', 'id', 'name', 'alias']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name) || has(x.alias))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.exists(x, has(x.id) && (has(x.alias) || has(x.tags) || has(x.name) || has(x.owner)))'
+                    - message: '''alias'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.exists(x, has(x.alias) && (has(x.id) || has(x.tags) || has(x.name) || has(x.owner)))'
+                    - message: '''alias'' is mutually exclusive, cannot be set with a combination of other amiSelectorTerms'
+                      rule: '!(self.exists(x, has(x.alias)) && self.size() != 1)'
+                associatePublicIPAddress:
+                  description: AssociatePublicIPAddress controls if public IP addresses are assigned to instances that are launched with the nodeclass.
+                  type: boolean
+                blockDeviceMappings:
+                  description: BlockDeviceMappings to be applied to provisioned nodes.
+                  items:
+                    properties:
+                      deviceName:
+                        description: The device name (for example, /dev/sdh or xvdh).
+                        type: string
+                      ebs:
+                        description: EBS contains parameters used to automatically set up EBS volumes when an instance is launched.
+                        properties:
+                          deleteOnTermination:
+                            description: DeleteOnTermination indicates whether the EBS volume is deleted on instance termination.
+                            type: boolean
+                          encrypted:
+                            description: |-
+                              Encrypted indicates whether the EBS volume is encrypted. Encrypted volumes can only
+                              be attached to instances that support Amazon EBS encryption. If you are creating
+                              a volume from a snapshot, you can't specify an encryption value.
+                            type: boolean
+                          iops:
+                            description: |-
+                              IOPS is the number of I/O operations per second (IOPS). For gp3, io1, and io2 volumes,
+                              this represents the number of IOPS that are provisioned for the volume. For
+                              gp2 volumes, this represents the baseline performance of the volume and the
+                              rate at which the volume accumulates I/O credits for bursting.
+
+                              The following are the supported values for each volume type:
+
+                                 * gp3: 3,000-16,000 IOPS
+
+                                 * io1: 100-64,000 IOPS
+
+                                 * io2: 100-64,000 IOPS
+
+                              For io1 and io2 volumes, we guarantee 64,000 IOPS only for Instances built
+                              on the Nitro System (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances).
+                              Other instance families guarantee performance up to 32,000 IOPS.
+
+                              This parameter is supported for io1, io2, and gp3 volumes only. This parameter
+                              is not supported for gp2, st1, sc1, or standard volumes.
+                            format: int64
+                            type: integer
+                          kmsKeyID:
+                            description: KMSKeyID (ARN) of the symmetric Key Management Service (KMS) CMK used for encryption.
+                            type: string
+                          snapshotID:
+                            description: SnapshotID is the ID of an EBS snapshot
+                            type: string
+                          throughput:
+                            description: |-
+                              Throughput to provision for a gp3 volume, with a maximum of 1,000 MiB/s.
+                              Valid Range: Minimum value of 125. Maximum value of 1000.
+                            format: int64
+                            type: integer
+                          volumeSize:
+                            description: |-
+                              VolumeSize in `Gi`, `G`, `Ti`, or `T`. You must specify either a snapshot ID or
+                              a volume size. The following are the supported volumes sizes for each volume
+                              type:
+
+                                 * gp2 and gp3: 1-16,384
+
+                                 * io1 and io2: 4-16,384
+
+                                 * st1 and sc1: 125-16,384
+
+                                 * standard: 1-1,024
+                            pattern: ^((?:[1-9][0-9]{0,3}|[1-4][0-9]{4}|[5][0-8][0-9]{3}|59000)Gi|(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|[6][0-3][0-9]{3}|64000)G|([1-9]||[1-5][0-7]|58)Ti|([1-9]||[1-5][0-9]|6[0-3]|64)T)$
+                            type: string
+                          volumeType:
+                            description: |-
+                              VolumeType of the block device.
+                              For more information, see Amazon EBS volume types (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html)
+                              in the Amazon Elastic Compute Cloud User Guide.
+                            enum:
+                              - standard
+                              - io1
+                              - io2
+                              - gp2
+                              - sc1
+                              - st1
+                              - gp3
+                            type: string
+                        type: object
+                        x-kubernetes-validations:
+                          - message: snapshotID or volumeSize must be defined
+                            rule: has(self.snapshotID) || has(self.volumeSize)
+                      rootVolume:
+                        description: |-
+                          RootVolume is a flag indicating if this device is mounted as kubelet root dir. You can
+                          configure at most one root volume in BlockDeviceMappings.
+                        type: boolean
+                    type: object
+                  maxItems: 50
+                  type: array
+                  x-kubernetes-validations:
+                    - message: must have only one blockDeviceMappings with rootVolume
+                      rule: self.filter(x, has(x.rootVolume)?x.rootVolume==true:false).size() <= 1
+                context:
+                  description: |-
+                    Context is a Reserved field in EC2 APIs
+                    https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet.html
+                  type: string
+                detailedMonitoring:
+                  description: DetailedMonitoring controls if detailed monitoring is enabled for instances that are launched
+                  type: boolean
+                instanceProfile:
+                  description: |-
+                    InstanceProfile is the AWS entity that instances use.
+                    This field is mutually exclusive from role.
+                    The instance profile should already have a role assigned to it that Karpenter
+                     has PassRole permission on for instance launch using this instanceProfile to succeed.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: instanceProfile cannot be empty
+                      rule: self != ''
+                instanceStorePolicy:
+                  description: InstanceStorePolicy specifies how to handle instance-store disks.
+                  enum:
+                    - RAID0
+                  type: string
+                kubelet:
+                  description: |-
+                    Kubelet defines args to be used when configuring kubelet on provisioned nodes.
+                    They are a subset of the upstream types, recognizing not all options may be supported.
+                    Wherever possible, the types and names should reflect the upstream kubelet types.
+                  properties:
+                    clusterDNS:
+                      description: |-
+                        clusterDNS is a list of IP addresses for the cluster DNS server.
+                        Note that not all providers may use all addresses.
+                      items:
+                        type: string
+                      type: array
+                    cpuCFSQuota:
+                      description: CPUCFSQuota enables CPU CFS quota enforcement for containers that specify CPU limits.
+                      type: boolean
+                    evictionHard:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionHard is the map of signal names to quantities that define hard eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionHard are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionMaxPodGracePeriod:
+                      description: |-
+                        EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in
+                        response to soft eviction thresholds being met.
+                      format: int32
+                      type: integer
+                    evictionSoft:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionSoft is the map of signal names to quantities that define soft eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoft are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionSoftGracePeriod:
+                      additionalProperties:
+                        type: string
+                      description: EvictionSoftGracePeriod is the map of signal names to quantities that define grace periods for each eviction signal
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoftGracePeriod are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    imageGCHighThresholdPercent:
+                      description: |-
+                        ImageGCHighThresholdPercent is the percent of disk usage after which image
+                        garbage collection is always run. The percent is calculated by dividing this
+                        field value by 100, so this field must be between 0 and 100, inclusive.
+                        When specified, the value must be greater than ImageGCLowThresholdPercent.
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    imageGCLowThresholdPercent:
+                      description: |-
+                        ImageGCLowThresholdPercent is the percent of disk usage before which image
+                        garbage collection is never run. Lowest disk usage to garbage collect to.
+                        The percent is calculated by dividing this field value by 100,
+                        so the field value must be between 0 and 100, inclusive.
+                        When specified, the value must be less than imageGCHighThresholdPercent
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    kubeReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: KubeReserved contains resources reserved for Kubernetes system components.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for kubeReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: kubeReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                    maxPods:
+                      description: |-
+                        MaxPods is an override for the maximum number of pods that can run on
+                        a worker node instance.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    podsPerCore:
+                      description: |-
+                        PodsPerCore is an override for the number of pods that can run on a worker node
+                        instance based on the number of cpu cores. This value cannot exceed MaxPods, so, if
+                        MaxPods is a lower value, that value will be used.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    systemReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: SystemReserved contains resources reserved for OS system daemons and kernel memory.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for systemReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: systemReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                  type: object
+                  x-kubernetes-validations:
+                    - message: imageGCHighThresholdPercent must be greater than imageGCLowThresholdPercent
+                      rule: 'has(self.imageGCHighThresholdPercent) && has(self.imageGCLowThresholdPercent) ?  self.imageGCHighThresholdPercent > self.imageGCLowThresholdPercent  : true'
+                    - message: evictionSoft OwnerKey does not have a matching evictionSoftGracePeriod
+                      rule: has(self.evictionSoft) ? self.evictionSoft.all(e, (e in self.evictionSoftGracePeriod)):true
+                    - message: evictionSoftGracePeriod OwnerKey does not have a matching evictionSoft
+                      rule: has(self.evictionSoftGracePeriod) ? self.evictionSoftGracePeriod.all(e, (e in self.evictionSoft)):true
+                metadataOptions:
+                  default:
+                    httpEndpoint: enabled
+                    httpProtocolIPv6: disabled
+                    httpPutResponseHopLimit: 1
+                    httpTokens: required
+                  description: |-
+                    MetadataOptions for the generated launch template of provisioned nodes.
+
+                    This specifies the exposure of the Instance Metadata Service to
+                    provisioned EC2 nodes. For more information,
+                    see Instance Metadata and User Data
+                    (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
+                    in the Amazon Elastic Compute Cloud User Guide.
+
+                    Refer to recommended, security best practices
+                    (https://aws.github.io/aws-eks-best-practices/security/docs/iam/#restrict-access-to-the-instance-profile-assigned-to-the-worker-node)
+                    for limiting exposure of Instance Metadata and User Data to pods.
+                    If omitted, defaults to httpEndpoint enabled, with httpProtocolIPv6
+                    disabled, with httpPutResponseLimit of 1, and with httpTokens
+                    required.
+                  properties:
+                    httpEndpoint:
+                      default: enabled
+                      description: |-
+                        HTTPEndpoint enables or disables the HTTP metadata endpoint on provisioned
+                        nodes. If metadata options is non-nil, but this parameter is not specified,
+                        the default state is "enabled".
+
+                        If you specify a value of "disabled", instance metadata will not be accessible
+                        on the node.
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpProtocolIPv6:
+                      default: disabled
+                      description: |-
+                        HTTPProtocolIPv6 enables or disables the IPv6 endpoint for the instance metadata
+                        service on provisioned nodes. If metadata options is non-nil, but this parameter
+                        is not specified, the default state is "disabled".
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpPutResponseHopLimit:
+                      default: 1
+                      description: |-
+                        HTTPPutResponseHopLimit is the desired HTTP PUT response hop limit for
+                        instance metadata requests. The larger the number, the further instance
+                        metadata requests can travel. Possible values are integers from 1 to 64.
+                        If metadata options is non-nil, but this parameter is not specified, the
+                        default value is 1.
+                      format: int64
+                      maximum: 64
+                      minimum: 1
+                      type: integer
+                    httpTokens:
+                      default: required
+                      description: |-
+                        HTTPTokens determines the state of token usage for instance metadata
+                        requests. If metadata options is non-nil, but this parameter is not
+                        specified, the default state is "required".
+
+                        If the state is optional, one can choose to retrieve instance metadata with
+                        or without a signed token header on the request. If one retrieves the IAM
+                        role credentials without a token, the version 1.0 role credentials are
+                        returned. If one retrieves the IAM role credentials using a valid signed
+                        token, the version 2.0 role credentials are returned.
+
+                        If the state is "required", one must send a signed token header with any
+                        instance metadata retrieval requests. In this state, retrieving the IAM
+                        role credentials always returns the version 2.0 credentials; the version
+                        1.0 credentials are not available.
+                      enum:
+                        - required
+                        - optional
+                      type: string
+                  type: object
+                role:
+                  description: |-
+                    Role is the AWS identity that nodes use. This field is immutable.
+                    This field is mutually exclusive from instanceProfile.
+                    Marking this field as immutable avoids concerns around terminating managed instance profiles from running instances.
+                    This field may be made mutable in the future, assuming the correct garbage collection and drift handling is implemented
+                    for the old instance profiles on an update.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: role cannot be empty
+                      rule: self != ''
+                    - message: immutable field changed
+                      rule: self == oldSelf
+                securityGroupSelectorTerms:
+                  description: SecurityGroupSelectorTerms is a list of or security group selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SecurityGroupSelectorTerm defines selection logic for a security group used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the security group id in EC2
+                        pattern: sg-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the security group name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select security groups.
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: securityGroupSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id', 'name']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && (has(x.tags) || has(x.name)))'
+                    - message: '''name'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.name) && (has(x.tags) || has(x.id)))'
+                subnetSelectorTerms:
+                  description: SubnetSelectorTerms is a list of or subnet selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SubnetSelectorTerm defines selection logic for a subnet used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the subnet id in EC2
+                        pattern: subnet-[0-9a-z]+
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: subnetSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id']
+                      rule: self.all(x, has(x.tags) || has(x.id))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in subnetSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && has(x.tags))'
+                tags:
+                  additionalProperties:
+                    type: string
+                  description: Tags to be applied on ec2 resources like instances and launch templates.
+                  type: object
+                  x-kubernetes-validations:
+                    - message: empty tag keys aren't supported
+                      rule: self.all(k, k != '')
+                    - message: tag contains a restricted tag matching eks:eks-cluster-name
+                      rule: self.all(k, k !='eks:eks-cluster-name')
+                    - message: tag contains a restricted tag matching kubernetes.io/cluster/
+                      rule: self.all(k, !k.startsWith('kubernetes.io/cluster') )
+                    - message: tag contains a restricted tag matching karpenter.sh/nodepool
+                      rule: self.all(k, k != 'karpenter.sh/nodepool')
+                    - message: tag contains a restricted tag matching karpenter.sh/nodeclaim
+                      rule: self.all(k, k !='karpenter.sh/nodeclaim')
+                    - message: tag contains a restricted tag matching karpenter.k8s.aws/ec2nodeclass
+                      rule: self.all(k, k !='karpenter.k8s.aws/ec2nodeclass')
+                userData:
+                  description: |-
+                    UserData to be applied to the provisioned nodes.
+                    It must be in the appropriate format based on the AMIFamily in use. Karpenter will merge certain fields into
+                    this UserData to ensure nodes are being provisioned with the correct configuration.
+                  type: string
+              required:
+                - amiSelectorTerms
+                - securityGroupSelectorTerms
+                - subnetSelectorTerms
+              type: object
+              x-kubernetes-validations:
+                - message: must specify exactly one of ['role', 'instanceProfile']
+                  rule: (has(self.role) && !has(self.instanceProfile)) || (!has(self.role) && has(self.instanceProfile))
+                - message: changing from 'instanceProfile' to 'role' is not supported. You must delete and recreate this node class if you want to change this.
+                  rule: (has(oldSelf.role) && has(self.role)) || (has(oldSelf.instanceProfile) && has(self.instanceProfile))
+                - message: if set, amiFamily must be 'AL2' or 'Custom' when using an AL2 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''al2'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''AL2'') : true)'
+                - message: if set, amiFamily must be 'AL2023' or 'Custom' when using an AL2023 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''al2023'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''AL2023'') : true)'
+                - message: if set, amiFamily must be 'Bottlerocket' or 'Custom' when using a Bottlerocket alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''bottlerocket'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Bottlerocket'') : true)'
+                - message: if set, amiFamily must be 'Windows2019' or 'Custom' when using a Windows2019 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''windows2019'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Windows2019'') : true)'
+                - message: if set, amiFamily must be 'Windows2022' or 'Custom' when using a Windows2022 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''windows2022'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Windows2022'') : true)'
+                - message: must specify amiFamily if amiSelectorTerms does not contain an alias
+                  rule: 'self.amiSelectorTerms.exists(x, has(x.alias)) ? true : has(self.amiFamily)'
+            status:
+              description: EC2NodeClassStatus contains the resolved state of the EC2NodeClass
+              properties:
+                amis:
+                  description: |-
+                    AMI contains the current AMI values that are available to the
+                    cluster under the AMI selectors.
+                  items:
+                    description: AMI contains resolved AMI selector values utilized for node launch
+                    properties:
+                      deprecated:
+                        description: Deprecation status of the AMI
+                        type: boolean
+                      id:
+                        description: ID of the AMI
+                        type: string
+                      name:
+                        description: Name of the AMI
+                        type: string
+                      requirements:
+                        description: Requirements of the AMI to be utilized on an instance type
+                        items:
+                          description: |-
+                            A node selector requirement is a selector that contains values, a key, and an operator
+                            that relates the key and values.
+                          properties:
+                            key:
+                              description: The label key that the selector applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                Represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                              type: string
+                            values:
+                              description: |-
+                                An array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. If the operator is Gt or Lt, the values
+                                array must have a single element, which will be interpreted as an integer.
+                                This array is replaced during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                            - key
+                            - operator
+                          type: object
+                        type: array
+                    required:
+                      - id
+                      - requirements
+                    type: object
+                  type: array
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                instanceProfile:
+                  description: InstanceProfile contains the resolved instance profile for the role
+                  type: string
+                securityGroups:
+                  description: |-
+                    SecurityGroups contains the current security group values that are available to the
+                    cluster under the SecurityGroups selectors.
+                  items:
+                    description: SecurityGroup contains resolved SecurityGroup selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the security group
+                        type: string
+                      name:
+                        description: Name of the security group
+                        type: string
+                    required:
+                      - id
+                    type: object
+                  type: array
+                subnets:
+                  description: |-
+                    Subnets contains the current subnet values that are available to the
+                    cluster under the subnet selectors.
+                  items:
+                    description: Subnet contains resolved Subnet selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the subnet
+                        type: string
+                      zone:
+                        description: The associated availability zone
+                        type: string
+                      zoneID:
+                        description: The associated availability zone ID
+                        type: string
+                    required:
+                      - id
+                      - zone
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/content/projects/karpenter/v1.2.2/karpenter.sh_nodeclaims.yaml
+++ b/content/projects/karpenter/v1.2.2/karpenter.sh_nodeclaims.yaml
@@ -1,0 +1,395 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: nodeclaims.karpenter.sh
+spec:
+  group: karpenter.sh
+  names:
+    categories:
+      - karpenter
+    kind: NodeClaim
+    listKind: NodeClaimList
+    plural: nodeclaims
+    singular: nodeclaim
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.labels.node\.kubernetes\.io/instance-type
+          name: Type
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/capacity-type
+          name: Capacity
+          type: string
+        - jsonPath: .metadata.labels.topology\.kubernetes\.io/zone
+          name: Zone
+          type: string
+        - jsonPath: .status.nodeName
+          name: Node
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .status.imageID
+          name: ImageID
+          priority: 1
+          type: string
+        - jsonPath: .status.providerID
+          name: ID
+          priority: 1
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/nodepool
+          name: NodePool
+          priority: 1
+          type: string
+        - jsonPath: .spec.nodeClassRef.name
+          name: NodeClass
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: NodeClaim is the Schema for the NodeClaims API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: NodeClaimSpec describes the desired state of the NodeClaim
+              properties:
+                expireAfter:
+                  default: 720h
+                  description: |-
+                    ExpireAfter is the duration the controller will wait
+                    before terminating a node, measured from when the node is created. This
+                    is useful to implement features like eventually consistent node upgrade,
+                    memory leak protection, and disruption testing.
+                  pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                  type: string
+                nodeClassRef:
+                  description: NodeClassRef is a reference to an object that defines provider specific configuration
+                  properties:
+                    group:
+                      description: API version of the referent
+                      pattern: ^[^/]*$
+                      type: string
+                      x-kubernetes-validations:
+                        - message: group may not be empty
+                          rule: self != ''
+                    kind:
+                      description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                      type: string
+                      x-kubernetes-validations:
+                        - message: kind may not be empty
+                          rule: self != ''
+                    name:
+                      description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                      type: string
+                      x-kubernetes-validations:
+                        - message: name may not be empty
+                          rule: self != ''
+                  required:
+                    - group
+                    - kind
+                    - name
+                  type: object
+                requirements:
+                  description: Requirements are layered with GetLabels and applied to every node.
+                  items:
+                    description: |-
+                      A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                      and minValues that represent the requirement to have at least that many values.
+                    properties:
+                      key:
+                        description: The label key that the selector applies to.
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                        x-kubernetes-validations:
+                          - message: label domain "kubernetes.io" is restricted
+                            rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                          - message: label domain "k8s.io" is restricted
+                            rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                          - message: label domain "karpenter.sh" is restricted
+                            rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                          - message: label "kubernetes.io/hostname" is restricted
+                            rule: self != "kubernetes.io/hostname"
+                          - message: label domain "karpenter.k8s.aws" is restricted
+                            rule: self in ["karpenter.k8s.aws/ec2nodeclass", "karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu", "karpenter.k8s.aws/instance-cpu-manufacturer", "karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz", "karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                      minValues:
+                        description: |-
+                          This field is ALPHA and can be dropped or replaced at any time
+                          MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                        maximum: 50
+                        minimum: 1
+                        type: integer
+                      operator:
+                        description: |-
+                          Represents a key's relationship to a set of values.
+                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                        type: string
+                        enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          - Gt
+                          - Lt
+                      values:
+                        description: |-
+                          An array of string values. If the operator is In or NotIn,
+                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                          the values array must be empty. If the operator is Gt or Lt, the values
+                          array must have a single element, which will be interpreted as an integer.
+                          This array is replaced during a strategic merge patch.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                        maxLength: 63
+                        pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                    required:
+                      - key
+                      - operator
+                    type: object
+                  maxItems: 100
+                  type: array
+                  x-kubernetes-validations:
+                    - message: requirements with operator 'In' must have a value defined
+                      rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                    - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                      rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                    - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                      rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                resources:
+                  description: Resources models the resource requirements for the NodeClaim to launch
+                  properties:
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: Requests describes the minimum required resources for the NodeClaim to launch
+                      type: object
+                  type: object
+                startupTaints:
+                  description: |-
+                    StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                    within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                    daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                    purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                taints:
+                  description: Taints will be applied to the NodeClaim's node.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                terminationGracePeriod:
+                  description: |-
+                    TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
+
+                    Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
+
+                    This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
+                    When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
+
+                    Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
+                    If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
+                    that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
+
+                    The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
+                    If left undefined, the controller will wait indefinitely for pods to be drained.
+                  pattern: ^([0-9]+(s|m|h))+$
+                  type: string
+              required:
+                - nodeClassRef
+                - requirements
+              type: object
+              x-kubernetes-validations:
+                - message: spec is immutable
+                  rule: self == oldSelf
+            status:
+              description: NodeClaimStatus defines the observed state of NodeClaim
+              properties:
+                allocatable:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Allocatable is the estimated allocatable capacity of the node
+                  type: object
+                capacity:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Capacity is the estimated full capacity of the node
+                  type: object
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        pattern: ^([A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?|)$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - status
+                      - type
+                    type: object
+                  type: array
+                imageID:
+                  description: ImageID is an identifier for the image that runs on the node
+                  type: string
+                lastPodEventTime:
+                  description: |-
+                    LastPodEventTime is updated with the last time a pod was scheduled
+                    or removed from the node. A pod going terminal or terminating
+                    is also considered as removed.
+                  format: date-time
+                  type: string
+                nodeName:
+                  description: NodeName is the name of the corresponding node object
+                  type: string
+                providerID:
+                  description: ProviderID of the corresponding node object
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/content/projects/karpenter/v1.2.2/karpenter.sh_nodepools.yaml
+++ b/content/projects/karpenter/v1.2.2/karpenter.sh_nodepools.yaml
@@ -1,0 +1,519 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: nodepools.karpenter.sh
+spec:
+  group: karpenter.sh
+  names:
+    categories:
+      - karpenter
+    kind: NodePool
+    listKind: NodePoolList
+    plural: nodepools
+    singular: nodepool
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.template.spec.nodeClassRef.name
+          name: NodeClass
+          type: string
+        - jsonPath: .status.resources.nodes
+          name: Nodes
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.weight
+          name: Weight
+          priority: 1
+          type: integer
+        - jsonPath: .status.resources.cpu
+          name: CPU
+          priority: 1
+          type: string
+        - jsonPath: .status.resources.memory
+          name: Memory
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: NodePool is the Schema for the NodePools API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                NodePoolSpec is the top level nodepool specification. Nodepools
+                launch nodes in response to pods that are unschedulable. A single nodepool
+                is capable of managing a diverse set of nodes. Node properties are determined
+                from a combination of nodepool and pod scheduling constraints.
+              properties:
+                disruption:
+                  default:
+                    consolidateAfter: 0s
+                  description: Disruption contains the parameters that relate to Karpenter's disruption logic
+                  properties:
+                    budgets:
+                      default:
+                        - nodes: 10%
+                      description: |-
+                        Budgets is a list of Budgets.
+                        If there are multiple active budgets, Karpenter uses
+                        the most restrictive value. If left undefined,
+                        this will default to one budget with a value to 10%.
+                      items:
+                        description: |-
+                          Budget defines when Karpenter will restrict the
+                          number of Node Claims that can be terminating simultaneously.
+                        properties:
+                          duration:
+                            description: |-
+                              Duration determines how long a Budget is active since each Schedule hit.
+                              Only minutes and hours are accepted, as cron does not work in seconds.
+                              If omitted, the budget is always active.
+                              This is required if Schedule is set.
+                              This regex has an optional 0s at the end since the duration.String() always adds
+                              a 0s at the end.
+                            pattern: ^((([0-9]+(h|m))|([0-9]+h[0-9]+m))(0s)?)$
+                            type: string
+                          nodes:
+                            default: 10%
+                            description: |-
+                              Nodes dictates the maximum number of NodeClaims owned by this NodePool
+                              that can be terminating at once. This is calculated by counting nodes that
+                              have a deletion timestamp set, or are actively being deleted by Karpenter.
+                              This field is required when specifying a budget.
+                              This cannot be of type intstr.IntOrString since kubebuilder doesn't support pattern
+                              checking for int nodes for IntOrString nodes.
+                              Ref: https://github.com/kubernetes-sigs/controller-tools/blob/55efe4be40394a288216dab63156b0a64fb82929/pkg/crd/markers/validation.go#L379-L388
+                            pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
+                            type: string
+                          reasons:
+                            description: |-
+                              Reasons is a list of disruption methods that this budget applies to. If Reasons is not set, this budget applies to all methods.
+                              Otherwise, this will apply to each reason defined.
+                              allowed reasons are Underutilized, Empty, and Drifted.
+                            items:
+                              description: DisruptionReason defines valid reasons for disruption budgets.
+                              enum:
+                                - Underutilized
+                                - Empty
+                                - Drifted
+                              type: string
+                            type: array
+                          schedule:
+                            description: |-
+                              Schedule specifies when a budget begins being active, following
+                              the upstream cronjob syntax. If omitted, the budget is always active.
+                              Timezones are not supported.
+                              This field is required if Duration is set.
+                            pattern: ^(@(annually|yearly|monthly|weekly|daily|midnight|hourly))|((.+)\s(.+)\s(.+)\s(.+)\s(.+))$
+                            type: string
+                        required:
+                          - nodes
+                        type: object
+                      maxItems: 50
+                      type: array
+                      x-kubernetes-validations:
+                        - message: '''schedule'' must be set with ''duration'''
+                          rule: self.all(x, has(x.schedule) == has(x.duration))
+                    consolidateAfter:
+                      description: |-
+                        ConsolidateAfter is the duration the controller will wait
+                        before attempting to terminate nodes that are underutilized.
+                        Refer to ConsolidationPolicy for how underutilization is considered.
+                      pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                      type: string
+                    consolidationPolicy:
+                      default: WhenEmptyOrUnderutilized
+                      description: |-
+                        ConsolidationPolicy describes which nodes Karpenter can disrupt through its consolidation
+                        algorithm. This policy defaults to "WhenEmptyOrUnderutilized" if not specified
+                      enum:
+                        - WhenEmpty
+                        - WhenEmptyOrUnderutilized
+                      type: string
+                  required:
+                    - consolidateAfter
+                  type: object
+                limits:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Limits define a set of bounds for provisioning capacity.
+                  type: object
+                template:
+                  description: |-
+                    Template contains the template of possibilities for the provisioning logic to launch a NodeClaim with.
+                    NodeClaims launched from this NodePool will often be further constrained than the template specifies.
+                  properties:
+                    metadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Annotations is an unstructured key value map stored with a resource that may be
+                            set by external tools to store and retrieve arbitrary metadata. They are not
+                            queryable and should be preserved when modifying objects.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                            maxLength: 63
+                            pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                          description: |-
+                            Map of string keys and values that can be used to organize and categorize
+                            (scope and select) objects. May match selectors of replication controllers
+                            and services.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
+                          type: object
+                          maxProperties: 100
+                          x-kubernetes-validations:
+                            - message: label domain "kubernetes.io" is restricted
+                              rule: self.all(x, x in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region",  "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || x.find("^([^/]+)").endsWith("node.kubernetes.io") || x.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !x.find("^([^/]+)").endsWith("kubernetes.io"))
+                            - message: label domain "k8s.io" is restricted
+                              rule: self.all(x, x.find("^([^/]+)").endsWith("kops.k8s.io") || !x.find("^([^/]+)").endsWith("k8s.io"))
+                            - message: label domain "karpenter.sh" is restricted
+                              rule: self.all(x, x in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !x.find("^([^/]+)").endsWith("karpenter.sh"))
+                            - message: label "karpenter.sh/nodepool" is restricted
+                              rule: self.all(x, x != "karpenter.sh/nodepool")
+                            - message: label "kubernetes.io/hostname" is restricted
+                              rule: self.all(x, x != "kubernetes.io/hostname")
+                            - message: label domain "karpenter.k8s.aws" is restricted
+                              rule: self.all(x, x in ["karpenter.k8s.aws/ec2nodeclass", "karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu", "karpenter.k8s.aws/instance-cpu-manufacturer", "karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz", "karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !x.find("^([^/]+)").endsWith("karpenter.k8s.aws"))
+                      type: object
+                    spec:
+                      description: |-
+                        NodeClaimTemplateSpec describes the desired state of the NodeClaim in the Nodepool
+                        NodeClaimTemplateSpec is used in the NodePool's NodeClaimTemplate, with the resource requests omitted since
+                        users are not able to set resource requests in the NodePool.
+                      properties:
+                        expireAfter:
+                          default: 720h
+                          description: |-
+                            ExpireAfter is the duration the controller will wait
+                            before terminating a node, measured from when the node is created. This
+                            is useful to implement features like eventually consistent node upgrade,
+                            memory leak protection, and disruption testing.
+                          pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                          type: string
+                        nodeClassRef:
+                          description: NodeClassRef is a reference to an object that defines provider specific configuration
+                          properties:
+                            group:
+                              description: API version of the referent
+                              pattern: ^[^/]*$
+                              type: string
+                              x-kubernetes-validations:
+                                - message: group may not be empty
+                                  rule: self != ''
+                            kind:
+                              description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                              type: string
+                              x-kubernetes-validations:
+                                - message: kind may not be empty
+                                  rule: self != ''
+                            name:
+                              description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                              x-kubernetes-validations:
+                                - message: name may not be empty
+                                  rule: self != ''
+                          required:
+                            - group
+                            - kind
+                            - name
+                          type: object
+                          x-kubernetes-validations:
+                            - message: nodeClassRef.group is immutable
+                              rule: self.group == oldSelf.group
+                            - message: nodeClassRef.kind is immutable
+                              rule: self.kind == oldSelf.kind
+                        requirements:
+                          description: Requirements are layered with GetLabels and applied to every node.
+                          items:
+                            description: |-
+                              A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                              and minValues that represent the requirement to have at least that many values.
+                            properties:
+                              key:
+                                description: The label key that the selector applies to.
+                                type: string
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                                x-kubernetes-validations:
+                                  - message: label domain "kubernetes.io" is restricted
+                                    rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                                  - message: label domain "k8s.io" is restricted
+                                    rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                                  - message: label domain "karpenter.sh" is restricted
+                                    rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                                  - message: label "karpenter.sh/nodepool" is restricted
+                                    rule: self != "karpenter.sh/nodepool"
+                                  - message: label "kubernetes.io/hostname" is restricted
+                                    rule: self != "kubernetes.io/hostname"
+                                  - message: label domain "karpenter.k8s.aws" is restricted
+                                    rule: self in ["karpenter.k8s.aws/ec2nodeclass", "karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu", "karpenter.k8s.aws/instance-cpu-manufacturer", "karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz", "karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                              minValues:
+                                description: |-
+                                  This field is ALPHA and can be dropped or replaced at any time
+                                  MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                                maximum: 50
+                                minimum: 1
+                                type: integer
+                              operator:
+                                description: |-
+                                  Represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                type: string
+                                enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  - Gt
+                                  - Lt
+                              values:
+                                description: |-
+                                  An array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                  array must have a single element, which will be interpreted as an integer.
+                                  This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          maxItems: 100
+                          type: array
+                          x-kubernetes-validations:
+                            - message: requirements with operator 'In' must have a value defined
+                              rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                            - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                              rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                            - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                              rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                        startupTaints:
+                          description: |-
+                            StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                            within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                            daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                            purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        taints:
+                          description: Taints will be applied to the NodeClaim's node.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        terminationGracePeriod:
+                          description: |-
+                            TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
+
+                            Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
+
+                            This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
+                            When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
+
+                            Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
+                            If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
+                            that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
+
+                            The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
+                            If left undefined, the controller will wait indefinitely for pods to be drained.
+                          pattern: ^([0-9]+(s|m|h))+$
+                          type: string
+                      required:
+                        - nodeClassRef
+                        - requirements
+                      type: object
+                  required:
+                    - spec
+                  type: object
+                weight:
+                  description: |-
+                    Weight is the priority given to the nodepool during scheduling. A higher
+                    numerical weight indicates that this nodepool will be ordered
+                    ahead of other nodepools with lower weights. A nodepool with no weight
+                    will be treated as if it is a nodepool with a weight of 0.
+                  format: int32
+                  maximum: 100
+                  minimum: 1
+                  type: integer
+              required:
+                - template
+              type: object
+            status:
+              description: NodePoolStatus defines the observed state of NodePool
+              properties:
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                resources:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Resources is the list of resources that have been provisioned.
+                  type: object
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/content/projects/karpenter/v1.2.3/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/content/projects/karpenter/v1.2.3/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -1,0 +1,742 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: ec2nodeclasses.karpenter.k8s.aws
+spec:
+  group: karpenter.k8s.aws
+  names:
+    categories:
+      - karpenter
+    kind: EC2NodeClass
+    listKind: EC2NodeClassList
+    plural: ec2nodeclasses
+    shortNames:
+      - ec2nc
+      - ec2ncs
+    singular: ec2nodeclass
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.role
+          name: Role
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: EC2NodeClass is the Schema for the EC2NodeClass API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                EC2NodeClassSpec is the top level specification for the AWS Karpenter Provider.
+                This will contain configuration necessary to launch instances in AWS.
+              properties:
+                amiFamily:
+                  description: |-
+                    AMIFamily dictates the UserData format and default BlockDeviceMappings used when generating launch templates.
+                    This field is optional when using an alias amiSelectorTerm, and the value will be inferred from the alias'
+                    family. When an alias is specified, this field may only be set to its corresponding family or 'Custom'. If no
+                    alias is specified, this field is required.
+                    NOTE: We ignore the AMIFamily for hashing here because we hash the AMIFamily dynamically by using the alias using
+                    the AMIFamily() helper function
+                  enum:
+                    - AL2
+                    - AL2023
+                    - Bottlerocket
+                    - Custom
+                    - Windows2019
+                    - Windows2022
+                  type: string
+                amiSelectorTerms:
+                  description: AMISelectorTerms is a list of or ami selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      AMISelectorTerm defines selection logic for an ami used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      alias:
+                        description: |-
+                          Alias specifies which EKS optimized AMI to select.
+                          Each alias consists of a family and an AMI version, specified as "family@version".
+                          Valid families include: al2, al2023, bottlerocket, windows2019, and windows2022.
+                          The version can either be pinned to a specific AMI release, with that AMIs version format (ex: "al2023@v20240625" or "bottlerocket@v1.10.0").
+                          The version can also be set to "latest" for any family. Setting the version to latest will result in drift when a new AMI is released. This is **not** recommended for production environments.
+                          Note: The Windows families do **not** support version pinning, and only latest may be used.
+                        maxLength: 30
+                        type: string
+                        x-kubernetes-validations:
+                          - message: '''alias'' is improperly formatted, must match the format ''family@version'''
+                            rule: self.matches('^[a-zA-Z0-9]+@.+$')
+                          - message: 'family is not supported, must be one of the following: ''al2'', ''al2023'', ''bottlerocket'', ''windows2019'', ''windows2022'''
+                            rule: self.split('@')[0] in ['al2','al2023','bottlerocket','windows2019','windows2022']
+                          - message: windows families may only specify version 'latest'
+                            rule: 'self.split(''@'')[0] in [''windows2019'',''windows2022''] ? self.split(''@'')[1] == ''latest'' : true'
+                      id:
+                        description: ID is the ami id in EC2
+                        pattern: ami-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the ami name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      owner:
+                        description: |-
+                          Owner is the owner for the ami.
+                          You can specify a combination of AWS account IDs, "self", "amazon", and "aws-marketplace"
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select amis.
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  minItems: 1
+                  type: array
+                  x-kubernetes-validations:
+                    - message: expected at least one, got none, ['tags', 'id', 'name', 'alias']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name) || has(x.alias))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.exists(x, has(x.id) && (has(x.alias) || has(x.tags) || has(x.name) || has(x.owner)))'
+                    - message: '''alias'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.exists(x, has(x.alias) && (has(x.id) || has(x.tags) || has(x.name) || has(x.owner)))'
+                    - message: '''alias'' is mutually exclusive, cannot be set with a combination of other amiSelectorTerms'
+                      rule: '!(self.exists(x, has(x.alias)) && self.size() != 1)'
+                associatePublicIPAddress:
+                  description: AssociatePublicIPAddress controls if public IP addresses are assigned to instances that are launched with the nodeclass.
+                  type: boolean
+                blockDeviceMappings:
+                  description: BlockDeviceMappings to be applied to provisioned nodes.
+                  items:
+                    properties:
+                      deviceName:
+                        description: The device name (for example, /dev/sdh or xvdh).
+                        type: string
+                      ebs:
+                        description: EBS contains parameters used to automatically set up EBS volumes when an instance is launched.
+                        properties:
+                          deleteOnTermination:
+                            description: DeleteOnTermination indicates whether the EBS volume is deleted on instance termination.
+                            type: boolean
+                          encrypted:
+                            description: |-
+                              Encrypted indicates whether the EBS volume is encrypted. Encrypted volumes can only
+                              be attached to instances that support Amazon EBS encryption. If you are creating
+                              a volume from a snapshot, you can't specify an encryption value.
+                            type: boolean
+                          iops:
+                            description: |-
+                              IOPS is the number of I/O operations per second (IOPS). For gp3, io1, and io2 volumes,
+                              this represents the number of IOPS that are provisioned for the volume. For
+                              gp2 volumes, this represents the baseline performance of the volume and the
+                              rate at which the volume accumulates I/O credits for bursting.
+
+                              The following are the supported values for each volume type:
+
+                                 * gp3: 3,000-16,000 IOPS
+
+                                 * io1: 100-64,000 IOPS
+
+                                 * io2: 100-64,000 IOPS
+
+                              For io1 and io2 volumes, we guarantee 64,000 IOPS only for Instances built
+                              on the Nitro System (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances).
+                              Other instance families guarantee performance up to 32,000 IOPS.
+
+                              This parameter is supported for io1, io2, and gp3 volumes only. This parameter
+                              is not supported for gp2, st1, sc1, or standard volumes.
+                            format: int64
+                            type: integer
+                          kmsKeyID:
+                            description: KMSKeyID (ARN) of the symmetric Key Management Service (KMS) CMK used for encryption.
+                            type: string
+                          snapshotID:
+                            description: SnapshotID is the ID of an EBS snapshot
+                            type: string
+                          throughput:
+                            description: |-
+                              Throughput to provision for a gp3 volume, with a maximum of 1,000 MiB/s.
+                              Valid Range: Minimum value of 125. Maximum value of 1000.
+                            format: int64
+                            type: integer
+                          volumeSize:
+                            description: |-
+                              VolumeSize in `Gi`, `G`, `Ti`, or `T`. You must specify either a snapshot ID or
+                              a volume size. The following are the supported volumes sizes for each volume
+                              type:
+
+                                 * gp2 and gp3: 1-16,384
+
+                                 * io1 and io2: 4-16,384
+
+                                 * st1 and sc1: 125-16,384
+
+                                 * standard: 1-1,024
+                            pattern: ^((?:[1-9][0-9]{0,3}|[1-4][0-9]{4}|[5][0-8][0-9]{3}|59000)Gi|(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|[6][0-3][0-9]{3}|64000)G|([1-9]||[1-5][0-7]|58)Ti|([1-9]||[1-5][0-9]|6[0-3]|64)T)$
+                            type: string
+                          volumeType:
+                            description: |-
+                              VolumeType of the block device.
+                              For more information, see Amazon EBS volume types (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html)
+                              in the Amazon Elastic Compute Cloud User Guide.
+                            enum:
+                              - standard
+                              - io1
+                              - io2
+                              - gp2
+                              - sc1
+                              - st1
+                              - gp3
+                            type: string
+                        type: object
+                        x-kubernetes-validations:
+                          - message: snapshotID or volumeSize must be defined
+                            rule: has(self.snapshotID) || has(self.volumeSize)
+                      rootVolume:
+                        description: |-
+                          RootVolume is a flag indicating if this device is mounted as kubelet root dir. You can
+                          configure at most one root volume in BlockDeviceMappings.
+                        type: boolean
+                    type: object
+                  maxItems: 50
+                  type: array
+                  x-kubernetes-validations:
+                    - message: must have only one blockDeviceMappings with rootVolume
+                      rule: self.filter(x, has(x.rootVolume)?x.rootVolume==true:false).size() <= 1
+                context:
+                  description: |-
+                    Context is a Reserved field in EC2 APIs
+                    https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet.html
+                  type: string
+                detailedMonitoring:
+                  description: DetailedMonitoring controls if detailed monitoring is enabled for instances that are launched
+                  type: boolean
+                instanceProfile:
+                  description: |-
+                    InstanceProfile is the AWS entity that instances use.
+                    This field is mutually exclusive from role.
+                    The instance profile should already have a role assigned to it that Karpenter
+                     has PassRole permission on for instance launch using this instanceProfile to succeed.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: instanceProfile cannot be empty
+                      rule: self != ''
+                instanceStorePolicy:
+                  description: InstanceStorePolicy specifies how to handle instance-store disks.
+                  enum:
+                    - RAID0
+                  type: string
+                kubelet:
+                  description: |-
+                    Kubelet defines args to be used when configuring kubelet on provisioned nodes.
+                    They are a subset of the upstream types, recognizing not all options may be supported.
+                    Wherever possible, the types and names should reflect the upstream kubelet types.
+                  properties:
+                    clusterDNS:
+                      description: |-
+                        clusterDNS is a list of IP addresses for the cluster DNS server.
+                        Note that not all providers may use all addresses.
+                      items:
+                        type: string
+                      type: array
+                    cpuCFSQuota:
+                      description: CPUCFSQuota enables CPU CFS quota enforcement for containers that specify CPU limits.
+                      type: boolean
+                    evictionHard:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionHard is the map of signal names to quantities that define hard eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionHard are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionMaxPodGracePeriod:
+                      description: |-
+                        EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in
+                        response to soft eviction thresholds being met.
+                      format: int32
+                      type: integer
+                    evictionSoft:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionSoft is the map of signal names to quantities that define soft eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoft are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionSoftGracePeriod:
+                      additionalProperties:
+                        type: string
+                      description: EvictionSoftGracePeriod is the map of signal names to quantities that define grace periods for each eviction signal
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoftGracePeriod are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    imageGCHighThresholdPercent:
+                      description: |-
+                        ImageGCHighThresholdPercent is the percent of disk usage after which image
+                        garbage collection is always run. The percent is calculated by dividing this
+                        field value by 100, so this field must be between 0 and 100, inclusive.
+                        When specified, the value must be greater than ImageGCLowThresholdPercent.
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    imageGCLowThresholdPercent:
+                      description: |-
+                        ImageGCLowThresholdPercent is the percent of disk usage before which image
+                        garbage collection is never run. Lowest disk usage to garbage collect to.
+                        The percent is calculated by dividing this field value by 100,
+                        so the field value must be between 0 and 100, inclusive.
+                        When specified, the value must be less than imageGCHighThresholdPercent
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    kubeReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: KubeReserved contains resources reserved for Kubernetes system components.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for kubeReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: kubeReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                    maxPods:
+                      description: |-
+                        MaxPods is an override for the maximum number of pods that can run on
+                        a worker node instance.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    podsPerCore:
+                      description: |-
+                        PodsPerCore is an override for the number of pods that can run on a worker node
+                        instance based on the number of cpu cores. This value cannot exceed MaxPods, so, if
+                        MaxPods is a lower value, that value will be used.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    systemReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: SystemReserved contains resources reserved for OS system daemons and kernel memory.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for systemReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: systemReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                  type: object
+                  x-kubernetes-validations:
+                    - message: imageGCHighThresholdPercent must be greater than imageGCLowThresholdPercent
+                      rule: 'has(self.imageGCHighThresholdPercent) && has(self.imageGCLowThresholdPercent) ?  self.imageGCHighThresholdPercent > self.imageGCLowThresholdPercent  : true'
+                    - message: evictionSoft OwnerKey does not have a matching evictionSoftGracePeriod
+                      rule: has(self.evictionSoft) ? self.evictionSoft.all(e, (e in self.evictionSoftGracePeriod)):true
+                    - message: evictionSoftGracePeriod OwnerKey does not have a matching evictionSoft
+                      rule: has(self.evictionSoftGracePeriod) ? self.evictionSoftGracePeriod.all(e, (e in self.evictionSoft)):true
+                metadataOptions:
+                  default:
+                    httpEndpoint: enabled
+                    httpProtocolIPv6: disabled
+                    httpPutResponseHopLimit: 1
+                    httpTokens: required
+                  description: |-
+                    MetadataOptions for the generated launch template of provisioned nodes.
+
+                    This specifies the exposure of the Instance Metadata Service to
+                    provisioned EC2 nodes. For more information,
+                    see Instance Metadata and User Data
+                    (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
+                    in the Amazon Elastic Compute Cloud User Guide.
+
+                    Refer to recommended, security best practices
+                    (https://aws.github.io/aws-eks-best-practices/security/docs/iam/#restrict-access-to-the-instance-profile-assigned-to-the-worker-node)
+                    for limiting exposure of Instance Metadata and User Data to pods.
+                    If omitted, defaults to httpEndpoint enabled, with httpProtocolIPv6
+                    disabled, with httpPutResponseLimit of 1, and with httpTokens
+                    required.
+                  properties:
+                    httpEndpoint:
+                      default: enabled
+                      description: |-
+                        HTTPEndpoint enables or disables the HTTP metadata endpoint on provisioned
+                        nodes. If metadata options is non-nil, but this parameter is not specified,
+                        the default state is "enabled".
+
+                        If you specify a value of "disabled", instance metadata will not be accessible
+                        on the node.
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpProtocolIPv6:
+                      default: disabled
+                      description: |-
+                        HTTPProtocolIPv6 enables or disables the IPv6 endpoint for the instance metadata
+                        service on provisioned nodes. If metadata options is non-nil, but this parameter
+                        is not specified, the default state is "disabled".
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpPutResponseHopLimit:
+                      default: 1
+                      description: |-
+                        HTTPPutResponseHopLimit is the desired HTTP PUT response hop limit for
+                        instance metadata requests. The larger the number, the further instance
+                        metadata requests can travel. Possible values are integers from 1 to 64.
+                        If metadata options is non-nil, but this parameter is not specified, the
+                        default value is 1.
+                      format: int64
+                      maximum: 64
+                      minimum: 1
+                      type: integer
+                    httpTokens:
+                      default: required
+                      description: |-
+                        HTTPTokens determines the state of token usage for instance metadata
+                        requests. If metadata options is non-nil, but this parameter is not
+                        specified, the default state is "required".
+
+                        If the state is optional, one can choose to retrieve instance metadata with
+                        or without a signed token header on the request. If one retrieves the IAM
+                        role credentials without a token, the version 1.0 role credentials are
+                        returned. If one retrieves the IAM role credentials using a valid signed
+                        token, the version 2.0 role credentials are returned.
+
+                        If the state is "required", one must send a signed token header with any
+                        instance metadata retrieval requests. In this state, retrieving the IAM
+                        role credentials always returns the version 2.0 credentials; the version
+                        1.0 credentials are not available.
+                      enum:
+                        - required
+                        - optional
+                      type: string
+                  type: object
+                role:
+                  description: |-
+                    Role is the AWS identity that nodes use. This field is immutable.
+                    This field is mutually exclusive from instanceProfile.
+                    Marking this field as immutable avoids concerns around terminating managed instance profiles from running instances.
+                    This field may be made mutable in the future, assuming the correct garbage collection and drift handling is implemented
+                    for the old instance profiles on an update.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: role cannot be empty
+                      rule: self != ''
+                    - message: immutable field changed
+                      rule: self == oldSelf
+                securityGroupSelectorTerms:
+                  description: SecurityGroupSelectorTerms is a list of or security group selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SecurityGroupSelectorTerm defines selection logic for a security group used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the security group id in EC2
+                        pattern: sg-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the security group name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select security groups.
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: securityGroupSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id', 'name']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && (has(x.tags) || has(x.name)))'
+                    - message: '''name'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
+                      rule: '!self.all(x, has(x.name) && (has(x.tags) || has(x.id)))'
+                subnetSelectorTerms:
+                  description: SubnetSelectorTerms is a list of or subnet selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SubnetSelectorTerm defines selection logic for a subnet used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the subnet id in EC2
+                        pattern: subnet-[0-9a-z]+
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: subnetSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id']
+                      rule: self.all(x, has(x.tags) || has(x.id))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in subnetSelectorTerms'
+                      rule: '!self.all(x, has(x.id) && has(x.tags))'
+                tags:
+                  additionalProperties:
+                    type: string
+                  description: Tags to be applied on ec2 resources like instances and launch templates.
+                  type: object
+                  x-kubernetes-validations:
+                    - message: empty tag keys aren't supported
+                      rule: self.all(k, k != '')
+                    - message: tag contains a restricted tag matching eks:eks-cluster-name
+                      rule: self.all(k, k !='eks:eks-cluster-name')
+                    - message: tag contains a restricted tag matching kubernetes.io/cluster/
+                      rule: self.all(k, !k.startsWith('kubernetes.io/cluster') )
+                    - message: tag contains a restricted tag matching karpenter.sh/nodepool
+                      rule: self.all(k, k != 'karpenter.sh/nodepool')
+                    - message: tag contains a restricted tag matching karpenter.sh/nodeclaim
+                      rule: self.all(k, k !='karpenter.sh/nodeclaim')
+                    - message: tag contains a restricted tag matching karpenter.k8s.aws/ec2nodeclass
+                      rule: self.all(k, k !='karpenter.k8s.aws/ec2nodeclass')
+                userData:
+                  description: |-
+                    UserData to be applied to the provisioned nodes.
+                    It must be in the appropriate format based on the AMIFamily in use. Karpenter will merge certain fields into
+                    this UserData to ensure nodes are being provisioned with the correct configuration.
+                  type: string
+              required:
+                - amiSelectorTerms
+                - securityGroupSelectorTerms
+                - subnetSelectorTerms
+              type: object
+              x-kubernetes-validations:
+                - message: must specify exactly one of ['role', 'instanceProfile']
+                  rule: (has(self.role) && !has(self.instanceProfile)) || (!has(self.role) && has(self.instanceProfile))
+                - message: changing from 'instanceProfile' to 'role' is not supported. You must delete and recreate this node class if you want to change this.
+                  rule: (has(oldSelf.role) && has(self.role)) || (has(oldSelf.instanceProfile) && has(self.instanceProfile))
+                - message: if set, amiFamily must be 'AL2' or 'Custom' when using an AL2 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''al2'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''AL2'') : true)'
+                - message: if set, amiFamily must be 'AL2023' or 'Custom' when using an AL2023 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''al2023'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''AL2023'') : true)'
+                - message: if set, amiFamily must be 'Bottlerocket' or 'Custom' when using a Bottlerocket alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''bottlerocket'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Bottlerocket'') : true)'
+                - message: if set, amiFamily must be 'Windows2019' or 'Custom' when using a Windows2019 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''windows2019'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Windows2019'') : true)'
+                - message: if set, amiFamily must be 'Windows2022' or 'Custom' when using a Windows2022 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''windows2022'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Windows2022'') : true)'
+                - message: must specify amiFamily if amiSelectorTerms does not contain an alias
+                  rule: 'self.amiSelectorTerms.exists(x, has(x.alias)) ? true : has(self.amiFamily)'
+            status:
+              description: EC2NodeClassStatus contains the resolved state of the EC2NodeClass
+              properties:
+                amis:
+                  description: |-
+                    AMI contains the current AMI values that are available to the
+                    cluster under the AMI selectors.
+                  items:
+                    description: AMI contains resolved AMI selector values utilized for node launch
+                    properties:
+                      deprecated:
+                        description: Deprecation status of the AMI
+                        type: boolean
+                      id:
+                        description: ID of the AMI
+                        type: string
+                      name:
+                        description: Name of the AMI
+                        type: string
+                      requirements:
+                        description: Requirements of the AMI to be utilized on an instance type
+                        items:
+                          description: |-
+                            A node selector requirement is a selector that contains values, a key, and an operator
+                            that relates the key and values.
+                          properties:
+                            key:
+                              description: The label key that the selector applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                Represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                              type: string
+                            values:
+                              description: |-
+                                An array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. If the operator is Gt or Lt, the values
+                                array must have a single element, which will be interpreted as an integer.
+                                This array is replaced during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                            - key
+                            - operator
+                          type: object
+                        type: array
+                    required:
+                      - id
+                      - requirements
+                    type: object
+                  type: array
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                instanceProfile:
+                  description: InstanceProfile contains the resolved instance profile for the role
+                  type: string
+                securityGroups:
+                  description: |-
+                    SecurityGroups contains the current security group values that are available to the
+                    cluster under the SecurityGroups selectors.
+                  items:
+                    description: SecurityGroup contains resolved SecurityGroup selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the security group
+                        type: string
+                      name:
+                        description: Name of the security group
+                        type: string
+                    required:
+                      - id
+                    type: object
+                  type: array
+                subnets:
+                  description: |-
+                    Subnets contains the current subnet values that are available to the
+                    cluster under the subnet selectors.
+                  items:
+                    description: Subnet contains resolved Subnet selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the subnet
+                        type: string
+                      zone:
+                        description: The associated availability zone
+                        type: string
+                      zoneID:
+                        description: The associated availability zone ID
+                        type: string
+                    required:
+                      - id
+                      - zone
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/content/projects/karpenter/v1.2.3/karpenter.sh_nodeclaims.yaml
+++ b/content/projects/karpenter/v1.2.3/karpenter.sh_nodeclaims.yaml
@@ -1,0 +1,395 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: nodeclaims.karpenter.sh
+spec:
+  group: karpenter.sh
+  names:
+    categories:
+      - karpenter
+    kind: NodeClaim
+    listKind: NodeClaimList
+    plural: nodeclaims
+    singular: nodeclaim
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.labels.node\.kubernetes\.io/instance-type
+          name: Type
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/capacity-type
+          name: Capacity
+          type: string
+        - jsonPath: .metadata.labels.topology\.kubernetes\.io/zone
+          name: Zone
+          type: string
+        - jsonPath: .status.nodeName
+          name: Node
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .status.imageID
+          name: ImageID
+          priority: 1
+          type: string
+        - jsonPath: .status.providerID
+          name: ID
+          priority: 1
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/nodepool
+          name: NodePool
+          priority: 1
+          type: string
+        - jsonPath: .spec.nodeClassRef.name
+          name: NodeClass
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: NodeClaim is the Schema for the NodeClaims API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: NodeClaimSpec describes the desired state of the NodeClaim
+              properties:
+                expireAfter:
+                  default: 720h
+                  description: |-
+                    ExpireAfter is the duration the controller will wait
+                    before terminating a node, measured from when the node is created. This
+                    is useful to implement features like eventually consistent node upgrade,
+                    memory leak protection, and disruption testing.
+                  pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                  type: string
+                nodeClassRef:
+                  description: NodeClassRef is a reference to an object that defines provider specific configuration
+                  properties:
+                    group:
+                      description: API version of the referent
+                      pattern: ^[^/]*$
+                      type: string
+                      x-kubernetes-validations:
+                        - message: group may not be empty
+                          rule: self != ''
+                    kind:
+                      description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                      type: string
+                      x-kubernetes-validations:
+                        - message: kind may not be empty
+                          rule: self != ''
+                    name:
+                      description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                      type: string
+                      x-kubernetes-validations:
+                        - message: name may not be empty
+                          rule: self != ''
+                  required:
+                    - group
+                    - kind
+                    - name
+                  type: object
+                requirements:
+                  description: Requirements are layered with GetLabels and applied to every node.
+                  items:
+                    description: |-
+                      A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                      and minValues that represent the requirement to have at least that many values.
+                    properties:
+                      key:
+                        description: The label key that the selector applies to.
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                        x-kubernetes-validations:
+                          - message: label domain "kubernetes.io" is restricted
+                            rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                          - message: label domain "k8s.io" is restricted
+                            rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                          - message: label domain "karpenter.sh" is restricted
+                            rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                          - message: label "kubernetes.io/hostname" is restricted
+                            rule: self != "kubernetes.io/hostname"
+                          - message: label domain "karpenter.k8s.aws" is restricted
+                            rule: self in ["karpenter.k8s.aws/ec2nodeclass", "karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu", "karpenter.k8s.aws/instance-cpu-manufacturer", "karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz", "karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                      minValues:
+                        description: |-
+                          This field is ALPHA and can be dropped or replaced at any time
+                          MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                        maximum: 50
+                        minimum: 1
+                        type: integer
+                      operator:
+                        description: |-
+                          Represents a key's relationship to a set of values.
+                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                        type: string
+                        enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          - Gt
+                          - Lt
+                      values:
+                        description: |-
+                          An array of string values. If the operator is In or NotIn,
+                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                          the values array must be empty. If the operator is Gt or Lt, the values
+                          array must have a single element, which will be interpreted as an integer.
+                          This array is replaced during a strategic merge patch.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                        maxLength: 63
+                        pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                    required:
+                      - key
+                      - operator
+                    type: object
+                  maxItems: 100
+                  type: array
+                  x-kubernetes-validations:
+                    - message: requirements with operator 'In' must have a value defined
+                      rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                    - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                      rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                    - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                      rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                resources:
+                  description: Resources models the resource requirements for the NodeClaim to launch
+                  properties:
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: Requests describes the minimum required resources for the NodeClaim to launch
+                      type: object
+                  type: object
+                startupTaints:
+                  description: |-
+                    StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                    within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                    daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                    purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                taints:
+                  description: Taints will be applied to the NodeClaim's node.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                terminationGracePeriod:
+                  description: |-
+                    TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
+
+                    Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
+
+                    This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
+                    When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
+
+                    Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
+                    If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
+                    that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
+
+                    The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
+                    If left undefined, the controller will wait indefinitely for pods to be drained.
+                  pattern: ^([0-9]+(s|m|h))+$
+                  type: string
+              required:
+                - nodeClassRef
+                - requirements
+              type: object
+              x-kubernetes-validations:
+                - message: spec is immutable
+                  rule: self == oldSelf
+            status:
+              description: NodeClaimStatus defines the observed state of NodeClaim
+              properties:
+                allocatable:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Allocatable is the estimated allocatable capacity of the node
+                  type: object
+                capacity:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Capacity is the estimated full capacity of the node
+                  type: object
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        pattern: ^([A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?|)$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - status
+                      - type
+                    type: object
+                  type: array
+                imageID:
+                  description: ImageID is an identifier for the image that runs on the node
+                  type: string
+                lastPodEventTime:
+                  description: |-
+                    LastPodEventTime is updated with the last time a pod was scheduled
+                    or removed from the node. A pod going terminal or terminating
+                    is also considered as removed.
+                  format: date-time
+                  type: string
+                nodeName:
+                  description: NodeName is the name of the corresponding node object
+                  type: string
+                providerID:
+                  description: ProviderID of the corresponding node object
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/content/projects/karpenter/v1.2.3/karpenter.sh_nodepools.yaml
+++ b/content/projects/karpenter/v1.2.3/karpenter.sh_nodepools.yaml
@@ -1,0 +1,519 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: nodepools.karpenter.sh
+spec:
+  group: karpenter.sh
+  names:
+    categories:
+      - karpenter
+    kind: NodePool
+    listKind: NodePoolList
+    plural: nodepools
+    singular: nodepool
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.template.spec.nodeClassRef.name
+          name: NodeClass
+          type: string
+        - jsonPath: .status.resources.nodes
+          name: Nodes
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.weight
+          name: Weight
+          priority: 1
+          type: integer
+        - jsonPath: .status.resources.cpu
+          name: CPU
+          priority: 1
+          type: string
+        - jsonPath: .status.resources.memory
+          name: Memory
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: NodePool is the Schema for the NodePools API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                NodePoolSpec is the top level nodepool specification. Nodepools
+                launch nodes in response to pods that are unschedulable. A single nodepool
+                is capable of managing a diverse set of nodes. Node properties are determined
+                from a combination of nodepool and pod scheduling constraints.
+              properties:
+                disruption:
+                  default:
+                    consolidateAfter: 0s
+                  description: Disruption contains the parameters that relate to Karpenter's disruption logic
+                  properties:
+                    budgets:
+                      default:
+                        - nodes: 10%
+                      description: |-
+                        Budgets is a list of Budgets.
+                        If there are multiple active budgets, Karpenter uses
+                        the most restrictive value. If left undefined,
+                        this will default to one budget with a value to 10%.
+                      items:
+                        description: |-
+                          Budget defines when Karpenter will restrict the
+                          number of Node Claims that can be terminating simultaneously.
+                        properties:
+                          duration:
+                            description: |-
+                              Duration determines how long a Budget is active since each Schedule hit.
+                              Only minutes and hours are accepted, as cron does not work in seconds.
+                              If omitted, the budget is always active.
+                              This is required if Schedule is set.
+                              This regex has an optional 0s at the end since the duration.String() always adds
+                              a 0s at the end.
+                            pattern: ^((([0-9]+(h|m))|([0-9]+h[0-9]+m))(0s)?)$
+                            type: string
+                          nodes:
+                            default: 10%
+                            description: |-
+                              Nodes dictates the maximum number of NodeClaims owned by this NodePool
+                              that can be terminating at once. This is calculated by counting nodes that
+                              have a deletion timestamp set, or are actively being deleted by Karpenter.
+                              This field is required when specifying a budget.
+                              This cannot be of type intstr.IntOrString since kubebuilder doesn't support pattern
+                              checking for int nodes for IntOrString nodes.
+                              Ref: https://github.com/kubernetes-sigs/controller-tools/blob/55efe4be40394a288216dab63156b0a64fb82929/pkg/crd/markers/validation.go#L379-L388
+                            pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
+                            type: string
+                          reasons:
+                            description: |-
+                              Reasons is a list of disruption methods that this budget applies to. If Reasons is not set, this budget applies to all methods.
+                              Otherwise, this will apply to each reason defined.
+                              allowed reasons are Underutilized, Empty, and Drifted.
+                            items:
+                              description: DisruptionReason defines valid reasons for disruption budgets.
+                              enum:
+                                - Underutilized
+                                - Empty
+                                - Drifted
+                              type: string
+                            type: array
+                          schedule:
+                            description: |-
+                              Schedule specifies when a budget begins being active, following
+                              the upstream cronjob syntax. If omitted, the budget is always active.
+                              Timezones are not supported.
+                              This field is required if Duration is set.
+                            pattern: ^(@(annually|yearly|monthly|weekly|daily|midnight|hourly))|((.+)\s(.+)\s(.+)\s(.+)\s(.+))$
+                            type: string
+                        required:
+                          - nodes
+                        type: object
+                      maxItems: 50
+                      type: array
+                      x-kubernetes-validations:
+                        - message: '''schedule'' must be set with ''duration'''
+                          rule: self.all(x, has(x.schedule) == has(x.duration))
+                    consolidateAfter:
+                      description: |-
+                        ConsolidateAfter is the duration the controller will wait
+                        before attempting to terminate nodes that are underutilized.
+                        Refer to ConsolidationPolicy for how underutilization is considered.
+                      pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                      type: string
+                    consolidationPolicy:
+                      default: WhenEmptyOrUnderutilized
+                      description: |-
+                        ConsolidationPolicy describes which nodes Karpenter can disrupt through its consolidation
+                        algorithm. This policy defaults to "WhenEmptyOrUnderutilized" if not specified
+                      enum:
+                        - WhenEmpty
+                        - WhenEmptyOrUnderutilized
+                      type: string
+                  required:
+                    - consolidateAfter
+                  type: object
+                limits:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Limits define a set of bounds for provisioning capacity.
+                  type: object
+                template:
+                  description: |-
+                    Template contains the template of possibilities for the provisioning logic to launch a NodeClaim with.
+                    NodeClaims launched from this NodePool will often be further constrained than the template specifies.
+                  properties:
+                    metadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Annotations is an unstructured key value map stored with a resource that may be
+                            set by external tools to store and retrieve arbitrary metadata. They are not
+                            queryable and should be preserved when modifying objects.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                            maxLength: 63
+                            pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                          description: |-
+                            Map of string keys and values that can be used to organize and categorize
+                            (scope and select) objects. May match selectors of replication controllers
+                            and services.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
+                          type: object
+                          maxProperties: 100
+                          x-kubernetes-validations:
+                            - message: label domain "kubernetes.io" is restricted
+                              rule: self.all(x, x in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region",  "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || x.find("^([^/]+)").endsWith("node.kubernetes.io") || x.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !x.find("^([^/]+)").endsWith("kubernetes.io"))
+                            - message: label domain "k8s.io" is restricted
+                              rule: self.all(x, x.find("^([^/]+)").endsWith("kops.k8s.io") || !x.find("^([^/]+)").endsWith("k8s.io"))
+                            - message: label domain "karpenter.sh" is restricted
+                              rule: self.all(x, x in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !x.find("^([^/]+)").endsWith("karpenter.sh"))
+                            - message: label "karpenter.sh/nodepool" is restricted
+                              rule: self.all(x, x != "karpenter.sh/nodepool")
+                            - message: label "kubernetes.io/hostname" is restricted
+                              rule: self.all(x, x != "kubernetes.io/hostname")
+                            - message: label domain "karpenter.k8s.aws" is restricted
+                              rule: self.all(x, x in ["karpenter.k8s.aws/ec2nodeclass", "karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu", "karpenter.k8s.aws/instance-cpu-manufacturer", "karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz", "karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !x.find("^([^/]+)").endsWith("karpenter.k8s.aws"))
+                      type: object
+                    spec:
+                      description: |-
+                        NodeClaimTemplateSpec describes the desired state of the NodeClaim in the Nodepool
+                        NodeClaimTemplateSpec is used in the NodePool's NodeClaimTemplate, with the resource requests omitted since
+                        users are not able to set resource requests in the NodePool.
+                      properties:
+                        expireAfter:
+                          default: 720h
+                          description: |-
+                            ExpireAfter is the duration the controller will wait
+                            before terminating a node, measured from when the node is created. This
+                            is useful to implement features like eventually consistent node upgrade,
+                            memory leak protection, and disruption testing.
+                          pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                          type: string
+                        nodeClassRef:
+                          description: NodeClassRef is a reference to an object that defines provider specific configuration
+                          properties:
+                            group:
+                              description: API version of the referent
+                              pattern: ^[^/]*$
+                              type: string
+                              x-kubernetes-validations:
+                                - message: group may not be empty
+                                  rule: self != ''
+                            kind:
+                              description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                              type: string
+                              x-kubernetes-validations:
+                                - message: kind may not be empty
+                                  rule: self != ''
+                            name:
+                              description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                              x-kubernetes-validations:
+                                - message: name may not be empty
+                                  rule: self != ''
+                          required:
+                            - group
+                            - kind
+                            - name
+                          type: object
+                          x-kubernetes-validations:
+                            - message: nodeClassRef.group is immutable
+                              rule: self.group == oldSelf.group
+                            - message: nodeClassRef.kind is immutable
+                              rule: self.kind == oldSelf.kind
+                        requirements:
+                          description: Requirements are layered with GetLabels and applied to every node.
+                          items:
+                            description: |-
+                              A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                              and minValues that represent the requirement to have at least that many values.
+                            properties:
+                              key:
+                                description: The label key that the selector applies to.
+                                type: string
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                                x-kubernetes-validations:
+                                  - message: label domain "kubernetes.io" is restricted
+                                    rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                                  - message: label domain "k8s.io" is restricted
+                                    rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                                  - message: label domain "karpenter.sh" is restricted
+                                    rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                                  - message: label "karpenter.sh/nodepool" is restricted
+                                    rule: self != "karpenter.sh/nodepool"
+                                  - message: label "kubernetes.io/hostname" is restricted
+                                    rule: self != "kubernetes.io/hostname"
+                                  - message: label domain "karpenter.k8s.aws" is restricted
+                                    rule: self in ["karpenter.k8s.aws/ec2nodeclass", "karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu", "karpenter.k8s.aws/instance-cpu-manufacturer", "karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz", "karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                              minValues:
+                                description: |-
+                                  This field is ALPHA and can be dropped or replaced at any time
+                                  MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                                maximum: 50
+                                minimum: 1
+                                type: integer
+                              operator:
+                                description: |-
+                                  Represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                type: string
+                                enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  - Gt
+                                  - Lt
+                              values:
+                                description: |-
+                                  An array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                  array must have a single element, which will be interpreted as an integer.
+                                  This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          maxItems: 100
+                          type: array
+                          x-kubernetes-validations:
+                            - message: requirements with operator 'In' must have a value defined
+                              rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                            - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                              rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                            - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                              rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                        startupTaints:
+                          description: |-
+                            StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                            within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                            daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                            purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        taints:
+                          description: Taints will be applied to the NodeClaim's node.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        terminationGracePeriod:
+                          description: |-
+                            TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
+
+                            Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
+
+                            This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
+                            When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
+
+                            Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
+                            If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
+                            that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
+
+                            The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
+                            If left undefined, the controller will wait indefinitely for pods to be drained.
+                          pattern: ^([0-9]+(s|m|h))+$
+                          type: string
+                      required:
+                        - nodeClassRef
+                        - requirements
+                      type: object
+                  required:
+                    - spec
+                  type: object
+                weight:
+                  description: |-
+                    Weight is the priority given to the nodepool during scheduling. A higher
+                    numerical weight indicates that this nodepool will be ordered
+                    ahead of other nodepools with lower weights. A nodepool with no weight
+                    will be treated as if it is a nodepool with a weight of 0.
+                  format: int32
+                  maximum: 100
+                  minimum: 1
+                  type: integer
+              required:
+                - template
+              type: object
+            status:
+              description: NodePoolStatus defines the observed state of NodePool
+              properties:
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                resources:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Resources is the list of resources that have been provisioned.
+                  type: object
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/content/projects/karpenter/v1.3.0/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/content/projects/karpenter/v1.3.0/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -1,0 +1,815 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: ec2nodeclasses.karpenter.k8s.aws
+spec:
+  group: karpenter.k8s.aws
+  names:
+    categories:
+      - karpenter
+    kind: EC2NodeClass
+    listKind: EC2NodeClassList
+    plural: ec2nodeclasses
+    shortNames:
+      - ec2nc
+      - ec2ncs
+    singular: ec2nodeclass
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.role
+          name: Role
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: EC2NodeClass is the Schema for the EC2NodeClass API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                EC2NodeClassSpec is the top level specification for the AWS Karpenter Provider.
+                This will contain configuration necessary to launch instances in AWS.
+              properties:
+                amiFamily:
+                  description: |-
+                    AMIFamily dictates the UserData format and default BlockDeviceMappings used when generating launch templates.
+                    This field is optional when using an alias amiSelectorTerm, and the value will be inferred from the alias'
+                    family. When an alias is specified, this field may only be set to its corresponding family or 'Custom'. If no
+                    alias is specified, this field is required.
+                    NOTE: We ignore the AMIFamily for hashing here because we hash the AMIFamily dynamically by using the alias using
+                    the AMIFamily() helper function
+                  enum:
+                    - AL2
+                    - AL2023
+                    - Bottlerocket
+                    - Custom
+                    - Windows2019
+                    - Windows2022
+                  type: string
+                amiSelectorTerms:
+                  description: AMISelectorTerms is a list of or ami selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      AMISelectorTerm defines selection logic for an ami used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      alias:
+                        description: |-
+                          Alias specifies which EKS optimized AMI to select.
+                          Each alias consists of a family and an AMI version, specified as "family@version".
+                          Valid families include: al2, al2023, bottlerocket, windows2019, and windows2022.
+                          The version can either be pinned to a specific AMI release, with that AMIs version format (ex: "al2023@v20240625" or "bottlerocket@v1.10.0").
+                          The version can also be set to "latest" for any family. Setting the version to latest will result in drift when a new AMI is released. This is **not** recommended for production environments.
+                          Note: The Windows families do **not** support version pinning, and only latest may be used.
+                        maxLength: 30
+                        type: string
+                        x-kubernetes-validations:
+                          - message: '''alias'' is improperly formatted, must match the format ''family@version'''
+                            rule: self.matches('^[a-zA-Z0-9]+@.+$')
+                          - message: 'family is not supported, must be one of the following: ''al2'', ''al2023'', ''bottlerocket'', ''windows2019'', ''windows2022'''
+                            rule: self.split('@')[0] in ['al2','al2023','bottlerocket','windows2019','windows2022']
+                          - message: windows families may only specify version 'latest'
+                            rule: 'self.split(''@'')[0] in [''windows2019'',''windows2022''] ? self.split(''@'')[1] == ''latest'' : true'
+                      id:
+                        description: ID is the ami id in EC2
+                        pattern: ami-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the ami name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      owner:
+                        description: |-
+                          Owner is the owner for the ami.
+                          You can specify a combination of AWS account IDs, "self", "amazon", and "aws-marketplace"
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select amis.
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  minItems: 1
+                  type: array
+                  x-kubernetes-validations:
+                    - message: expected at least one, got none, ['tags', 'id', 'name', 'alias']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name) || has(x.alias))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.exists(x, has(x.id) && (has(x.alias) || has(x.tags) || has(x.name) || has(x.owner)))'
+                    - message: '''alias'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.exists(x, has(x.alias) && (has(x.id) || has(x.tags) || has(x.name) || has(x.owner)))'
+                    - message: '''alias'' is mutually exclusive, cannot be set with a combination of other amiSelectorTerms'
+                      rule: '!(self.exists(x, has(x.alias)) && self.size() != 1)'
+                associatePublicIPAddress:
+                  description: AssociatePublicIPAddress controls if public IP addresses are assigned to instances that are launched with the nodeclass.
+                  type: boolean
+                blockDeviceMappings:
+                  description: BlockDeviceMappings to be applied to provisioned nodes.
+                  items:
+                    properties:
+                      deviceName:
+                        description: The device name (for example, /dev/sdh or xvdh).
+                        type: string
+                      ebs:
+                        description: EBS contains parameters used to automatically set up EBS volumes when an instance is launched.
+                        properties:
+                          deleteOnTermination:
+                            description: DeleteOnTermination indicates whether the EBS volume is deleted on instance termination.
+                            type: boolean
+                          encrypted:
+                            description: |-
+                              Encrypted indicates whether the EBS volume is encrypted. Encrypted volumes can only
+                              be attached to instances that support Amazon EBS encryption. If you are creating
+                              a volume from a snapshot, you can't specify an encryption value.
+                            type: boolean
+                          iops:
+                            description: |-
+                              IOPS is the number of I/O operations per second (IOPS). For gp3, io1, and io2 volumes,
+                              this represents the number of IOPS that are provisioned for the volume. For
+                              gp2 volumes, this represents the baseline performance of the volume and the
+                              rate at which the volume accumulates I/O credits for bursting.
+
+                              The following are the supported values for each volume type:
+
+                                 * gp3: 3,000-16,000 IOPS
+
+                                 * io1: 100-64,000 IOPS
+
+                                 * io2: 100-64,000 IOPS
+
+                              For io1 and io2 volumes, we guarantee 64,000 IOPS only for Instances built
+                              on the Nitro System (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances).
+                              Other instance families guarantee performance up to 32,000 IOPS.
+
+                              This parameter is supported for io1, io2, and gp3 volumes only. This parameter
+                              is not supported for gp2, st1, sc1, or standard volumes.
+                            format: int64
+                            type: integer
+                          kmsKeyID:
+                            description: KMSKeyID (ARN) of the symmetric Key Management Service (KMS) CMK used for encryption.
+                            type: string
+                          snapshotID:
+                            description: SnapshotID is the ID of an EBS snapshot
+                            type: string
+                          throughput:
+                            description: |-
+                              Throughput to provision for a gp3 volume, with a maximum of 1,000 MiB/s.
+                              Valid Range: Minimum value of 125. Maximum value of 1000.
+                            format: int64
+                            type: integer
+                          volumeSize:
+                            description: |-
+                              VolumeSize in `Gi`, `G`, `Ti`, or `T`. You must specify either a snapshot ID or
+                              a volume size. The following are the supported volumes sizes for each volume
+                              type:
+
+                                 * gp2 and gp3: 1-16,384
+
+                                 * io1 and io2: 4-16,384
+
+                                 * st1 and sc1: 125-16,384
+
+                                 * standard: 1-1,024
+                            pattern: ^((?:[1-9][0-9]{0,3}|[1-4][0-9]{4}|[5][0-8][0-9]{3}|59000)Gi|(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|[6][0-3][0-9]{3}|64000)G|([1-9]||[1-5][0-7]|58)Ti|([1-9]||[1-5][0-9]|6[0-3]|64)T)$
+                            type: string
+                          volumeType:
+                            description: |-
+                              VolumeType of the block device.
+                              For more information, see Amazon EBS volume types (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html)
+                              in the Amazon Elastic Compute Cloud User Guide.
+                            enum:
+                              - standard
+                              - io1
+                              - io2
+                              - gp2
+                              - sc1
+                              - st1
+                              - gp3
+                            type: string
+                        type: object
+                        x-kubernetes-validations:
+                          - message: snapshotID or volumeSize must be defined
+                            rule: has(self.snapshotID) || has(self.volumeSize)
+                      rootVolume:
+                        description: |-
+                          RootVolume is a flag indicating if this device is mounted as kubelet root dir. You can
+                          configure at most one root volume in BlockDeviceMappings.
+                        type: boolean
+                    type: object
+                  maxItems: 50
+                  type: array
+                  x-kubernetes-validations:
+                    - message: must have only one blockDeviceMappings with rootVolume
+                      rule: self.filter(x, has(x.rootVolume)?x.rootVolume==true:false).size() <= 1
+                capacityReservationSelectorTerms:
+                  description: |-
+                    CapacityReservationSelectorTerms is a list of capacity reservation selector terms. Each term is ORed together to
+                    determine the set of eligible capacity reservations.
+                  items:
+                    properties:
+                      id:
+                        description: ID is the capacity reservation id in EC2
+                        pattern: ^cr-[0-9a-z]+$
+                        type: string
+                      ownerID:
+                        description: Owner is the owner id for the ami.
+                        pattern: ^[0-9]{12}$
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select capacity reservations.
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: expected at least one, got none, ['tags', 'id']
+                      rule: self.all(x, has(x.tags) || has(x.id))
+                    - message: '''id'' is mutually exclusive, cannot be set along with tags in a capacity reservation selector term'
+                      rule: '!self.all(x, has(x.id) && (has(x.tags) || has(x.ownerID)))'
+                context:
+                  description: |-
+                    Context is a Reserved field in EC2 APIs
+                    https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet.html
+                  type: string
+                detailedMonitoring:
+                  description: DetailedMonitoring controls if detailed monitoring is enabled for instances that are launched
+                  type: boolean
+                instanceProfile:
+                  description: |-
+                    InstanceProfile is the AWS entity that instances use.
+                    This field is mutually exclusive from role.
+                    The instance profile should already have a role assigned to it that Karpenter
+                     has PassRole permission on for instance launch using this instanceProfile to succeed.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: instanceProfile cannot be empty
+                      rule: self != ''
+                instanceStorePolicy:
+                  description: InstanceStorePolicy specifies how to handle instance-store disks.
+                  enum:
+                    - RAID0
+                  type: string
+                kubelet:
+                  description: |-
+                    Kubelet defines args to be used when configuring kubelet on provisioned nodes.
+                    They are a subset of the upstream types, recognizing not all options may be supported.
+                    Wherever possible, the types and names should reflect the upstream kubelet types.
+                  properties:
+                    clusterDNS:
+                      description: |-
+                        clusterDNS is a list of IP addresses for the cluster DNS server.
+                        Note that not all providers may use all addresses.
+                      items:
+                        type: string
+                      type: array
+                    cpuCFSQuota:
+                      description: CPUCFSQuota enables CPU CFS quota enforcement for containers that specify CPU limits.
+                      type: boolean
+                    evictionHard:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionHard is the map of signal names to quantities that define hard eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionHard are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionMaxPodGracePeriod:
+                      description: |-
+                        EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in
+                        response to soft eviction thresholds being met.
+                      format: int32
+                      type: integer
+                    evictionSoft:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionSoft is the map of signal names to quantities that define soft eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoft are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionSoftGracePeriod:
+                      additionalProperties:
+                        type: string
+                      description: EvictionSoftGracePeriod is the map of signal names to quantities that define grace periods for each eviction signal
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoftGracePeriod are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    imageGCHighThresholdPercent:
+                      description: |-
+                        ImageGCHighThresholdPercent is the percent of disk usage after which image
+                        garbage collection is always run. The percent is calculated by dividing this
+                        field value by 100, so this field must be between 0 and 100, inclusive.
+                        When specified, the value must be greater than ImageGCLowThresholdPercent.
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    imageGCLowThresholdPercent:
+                      description: |-
+                        ImageGCLowThresholdPercent is the percent of disk usage before which image
+                        garbage collection is never run. Lowest disk usage to garbage collect to.
+                        The percent is calculated by dividing this field value by 100,
+                        so the field value must be between 0 and 100, inclusive.
+                        When specified, the value must be less than imageGCHighThresholdPercent
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    kubeReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: KubeReserved contains resources reserved for Kubernetes system components.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for kubeReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: kubeReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                    maxPods:
+                      description: |-
+                        MaxPods is an override for the maximum number of pods that can run on
+                        a worker node instance.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    podsPerCore:
+                      description: |-
+                        PodsPerCore is an override for the number of pods that can run on a worker node
+                        instance based on the number of cpu cores. This value cannot exceed MaxPods, so, if
+                        MaxPods is a lower value, that value will be used.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    systemReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: SystemReserved contains resources reserved for OS system daemons and kernel memory.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for systemReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: systemReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                  type: object
+                  x-kubernetes-validations:
+                    - message: imageGCHighThresholdPercent must be greater than imageGCLowThresholdPercent
+                      rule: 'has(self.imageGCHighThresholdPercent) && has(self.imageGCLowThresholdPercent) ?  self.imageGCHighThresholdPercent > self.imageGCLowThresholdPercent  : true'
+                    - message: evictionSoft OwnerKey does not have a matching evictionSoftGracePeriod
+                      rule: has(self.evictionSoft) ? self.evictionSoft.all(e, (e in self.evictionSoftGracePeriod)):true
+                    - message: evictionSoftGracePeriod OwnerKey does not have a matching evictionSoft
+                      rule: has(self.evictionSoftGracePeriod) ? self.evictionSoftGracePeriod.all(e, (e in self.evictionSoft)):true
+                metadataOptions:
+                  default:
+                    httpEndpoint: enabled
+                    httpProtocolIPv6: disabled
+                    httpPutResponseHopLimit: 1
+                    httpTokens: required
+                  description: |-
+                    MetadataOptions for the generated launch template of provisioned nodes.
+
+                    This specifies the exposure of the Instance Metadata Service to
+                    provisioned EC2 nodes. For more information,
+                    see Instance Metadata and User Data
+                    (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
+                    in the Amazon Elastic Compute Cloud User Guide.
+
+                    Refer to recommended, security best practices
+                    (https://aws.github.io/aws-eks-best-practices/security/docs/iam/#restrict-access-to-the-instance-profile-assigned-to-the-worker-node)
+                    for limiting exposure of Instance Metadata and User Data to pods.
+                    If omitted, defaults to httpEndpoint enabled, with httpProtocolIPv6
+                    disabled, with httpPutResponseLimit of 1, and with httpTokens
+                    required.
+                  properties:
+                    httpEndpoint:
+                      default: enabled
+                      description: |-
+                        HTTPEndpoint enables or disables the HTTP metadata endpoint on provisioned
+                        nodes. If metadata options is non-nil, but this parameter is not specified,
+                        the default state is "enabled".
+
+                        If you specify a value of "disabled", instance metadata will not be accessible
+                        on the node.
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpProtocolIPv6:
+                      default: disabled
+                      description: |-
+                        HTTPProtocolIPv6 enables or disables the IPv6 endpoint for the instance metadata
+                        service on provisioned nodes. If metadata options is non-nil, but this parameter
+                        is not specified, the default state is "disabled".
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpPutResponseHopLimit:
+                      default: 1
+                      description: |-
+                        HTTPPutResponseHopLimit is the desired HTTP PUT response hop limit for
+                        instance metadata requests. The larger the number, the further instance
+                        metadata requests can travel. Possible values are integers from 1 to 64.
+                        If metadata options is non-nil, but this parameter is not specified, the
+                        default value is 1.
+                      format: int64
+                      maximum: 64
+                      minimum: 1
+                      type: integer
+                    httpTokens:
+                      default: required
+                      description: |-
+                        HTTPTokens determines the state of token usage for instance metadata
+                        requests. If metadata options is non-nil, but this parameter is not
+                        specified, the default state is "required".
+
+                        If the state is optional, one can choose to retrieve instance metadata with
+                        or without a signed token header on the request. If one retrieves the IAM
+                        role credentials without a token, the version 1.0 role credentials are
+                        returned. If one retrieves the IAM role credentials using a valid signed
+                        token, the version 2.0 role credentials are returned.
+
+                        If the state is "required", one must send a signed token header with any
+                        instance metadata retrieval requests. In this state, retrieving the IAM
+                        role credentials always returns the version 2.0 credentials; the version
+                        1.0 credentials are not available.
+                      enum:
+                        - required
+                        - optional
+                      type: string
+                  type: object
+                role:
+                  description: |-
+                    Role is the AWS identity that nodes use. This field is immutable.
+                    This field is mutually exclusive from instanceProfile.
+                    Marking this field as immutable avoids concerns around terminating managed instance profiles from running instances.
+                    This field may be made mutable in the future, assuming the correct garbage collection and drift handling is implemented
+                    for the old instance profiles on an update.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: role cannot be empty
+                      rule: self != ''
+                    - message: immutable field changed
+                      rule: self == oldSelf
+                securityGroupSelectorTerms:
+                  description: SecurityGroupSelectorTerms is a list of security group selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SecurityGroupSelectorTerm defines selection logic for a security group used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the security group id in EC2
+                        pattern: sg-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the security group name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select security groups.
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: securityGroupSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id', 'name']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in a security group selector term'
+                      rule: '!self.all(x, has(x.id) && (has(x.tags) || has(x.name)))'
+                    - message: '''name'' is mutually exclusive, cannot be set with a combination of other fields in a security group selector term'
+                      rule: '!self.all(x, has(x.name) && (has(x.tags) || has(x.id)))'
+                subnetSelectorTerms:
+                  description: SubnetSelectorTerms is a list of subnet selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SubnetSelectorTerm defines selection logic for a subnet used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the subnet id in EC2
+                        pattern: subnet-[0-9a-z]+
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: subnetSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id']
+                      rule: self.all(x, has(x.tags) || has(x.id))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in a subnet selector term'
+                      rule: '!self.all(x, has(x.id) && has(x.tags))'
+                tags:
+                  additionalProperties:
+                    type: string
+                  description: Tags to be applied on ec2 resources like instances and launch templates.
+                  type: object
+                  x-kubernetes-validations:
+                    - message: empty tag keys aren't supported
+                      rule: self.all(k, k != '')
+                    - message: tag contains a restricted tag matching eks:eks-cluster-name
+                      rule: self.all(k, k !='eks:eks-cluster-name')
+                    - message: tag contains a restricted tag matching kubernetes.io/cluster/
+                      rule: self.all(k, !k.startsWith('kubernetes.io/cluster') )
+                    - message: tag contains a restricted tag matching karpenter.sh/nodepool
+                      rule: self.all(k, k != 'karpenter.sh/nodepool')
+                    - message: tag contains a restricted tag matching karpenter.sh/nodeclaim
+                      rule: self.all(k, k !='karpenter.sh/nodeclaim')
+                    - message: tag contains a restricted tag matching karpenter.k8s.aws/ec2nodeclass
+                      rule: self.all(k, k !='karpenter.k8s.aws/ec2nodeclass')
+                userData:
+                  description: |-
+                    UserData to be applied to the provisioned nodes.
+                    It must be in the appropriate format based on the AMIFamily in use. Karpenter will merge certain fields into
+                    this UserData to ensure nodes are being provisioned with the correct configuration.
+                  type: string
+              required:
+                - amiSelectorTerms
+                - securityGroupSelectorTerms
+                - subnetSelectorTerms
+              type: object
+              x-kubernetes-validations:
+                - message: must specify exactly one of ['role', 'instanceProfile']
+                  rule: (has(self.role) && !has(self.instanceProfile)) || (!has(self.role) && has(self.instanceProfile))
+                - message: changing from 'instanceProfile' to 'role' is not supported. You must delete and recreate this node class if you want to change this.
+                  rule: (has(oldSelf.role) && has(self.role)) || (has(oldSelf.instanceProfile) && has(self.instanceProfile))
+                - message: if set, amiFamily must be 'AL2' or 'Custom' when using an AL2 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''al2'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''AL2'') : true)'
+                - message: if set, amiFamily must be 'AL2023' or 'Custom' when using an AL2023 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''al2023'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''AL2023'') : true)'
+                - message: if set, amiFamily must be 'Bottlerocket' or 'Custom' when using a Bottlerocket alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''bottlerocket'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Bottlerocket'') : true)'
+                - message: if set, amiFamily must be 'Windows2019' or 'Custom' when using a Windows2019 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''windows2019'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Windows2019'') : true)'
+                - message: if set, amiFamily must be 'Windows2022' or 'Custom' when using a Windows2022 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''windows2022'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Windows2022'') : true)'
+                - message: must specify amiFamily if amiSelectorTerms does not contain an alias
+                  rule: 'self.amiSelectorTerms.exists(x, has(x.alias)) ? true : has(self.amiFamily)'
+            status:
+              description: EC2NodeClassStatus contains the resolved state of the EC2NodeClass
+              properties:
+                amis:
+                  description: |-
+                    AMI contains the current AMI values that are available to the
+                    cluster under the AMI selectors.
+                  items:
+                    description: AMI contains resolved AMI selector values utilized for node launch
+                    properties:
+                      deprecated:
+                        description: Deprecation status of the AMI
+                        type: boolean
+                      id:
+                        description: ID of the AMI
+                        type: string
+                      name:
+                        description: Name of the AMI
+                        type: string
+                      requirements:
+                        description: Requirements of the AMI to be utilized on an instance type
+                        items:
+                          description: |-
+                            A node selector requirement is a selector that contains values, a key, and an operator
+                            that relates the key and values.
+                          properties:
+                            key:
+                              description: The label key that the selector applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                Represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                              type: string
+                            values:
+                              description: |-
+                                An array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. If the operator is Gt or Lt, the values
+                                array must have a single element, which will be interpreted as an integer.
+                                This array is replaced during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                            - key
+                            - operator
+                          type: object
+                        type: array
+                    required:
+                      - id
+                      - requirements
+                    type: object
+                  type: array
+                capacityReservations:
+                  description: |-
+                    CapacityReservations contains the current capacity reservation values that are available to this NodeClass under the
+                    CapacityReservation selectors.
+                  items:
+                    properties:
+                      availabilityZone:
+                        description: The availability zone the capacity reservation is available in.
+                        type: string
+                      endTime:
+                        description: |-
+                          The time at which the capacity reservation expires. Once expired, the reserved capacity is released and Karpenter
+                          will no longer be able to launch instances into that reservation.
+                        format: date-time
+                        type: string
+                      id:
+                        description: The id for the capacity reservation.
+                        pattern: ^cr-[0-9a-z]+$
+                        type: string
+                      instanceMatchCriteria:
+                        description: Indicates the type of instance launches the capacity reservation accepts.
+                        enum:
+                          - open
+                          - targeted
+                        type: string
+                      instanceType:
+                        description: The instance type for the capacity reservation.
+                        type: string
+                      ownerID:
+                        description: The ID of the AWS account that owns the capacity reservation.
+                        pattern: ^[0-9]{12}$
+                        type: string
+                    required:
+                      - availabilityZone
+                      - id
+                      - instanceMatchCriteria
+                      - instanceType
+                      - ownerID
+                    type: object
+                  type: array
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                instanceProfile:
+                  description: InstanceProfile contains the resolved instance profile for the role
+                  type: string
+                securityGroups:
+                  description: |-
+                    SecurityGroups contains the current security group values that are available to the
+                    cluster under the SecurityGroups selectors.
+                  items:
+                    description: SecurityGroup contains resolved SecurityGroup selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the security group
+                        type: string
+                      name:
+                        description: Name of the security group
+                        type: string
+                    required:
+                      - id
+                    type: object
+                  type: array
+                subnets:
+                  description: |-
+                    Subnets contains the current subnet values that are available to the
+                    cluster under the subnet selectors.
+                  items:
+                    description: Subnet contains resolved Subnet selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the subnet
+                        type: string
+                      zone:
+                        description: The associated availability zone
+                        type: string
+                      zoneID:
+                        description: The associated availability zone ID
+                        type: string
+                    required:
+                      - id
+                      - zone
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/content/projects/karpenter/v1.3.0/karpenter.sh_nodeclaims.yaml
+++ b/content/projects/karpenter/v1.3.0/karpenter.sh_nodeclaims.yaml
@@ -1,0 +1,395 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: nodeclaims.karpenter.sh
+spec:
+  group: karpenter.sh
+  names:
+    categories:
+      - karpenter
+    kind: NodeClaim
+    listKind: NodeClaimList
+    plural: nodeclaims
+    singular: nodeclaim
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.labels.node\.kubernetes\.io/instance-type
+          name: Type
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/capacity-type
+          name: Capacity
+          type: string
+        - jsonPath: .metadata.labels.topology\.kubernetes\.io/zone
+          name: Zone
+          type: string
+        - jsonPath: .status.nodeName
+          name: Node
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .status.imageID
+          name: ImageID
+          priority: 1
+          type: string
+        - jsonPath: .status.providerID
+          name: ID
+          priority: 1
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/nodepool
+          name: NodePool
+          priority: 1
+          type: string
+        - jsonPath: .spec.nodeClassRef.name
+          name: NodeClass
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: NodeClaim is the Schema for the NodeClaims API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: NodeClaimSpec describes the desired state of the NodeClaim
+              properties:
+                expireAfter:
+                  default: 720h
+                  description: |-
+                    ExpireAfter is the duration the controller will wait
+                    before terminating a node, measured from when the node is created. This
+                    is useful to implement features like eventually consistent node upgrade,
+                    memory leak protection, and disruption testing.
+                  pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                  type: string
+                nodeClassRef:
+                  description: NodeClassRef is a reference to an object that defines provider specific configuration
+                  properties:
+                    group:
+                      description: API version of the referent
+                      pattern: ^[^/]*$
+                      type: string
+                      x-kubernetes-validations:
+                        - message: group may not be empty
+                          rule: self != ''
+                    kind:
+                      description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                      type: string
+                      x-kubernetes-validations:
+                        - message: kind may not be empty
+                          rule: self != ''
+                    name:
+                      description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                      type: string
+                      x-kubernetes-validations:
+                        - message: name may not be empty
+                          rule: self != ''
+                  required:
+                    - group
+                    - kind
+                    - name
+                  type: object
+                requirements:
+                  description: Requirements are layered with GetLabels and applied to every node.
+                  items:
+                    description: |-
+                      A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                      and minValues that represent the requirement to have at least that many values.
+                    properties:
+                      key:
+                        description: The label key that the selector applies to.
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                        x-kubernetes-validations:
+                          - message: label domain "kubernetes.io" is restricted
+                            rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                          - message: label domain "k8s.io" is restricted
+                            rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                          - message: label domain "karpenter.sh" is restricted
+                            rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                          - message: label "kubernetes.io/hostname" is restricted
+                            rule: self != "kubernetes.io/hostname"
+                          - message: label domain "karpenter.k8s.aws" is restricted
+                            rule: self in ["karpenter.k8s.aws/capacity-reservation-id", "karpenter.k8s.aws/ec2nodeclass", "karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu", "karpenter.k8s.aws/instance-cpu-manufacturer", "karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz", "karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                      minValues:
+                        description: |-
+                          This field is ALPHA and can be dropped or replaced at any time
+                          MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                        maximum: 50
+                        minimum: 1
+                        type: integer
+                      operator:
+                        description: |-
+                          Represents a key's relationship to a set of values.
+                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                        type: string
+                        enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          - Gt
+                          - Lt
+                      values:
+                        description: |-
+                          An array of string values. If the operator is In or NotIn,
+                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                          the values array must be empty. If the operator is Gt or Lt, the values
+                          array must have a single element, which will be interpreted as an integer.
+                          This array is replaced during a strategic merge patch.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                        maxLength: 63
+                        pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                    required:
+                      - key
+                      - operator
+                    type: object
+                  maxItems: 100
+                  type: array
+                  x-kubernetes-validations:
+                    - message: requirements with operator 'In' must have a value defined
+                      rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                    - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                      rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                    - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                      rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                resources:
+                  description: Resources models the resource requirements for the NodeClaim to launch
+                  properties:
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: Requests describes the minimum required resources for the NodeClaim to launch
+                      type: object
+                  type: object
+                startupTaints:
+                  description: |-
+                    StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                    within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                    daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                    purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                taints:
+                  description: Taints will be applied to the NodeClaim's node.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                terminationGracePeriod:
+                  description: |-
+                    TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
+
+                    Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
+
+                    This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
+                    When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
+
+                    Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
+                    If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
+                    that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
+
+                    The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
+                    If left undefined, the controller will wait indefinitely for pods to be drained.
+                  pattern: ^([0-9]+(s|m|h))+$
+                  type: string
+              required:
+                - nodeClassRef
+                - requirements
+              type: object
+              x-kubernetes-validations:
+                - message: spec is immutable
+                  rule: self == oldSelf
+            status:
+              description: NodeClaimStatus defines the observed state of NodeClaim
+              properties:
+                allocatable:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Allocatable is the estimated allocatable capacity of the node
+                  type: object
+                capacity:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Capacity is the estimated full capacity of the node
+                  type: object
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        pattern: ^([A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?|)$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - status
+                      - type
+                    type: object
+                  type: array
+                imageID:
+                  description: ImageID is an identifier for the image that runs on the node
+                  type: string
+                lastPodEventTime:
+                  description: |-
+                    LastPodEventTime is updated with the last time a pod was scheduled
+                    or removed from the node. A pod going terminal or terminating
+                    is also considered as removed.
+                  format: date-time
+                  type: string
+                nodeName:
+                  description: NodeName is the name of the corresponding node object
+                  type: string
+                providerID:
+                  description: ProviderID of the corresponding node object
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/content/projects/karpenter/v1.3.0/karpenter.sh_nodepools.yaml
+++ b/content/projects/karpenter/v1.3.0/karpenter.sh_nodepools.yaml
@@ -1,0 +1,519 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: nodepools.karpenter.sh
+spec:
+  group: karpenter.sh
+  names:
+    categories:
+      - karpenter
+    kind: NodePool
+    listKind: NodePoolList
+    plural: nodepools
+    singular: nodepool
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.template.spec.nodeClassRef.name
+          name: NodeClass
+          type: string
+        - jsonPath: .status.resources.nodes
+          name: Nodes
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.weight
+          name: Weight
+          priority: 1
+          type: integer
+        - jsonPath: .status.resources.cpu
+          name: CPU
+          priority: 1
+          type: string
+        - jsonPath: .status.resources.memory
+          name: Memory
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: NodePool is the Schema for the NodePools API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                NodePoolSpec is the top level nodepool specification. Nodepools
+                launch nodes in response to pods that are unschedulable. A single nodepool
+                is capable of managing a diverse set of nodes. Node properties are determined
+                from a combination of nodepool and pod scheduling constraints.
+              properties:
+                disruption:
+                  default:
+                    consolidateAfter: 0s
+                  description: Disruption contains the parameters that relate to Karpenter's disruption logic
+                  properties:
+                    budgets:
+                      default:
+                        - nodes: 10%
+                      description: |-
+                        Budgets is a list of Budgets.
+                        If there are multiple active budgets, Karpenter uses
+                        the most restrictive value. If left undefined,
+                        this will default to one budget with a value to 10%.
+                      items:
+                        description: |-
+                          Budget defines when Karpenter will restrict the
+                          number of Node Claims that can be terminating simultaneously.
+                        properties:
+                          duration:
+                            description: |-
+                              Duration determines how long a Budget is active since each Schedule hit.
+                              Only minutes and hours are accepted, as cron does not work in seconds.
+                              If omitted, the budget is always active.
+                              This is required if Schedule is set.
+                              This regex has an optional 0s at the end since the duration.String() always adds
+                              a 0s at the end.
+                            pattern: ^((([0-9]+(h|m))|([0-9]+h[0-9]+m))(0s)?)$
+                            type: string
+                          nodes:
+                            default: 10%
+                            description: |-
+                              Nodes dictates the maximum number of NodeClaims owned by this NodePool
+                              that can be terminating at once. This is calculated by counting nodes that
+                              have a deletion timestamp set, or are actively being deleted by Karpenter.
+                              This field is required when specifying a budget.
+                              This cannot be of type intstr.IntOrString since kubebuilder doesn't support pattern
+                              checking for int nodes for IntOrString nodes.
+                              Ref: https://github.com/kubernetes-sigs/controller-tools/blob/55efe4be40394a288216dab63156b0a64fb82929/pkg/crd/markers/validation.go#L379-L388
+                            pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
+                            type: string
+                          reasons:
+                            description: |-
+                              Reasons is a list of disruption methods that this budget applies to. If Reasons is not set, this budget applies to all methods.
+                              Otherwise, this will apply to each reason defined.
+                              allowed reasons are Underutilized, Empty, and Drifted.
+                            items:
+                              description: DisruptionReason defines valid reasons for disruption budgets.
+                              enum:
+                                - Underutilized
+                                - Empty
+                                - Drifted
+                              type: string
+                            type: array
+                          schedule:
+                            description: |-
+                              Schedule specifies when a budget begins being active, following
+                              the upstream cronjob syntax. If omitted, the budget is always active.
+                              Timezones are not supported.
+                              This field is required if Duration is set.
+                            pattern: ^(@(annually|yearly|monthly|weekly|daily|midnight|hourly))|((.+)\s(.+)\s(.+)\s(.+)\s(.+))$
+                            type: string
+                        required:
+                          - nodes
+                        type: object
+                      maxItems: 50
+                      type: array
+                      x-kubernetes-validations:
+                        - message: '''schedule'' must be set with ''duration'''
+                          rule: self.all(x, has(x.schedule) == has(x.duration))
+                    consolidateAfter:
+                      description: |-
+                        ConsolidateAfter is the duration the controller will wait
+                        before attempting to terminate nodes that are underutilized.
+                        Refer to ConsolidationPolicy for how underutilization is considered.
+                      pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                      type: string
+                    consolidationPolicy:
+                      default: WhenEmptyOrUnderutilized
+                      description: |-
+                        ConsolidationPolicy describes which nodes Karpenter can disrupt through its consolidation
+                        algorithm. This policy defaults to "WhenEmptyOrUnderutilized" if not specified
+                      enum:
+                        - WhenEmpty
+                        - WhenEmptyOrUnderutilized
+                      type: string
+                  required:
+                    - consolidateAfter
+                  type: object
+                limits:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Limits define a set of bounds for provisioning capacity.
+                  type: object
+                template:
+                  description: |-
+                    Template contains the template of possibilities for the provisioning logic to launch a NodeClaim with.
+                    NodeClaims launched from this NodePool will often be further constrained than the template specifies.
+                  properties:
+                    metadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Annotations is an unstructured key value map stored with a resource that may be
+                            set by external tools to store and retrieve arbitrary metadata. They are not
+                            queryable and should be preserved when modifying objects.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                            maxLength: 63
+                            pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                          description: |-
+                            Map of string keys and values that can be used to organize and categorize
+                            (scope and select) objects. May match selectors of replication controllers
+                            and services.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
+                          type: object
+                          maxProperties: 100
+                          x-kubernetes-validations:
+                            - message: label domain "kubernetes.io" is restricted
+                              rule: self.all(x, x in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region",  "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || x.find("^([^/]+)").endsWith("node.kubernetes.io") || x.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !x.find("^([^/]+)").endsWith("kubernetes.io"))
+                            - message: label domain "k8s.io" is restricted
+                              rule: self.all(x, x.find("^([^/]+)").endsWith("kops.k8s.io") || !x.find("^([^/]+)").endsWith("k8s.io"))
+                            - message: label domain "karpenter.sh" is restricted
+                              rule: self.all(x, x in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !x.find("^([^/]+)").endsWith("karpenter.sh"))
+                            - message: label "karpenter.sh/nodepool" is restricted
+                              rule: self.all(x, x != "karpenter.sh/nodepool")
+                            - message: label "kubernetes.io/hostname" is restricted
+                              rule: self.all(x, x != "kubernetes.io/hostname")
+                            - message: label domain "karpenter.k8s.aws" is restricted
+                              rule: self.all(x, x in ["karpenter.k8s.aws/capacity-reservation-id", "karpenter.k8s.aws/ec2nodeclass", "karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu", "karpenter.k8s.aws/instance-cpu-manufacturer", "karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz", "karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !x.find("^([^/]+)").endsWith("karpenter.k8s.aws"))
+                      type: object
+                    spec:
+                      description: |-
+                        NodeClaimTemplateSpec describes the desired state of the NodeClaim in the Nodepool
+                        NodeClaimTemplateSpec is used in the NodePool's NodeClaimTemplate, with the resource requests omitted since
+                        users are not able to set resource requests in the NodePool.
+                      properties:
+                        expireAfter:
+                          default: 720h
+                          description: |-
+                            ExpireAfter is the duration the controller will wait
+                            before terminating a node, measured from when the node is created. This
+                            is useful to implement features like eventually consistent node upgrade,
+                            memory leak protection, and disruption testing.
+                          pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                          type: string
+                        nodeClassRef:
+                          description: NodeClassRef is a reference to an object that defines provider specific configuration
+                          properties:
+                            group:
+                              description: API version of the referent
+                              pattern: ^[^/]*$
+                              type: string
+                              x-kubernetes-validations:
+                                - message: group may not be empty
+                                  rule: self != ''
+                            kind:
+                              description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                              type: string
+                              x-kubernetes-validations:
+                                - message: kind may not be empty
+                                  rule: self != ''
+                            name:
+                              description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                              x-kubernetes-validations:
+                                - message: name may not be empty
+                                  rule: self != ''
+                          required:
+                            - group
+                            - kind
+                            - name
+                          type: object
+                          x-kubernetes-validations:
+                            - message: nodeClassRef.group is immutable
+                              rule: self.group == oldSelf.group
+                            - message: nodeClassRef.kind is immutable
+                              rule: self.kind == oldSelf.kind
+                        requirements:
+                          description: Requirements are layered with GetLabels and applied to every node.
+                          items:
+                            description: |-
+                              A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                              and minValues that represent the requirement to have at least that many values.
+                            properties:
+                              key:
+                                description: The label key that the selector applies to.
+                                type: string
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                                x-kubernetes-validations:
+                                  - message: label domain "kubernetes.io" is restricted
+                                    rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                                  - message: label domain "k8s.io" is restricted
+                                    rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                                  - message: label domain "karpenter.sh" is restricted
+                                    rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                                  - message: label "karpenter.sh/nodepool" is restricted
+                                    rule: self != "karpenter.sh/nodepool"
+                                  - message: label "kubernetes.io/hostname" is restricted
+                                    rule: self != "kubernetes.io/hostname"
+                                  - message: label domain "karpenter.k8s.aws" is restricted
+                                    rule: self in ["karpenter.k8s.aws/capacity-reservation-id", "karpenter.k8s.aws/ec2nodeclass", "karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu", "karpenter.k8s.aws/instance-cpu-manufacturer", "karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz", "karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                              minValues:
+                                description: |-
+                                  This field is ALPHA and can be dropped or replaced at any time
+                                  MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                                maximum: 50
+                                minimum: 1
+                                type: integer
+                              operator:
+                                description: |-
+                                  Represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                type: string
+                                enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  - Gt
+                                  - Lt
+                              values:
+                                description: |-
+                                  An array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                  array must have a single element, which will be interpreted as an integer.
+                                  This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          maxItems: 100
+                          type: array
+                          x-kubernetes-validations:
+                            - message: requirements with operator 'In' must have a value defined
+                              rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                            - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                              rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                            - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                              rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                        startupTaints:
+                          description: |-
+                            StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                            within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                            daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                            purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        taints:
+                          description: Taints will be applied to the NodeClaim's node.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        terminationGracePeriod:
+                          description: |-
+                            TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
+
+                            Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
+
+                            This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
+                            When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
+
+                            Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
+                            If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
+                            that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
+
+                            The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
+                            If left undefined, the controller will wait indefinitely for pods to be drained.
+                          pattern: ^([0-9]+(s|m|h))+$
+                          type: string
+                      required:
+                        - nodeClassRef
+                        - requirements
+                      type: object
+                  required:
+                    - spec
+                  type: object
+                weight:
+                  description: |-
+                    Weight is the priority given to the nodepool during scheduling. A higher
+                    numerical weight indicates that this nodepool will be ordered
+                    ahead of other nodepools with lower weights. A nodepool with no weight
+                    will be treated as if it is a nodepool with a weight of 0.
+                  format: int32
+                  maximum: 100
+                  minimum: 1
+                  type: integer
+              required:
+                - template
+              type: object
+            status:
+              description: NodePoolStatus defines the observed state of NodePool
+              properties:
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                resources:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Resources is the list of resources that have been provisioned.
+                  type: object
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/content/projects/karpenter/v1.3.1/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/content/projects/karpenter/v1.3.1/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -1,0 +1,815 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: ec2nodeclasses.karpenter.k8s.aws
+spec:
+  group: karpenter.k8s.aws
+  names:
+    categories:
+      - karpenter
+    kind: EC2NodeClass
+    listKind: EC2NodeClassList
+    plural: ec2nodeclasses
+    shortNames:
+      - ec2nc
+      - ec2ncs
+    singular: ec2nodeclass
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.role
+          name: Role
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: EC2NodeClass is the Schema for the EC2NodeClass API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                EC2NodeClassSpec is the top level specification for the AWS Karpenter Provider.
+                This will contain configuration necessary to launch instances in AWS.
+              properties:
+                amiFamily:
+                  description: |-
+                    AMIFamily dictates the UserData format and default BlockDeviceMappings used when generating launch templates.
+                    This field is optional when using an alias amiSelectorTerm, and the value will be inferred from the alias'
+                    family. When an alias is specified, this field may only be set to its corresponding family or 'Custom'. If no
+                    alias is specified, this field is required.
+                    NOTE: We ignore the AMIFamily for hashing here because we hash the AMIFamily dynamically by using the alias using
+                    the AMIFamily() helper function
+                  enum:
+                    - AL2
+                    - AL2023
+                    - Bottlerocket
+                    - Custom
+                    - Windows2019
+                    - Windows2022
+                  type: string
+                amiSelectorTerms:
+                  description: AMISelectorTerms is a list of or ami selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      AMISelectorTerm defines selection logic for an ami used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      alias:
+                        description: |-
+                          Alias specifies which EKS optimized AMI to select.
+                          Each alias consists of a family and an AMI version, specified as "family@version".
+                          Valid families include: al2, al2023, bottlerocket, windows2019, and windows2022.
+                          The version can either be pinned to a specific AMI release, with that AMIs version format (ex: "al2023@v20240625" or "bottlerocket@v1.10.0").
+                          The version can also be set to "latest" for any family. Setting the version to latest will result in drift when a new AMI is released. This is **not** recommended for production environments.
+                          Note: The Windows families do **not** support version pinning, and only latest may be used.
+                        maxLength: 30
+                        type: string
+                        x-kubernetes-validations:
+                          - message: '''alias'' is improperly formatted, must match the format ''family@version'''
+                            rule: self.matches('^[a-zA-Z0-9]+@.+$')
+                          - message: 'family is not supported, must be one of the following: ''al2'', ''al2023'', ''bottlerocket'', ''windows2019'', ''windows2022'''
+                            rule: self.split('@')[0] in ['al2','al2023','bottlerocket','windows2019','windows2022']
+                          - message: windows families may only specify version 'latest'
+                            rule: 'self.split(''@'')[0] in [''windows2019'',''windows2022''] ? self.split(''@'')[1] == ''latest'' : true'
+                      id:
+                        description: ID is the ami id in EC2
+                        pattern: ami-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the ami name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      owner:
+                        description: |-
+                          Owner is the owner for the ami.
+                          You can specify a combination of AWS account IDs, "self", "amazon", and "aws-marketplace"
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select amis.
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  minItems: 1
+                  type: array
+                  x-kubernetes-validations:
+                    - message: expected at least one, got none, ['tags', 'id', 'name', 'alias']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name) || has(x.alias))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.exists(x, has(x.id) && (has(x.alias) || has(x.tags) || has(x.name) || has(x.owner)))'
+                    - message: '''alias'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.exists(x, has(x.alias) && (has(x.id) || has(x.tags) || has(x.name) || has(x.owner)))'
+                    - message: '''alias'' is mutually exclusive, cannot be set with a combination of other amiSelectorTerms'
+                      rule: '!(self.exists(x, has(x.alias)) && self.size() != 1)'
+                associatePublicIPAddress:
+                  description: AssociatePublicIPAddress controls if public IP addresses are assigned to instances that are launched with the nodeclass.
+                  type: boolean
+                blockDeviceMappings:
+                  description: BlockDeviceMappings to be applied to provisioned nodes.
+                  items:
+                    properties:
+                      deviceName:
+                        description: The device name (for example, /dev/sdh or xvdh).
+                        type: string
+                      ebs:
+                        description: EBS contains parameters used to automatically set up EBS volumes when an instance is launched.
+                        properties:
+                          deleteOnTermination:
+                            description: DeleteOnTermination indicates whether the EBS volume is deleted on instance termination.
+                            type: boolean
+                          encrypted:
+                            description: |-
+                              Encrypted indicates whether the EBS volume is encrypted. Encrypted volumes can only
+                              be attached to instances that support Amazon EBS encryption. If you are creating
+                              a volume from a snapshot, you can't specify an encryption value.
+                            type: boolean
+                          iops:
+                            description: |-
+                              IOPS is the number of I/O operations per second (IOPS). For gp3, io1, and io2 volumes,
+                              this represents the number of IOPS that are provisioned for the volume. For
+                              gp2 volumes, this represents the baseline performance of the volume and the
+                              rate at which the volume accumulates I/O credits for bursting.
+
+                              The following are the supported values for each volume type:
+
+                                 * gp3: 3,000-16,000 IOPS
+
+                                 * io1: 100-64,000 IOPS
+
+                                 * io2: 100-64,000 IOPS
+
+                              For io1 and io2 volumes, we guarantee 64,000 IOPS only for Instances built
+                              on the Nitro System (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances).
+                              Other instance families guarantee performance up to 32,000 IOPS.
+
+                              This parameter is supported for io1, io2, and gp3 volumes only. This parameter
+                              is not supported for gp2, st1, sc1, or standard volumes.
+                            format: int64
+                            type: integer
+                          kmsKeyID:
+                            description: KMSKeyID (ARN) of the symmetric Key Management Service (KMS) CMK used for encryption.
+                            type: string
+                          snapshotID:
+                            description: SnapshotID is the ID of an EBS snapshot
+                            type: string
+                          throughput:
+                            description: |-
+                              Throughput to provision for a gp3 volume, with a maximum of 1,000 MiB/s.
+                              Valid Range: Minimum value of 125. Maximum value of 1000.
+                            format: int64
+                            type: integer
+                          volumeSize:
+                            description: |-
+                              VolumeSize in `Gi`, `G`, `Ti`, or `T`. You must specify either a snapshot ID or
+                              a volume size. The following are the supported volumes sizes for each volume
+                              type:
+
+                                 * gp2 and gp3: 1-16,384
+
+                                 * io1 and io2: 4-16,384
+
+                                 * st1 and sc1: 125-16,384
+
+                                 * standard: 1-1,024
+                            pattern: ^((?:[1-9][0-9]{0,3}|[1-4][0-9]{4}|[5][0-8][0-9]{3}|59000)Gi|(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|[6][0-3][0-9]{3}|64000)G|([1-9]||[1-5][0-7]|58)Ti|([1-9]||[1-5][0-9]|6[0-3]|64)T)$
+                            type: string
+                          volumeType:
+                            description: |-
+                              VolumeType of the block device.
+                              For more information, see Amazon EBS volume types (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html)
+                              in the Amazon Elastic Compute Cloud User Guide.
+                            enum:
+                              - standard
+                              - io1
+                              - io2
+                              - gp2
+                              - sc1
+                              - st1
+                              - gp3
+                            type: string
+                        type: object
+                        x-kubernetes-validations:
+                          - message: snapshotID or volumeSize must be defined
+                            rule: has(self.snapshotID) || has(self.volumeSize)
+                      rootVolume:
+                        description: |-
+                          RootVolume is a flag indicating if this device is mounted as kubelet root dir. You can
+                          configure at most one root volume in BlockDeviceMappings.
+                        type: boolean
+                    type: object
+                  maxItems: 50
+                  type: array
+                  x-kubernetes-validations:
+                    - message: must have only one blockDeviceMappings with rootVolume
+                      rule: self.filter(x, has(x.rootVolume)?x.rootVolume==true:false).size() <= 1
+                capacityReservationSelectorTerms:
+                  description: |-
+                    CapacityReservationSelectorTerms is a list of capacity reservation selector terms. Each term is ORed together to
+                    determine the set of eligible capacity reservations.
+                  items:
+                    properties:
+                      id:
+                        description: ID is the capacity reservation id in EC2
+                        pattern: ^cr-[0-9a-z]+$
+                        type: string
+                      ownerID:
+                        description: Owner is the owner id for the ami.
+                        pattern: ^[0-9]{12}$
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select capacity reservations.
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: expected at least one, got none, ['tags', 'id']
+                      rule: self.all(x, has(x.tags) || has(x.id))
+                    - message: '''id'' is mutually exclusive, cannot be set along with tags in a capacity reservation selector term'
+                      rule: '!self.all(x, has(x.id) && (has(x.tags) || has(x.ownerID)))'
+                context:
+                  description: |-
+                    Context is a Reserved field in EC2 APIs
+                    https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet.html
+                  type: string
+                detailedMonitoring:
+                  description: DetailedMonitoring controls if detailed monitoring is enabled for instances that are launched
+                  type: boolean
+                instanceProfile:
+                  description: |-
+                    InstanceProfile is the AWS entity that instances use.
+                    This field is mutually exclusive from role.
+                    The instance profile should already have a role assigned to it that Karpenter
+                     has PassRole permission on for instance launch using this instanceProfile to succeed.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: instanceProfile cannot be empty
+                      rule: self != ''
+                instanceStorePolicy:
+                  description: InstanceStorePolicy specifies how to handle instance-store disks.
+                  enum:
+                    - RAID0
+                  type: string
+                kubelet:
+                  description: |-
+                    Kubelet defines args to be used when configuring kubelet on provisioned nodes.
+                    They are a subset of the upstream types, recognizing not all options may be supported.
+                    Wherever possible, the types and names should reflect the upstream kubelet types.
+                  properties:
+                    clusterDNS:
+                      description: |-
+                        clusterDNS is a list of IP addresses for the cluster DNS server.
+                        Note that not all providers may use all addresses.
+                      items:
+                        type: string
+                      type: array
+                    cpuCFSQuota:
+                      description: CPUCFSQuota enables CPU CFS quota enforcement for containers that specify CPU limits.
+                      type: boolean
+                    evictionHard:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionHard is the map of signal names to quantities that define hard eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionHard are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionMaxPodGracePeriod:
+                      description: |-
+                        EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in
+                        response to soft eviction thresholds being met.
+                      format: int32
+                      type: integer
+                    evictionSoft:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionSoft is the map of signal names to quantities that define soft eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoft are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionSoftGracePeriod:
+                      additionalProperties:
+                        type: string
+                      description: EvictionSoftGracePeriod is the map of signal names to quantities that define grace periods for each eviction signal
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoftGracePeriod are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    imageGCHighThresholdPercent:
+                      description: |-
+                        ImageGCHighThresholdPercent is the percent of disk usage after which image
+                        garbage collection is always run. The percent is calculated by dividing this
+                        field value by 100, so this field must be between 0 and 100, inclusive.
+                        When specified, the value must be greater than ImageGCLowThresholdPercent.
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    imageGCLowThresholdPercent:
+                      description: |-
+                        ImageGCLowThresholdPercent is the percent of disk usage before which image
+                        garbage collection is never run. Lowest disk usage to garbage collect to.
+                        The percent is calculated by dividing this field value by 100,
+                        so the field value must be between 0 and 100, inclusive.
+                        When specified, the value must be less than imageGCHighThresholdPercent
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    kubeReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: KubeReserved contains resources reserved for Kubernetes system components.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for kubeReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: kubeReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                    maxPods:
+                      description: |-
+                        MaxPods is an override for the maximum number of pods that can run on
+                        a worker node instance.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    podsPerCore:
+                      description: |-
+                        PodsPerCore is an override for the number of pods that can run on a worker node
+                        instance based on the number of cpu cores. This value cannot exceed MaxPods, so, if
+                        MaxPods is a lower value, that value will be used.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    systemReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: SystemReserved contains resources reserved for OS system daemons and kernel memory.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for systemReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: systemReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                  type: object
+                  x-kubernetes-validations:
+                    - message: imageGCHighThresholdPercent must be greater than imageGCLowThresholdPercent
+                      rule: 'has(self.imageGCHighThresholdPercent) && has(self.imageGCLowThresholdPercent) ?  self.imageGCHighThresholdPercent > self.imageGCLowThresholdPercent  : true'
+                    - message: evictionSoft OwnerKey does not have a matching evictionSoftGracePeriod
+                      rule: has(self.evictionSoft) ? self.evictionSoft.all(e, (e in self.evictionSoftGracePeriod)):true
+                    - message: evictionSoftGracePeriod OwnerKey does not have a matching evictionSoft
+                      rule: has(self.evictionSoftGracePeriod) ? self.evictionSoftGracePeriod.all(e, (e in self.evictionSoft)):true
+                metadataOptions:
+                  default:
+                    httpEndpoint: enabled
+                    httpProtocolIPv6: disabled
+                    httpPutResponseHopLimit: 1
+                    httpTokens: required
+                  description: |-
+                    MetadataOptions for the generated launch template of provisioned nodes.
+
+                    This specifies the exposure of the Instance Metadata Service to
+                    provisioned EC2 nodes. For more information,
+                    see Instance Metadata and User Data
+                    (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
+                    in the Amazon Elastic Compute Cloud User Guide.
+
+                    Refer to recommended, security best practices
+                    (https://aws.github.io/aws-eks-best-practices/security/docs/iam/#restrict-access-to-the-instance-profile-assigned-to-the-worker-node)
+                    for limiting exposure of Instance Metadata and User Data to pods.
+                    If omitted, defaults to httpEndpoint enabled, with httpProtocolIPv6
+                    disabled, with httpPutResponseLimit of 1, and with httpTokens
+                    required.
+                  properties:
+                    httpEndpoint:
+                      default: enabled
+                      description: |-
+                        HTTPEndpoint enables or disables the HTTP metadata endpoint on provisioned
+                        nodes. If metadata options is non-nil, but this parameter is not specified,
+                        the default state is "enabled".
+
+                        If you specify a value of "disabled", instance metadata will not be accessible
+                        on the node.
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpProtocolIPv6:
+                      default: disabled
+                      description: |-
+                        HTTPProtocolIPv6 enables or disables the IPv6 endpoint for the instance metadata
+                        service on provisioned nodes. If metadata options is non-nil, but this parameter
+                        is not specified, the default state is "disabled".
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpPutResponseHopLimit:
+                      default: 1
+                      description: |-
+                        HTTPPutResponseHopLimit is the desired HTTP PUT response hop limit for
+                        instance metadata requests. The larger the number, the further instance
+                        metadata requests can travel. Possible values are integers from 1 to 64.
+                        If metadata options is non-nil, but this parameter is not specified, the
+                        default value is 1.
+                      format: int64
+                      maximum: 64
+                      minimum: 1
+                      type: integer
+                    httpTokens:
+                      default: required
+                      description: |-
+                        HTTPTokens determines the state of token usage for instance metadata
+                        requests. If metadata options is non-nil, but this parameter is not
+                        specified, the default state is "required".
+
+                        If the state is optional, one can choose to retrieve instance metadata with
+                        or without a signed token header on the request. If one retrieves the IAM
+                        role credentials without a token, the version 1.0 role credentials are
+                        returned. If one retrieves the IAM role credentials using a valid signed
+                        token, the version 2.0 role credentials are returned.
+
+                        If the state is "required", one must send a signed token header with any
+                        instance metadata retrieval requests. In this state, retrieving the IAM
+                        role credentials always returns the version 2.0 credentials; the version
+                        1.0 credentials are not available.
+                      enum:
+                        - required
+                        - optional
+                      type: string
+                  type: object
+                role:
+                  description: |-
+                    Role is the AWS identity that nodes use. This field is immutable.
+                    This field is mutually exclusive from instanceProfile.
+                    Marking this field as immutable avoids concerns around terminating managed instance profiles from running instances.
+                    This field may be made mutable in the future, assuming the correct garbage collection and drift handling is implemented
+                    for the old instance profiles on an update.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: role cannot be empty
+                      rule: self != ''
+                    - message: immutable field changed
+                      rule: self == oldSelf
+                securityGroupSelectorTerms:
+                  description: SecurityGroupSelectorTerms is a list of security group selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SecurityGroupSelectorTerm defines selection logic for a security group used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the security group id in EC2
+                        pattern: sg-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the security group name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select security groups.
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: securityGroupSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id', 'name']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in a security group selector term'
+                      rule: '!self.all(x, has(x.id) && (has(x.tags) || has(x.name)))'
+                    - message: '''name'' is mutually exclusive, cannot be set with a combination of other fields in a security group selector term'
+                      rule: '!self.all(x, has(x.name) && (has(x.tags) || has(x.id)))'
+                subnetSelectorTerms:
+                  description: SubnetSelectorTerms is a list of subnet selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SubnetSelectorTerm defines selection logic for a subnet used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the subnet id in EC2
+                        pattern: subnet-[0-9a-z]+
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: subnetSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id']
+                      rule: self.all(x, has(x.tags) || has(x.id))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in a subnet selector term'
+                      rule: '!self.all(x, has(x.id) && has(x.tags))'
+                tags:
+                  additionalProperties:
+                    type: string
+                  description: Tags to be applied on ec2 resources like instances and launch templates.
+                  type: object
+                  x-kubernetes-validations:
+                    - message: empty tag keys aren't supported
+                      rule: self.all(k, k != '')
+                    - message: tag contains a restricted tag matching eks:eks-cluster-name
+                      rule: self.all(k, k !='eks:eks-cluster-name')
+                    - message: tag contains a restricted tag matching kubernetes.io/cluster/
+                      rule: self.all(k, !k.startsWith('kubernetes.io/cluster') )
+                    - message: tag contains a restricted tag matching karpenter.sh/nodepool
+                      rule: self.all(k, k != 'karpenter.sh/nodepool')
+                    - message: tag contains a restricted tag matching karpenter.sh/nodeclaim
+                      rule: self.all(k, k !='karpenter.sh/nodeclaim')
+                    - message: tag contains a restricted tag matching karpenter.k8s.aws/ec2nodeclass
+                      rule: self.all(k, k !='karpenter.k8s.aws/ec2nodeclass')
+                userData:
+                  description: |-
+                    UserData to be applied to the provisioned nodes.
+                    It must be in the appropriate format based on the AMIFamily in use. Karpenter will merge certain fields into
+                    this UserData to ensure nodes are being provisioned with the correct configuration.
+                  type: string
+              required:
+                - amiSelectorTerms
+                - securityGroupSelectorTerms
+                - subnetSelectorTerms
+              type: object
+              x-kubernetes-validations:
+                - message: must specify exactly one of ['role', 'instanceProfile']
+                  rule: (has(self.role) && !has(self.instanceProfile)) || (!has(self.role) && has(self.instanceProfile))
+                - message: changing from 'instanceProfile' to 'role' is not supported. You must delete and recreate this node class if you want to change this.
+                  rule: (has(oldSelf.role) && has(self.role)) || (has(oldSelf.instanceProfile) && has(self.instanceProfile))
+                - message: if set, amiFamily must be 'AL2' or 'Custom' when using an AL2 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''al2'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''AL2'') : true)'
+                - message: if set, amiFamily must be 'AL2023' or 'Custom' when using an AL2023 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''al2023'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''AL2023'') : true)'
+                - message: if set, amiFamily must be 'Bottlerocket' or 'Custom' when using a Bottlerocket alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''bottlerocket'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Bottlerocket'') : true)'
+                - message: if set, amiFamily must be 'Windows2019' or 'Custom' when using a Windows2019 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''windows2019'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Windows2019'') : true)'
+                - message: if set, amiFamily must be 'Windows2022' or 'Custom' when using a Windows2022 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''windows2022'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Windows2022'') : true)'
+                - message: must specify amiFamily if amiSelectorTerms does not contain an alias
+                  rule: 'self.amiSelectorTerms.exists(x, has(x.alias)) ? true : has(self.amiFamily)'
+            status:
+              description: EC2NodeClassStatus contains the resolved state of the EC2NodeClass
+              properties:
+                amis:
+                  description: |-
+                    AMI contains the current AMI values that are available to the
+                    cluster under the AMI selectors.
+                  items:
+                    description: AMI contains resolved AMI selector values utilized for node launch
+                    properties:
+                      deprecated:
+                        description: Deprecation status of the AMI
+                        type: boolean
+                      id:
+                        description: ID of the AMI
+                        type: string
+                      name:
+                        description: Name of the AMI
+                        type: string
+                      requirements:
+                        description: Requirements of the AMI to be utilized on an instance type
+                        items:
+                          description: |-
+                            A node selector requirement is a selector that contains values, a key, and an operator
+                            that relates the key and values.
+                          properties:
+                            key:
+                              description: The label key that the selector applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                Represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                              type: string
+                            values:
+                              description: |-
+                                An array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. If the operator is Gt or Lt, the values
+                                array must have a single element, which will be interpreted as an integer.
+                                This array is replaced during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                            - key
+                            - operator
+                          type: object
+                        type: array
+                    required:
+                      - id
+                      - requirements
+                    type: object
+                  type: array
+                capacityReservations:
+                  description: |-
+                    CapacityReservations contains the current capacity reservation values that are available to this NodeClass under the
+                    CapacityReservation selectors.
+                  items:
+                    properties:
+                      availabilityZone:
+                        description: The availability zone the capacity reservation is available in.
+                        type: string
+                      endTime:
+                        description: |-
+                          The time at which the capacity reservation expires. Once expired, the reserved capacity is released and Karpenter
+                          will no longer be able to launch instances into that reservation.
+                        format: date-time
+                        type: string
+                      id:
+                        description: The id for the capacity reservation.
+                        pattern: ^cr-[0-9a-z]+$
+                        type: string
+                      instanceMatchCriteria:
+                        description: Indicates the type of instance launches the capacity reservation accepts.
+                        enum:
+                          - open
+                          - targeted
+                        type: string
+                      instanceType:
+                        description: The instance type for the capacity reservation.
+                        type: string
+                      ownerID:
+                        description: The ID of the AWS account that owns the capacity reservation.
+                        pattern: ^[0-9]{12}$
+                        type: string
+                    required:
+                      - availabilityZone
+                      - id
+                      - instanceMatchCriteria
+                      - instanceType
+                      - ownerID
+                    type: object
+                  type: array
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                instanceProfile:
+                  description: InstanceProfile contains the resolved instance profile for the role
+                  type: string
+                securityGroups:
+                  description: |-
+                    SecurityGroups contains the current security group values that are available to the
+                    cluster under the SecurityGroups selectors.
+                  items:
+                    description: SecurityGroup contains resolved SecurityGroup selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the security group
+                        type: string
+                      name:
+                        description: Name of the security group
+                        type: string
+                    required:
+                      - id
+                    type: object
+                  type: array
+                subnets:
+                  description: |-
+                    Subnets contains the current subnet values that are available to the
+                    cluster under the subnet selectors.
+                  items:
+                    description: Subnet contains resolved Subnet selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the subnet
+                        type: string
+                      zone:
+                        description: The associated availability zone
+                        type: string
+                      zoneID:
+                        description: The associated availability zone ID
+                        type: string
+                    required:
+                      - id
+                      - zone
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/content/projects/karpenter/v1.3.1/karpenter.sh_nodeclaims.yaml
+++ b/content/projects/karpenter/v1.3.1/karpenter.sh_nodeclaims.yaml
@@ -1,0 +1,395 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: nodeclaims.karpenter.sh
+spec:
+  group: karpenter.sh
+  names:
+    categories:
+      - karpenter
+    kind: NodeClaim
+    listKind: NodeClaimList
+    plural: nodeclaims
+    singular: nodeclaim
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.labels.node\.kubernetes\.io/instance-type
+          name: Type
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/capacity-type
+          name: Capacity
+          type: string
+        - jsonPath: .metadata.labels.topology\.kubernetes\.io/zone
+          name: Zone
+          type: string
+        - jsonPath: .status.nodeName
+          name: Node
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .status.imageID
+          name: ImageID
+          priority: 1
+          type: string
+        - jsonPath: .status.providerID
+          name: ID
+          priority: 1
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/nodepool
+          name: NodePool
+          priority: 1
+          type: string
+        - jsonPath: .spec.nodeClassRef.name
+          name: NodeClass
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: NodeClaim is the Schema for the NodeClaims API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: NodeClaimSpec describes the desired state of the NodeClaim
+              properties:
+                expireAfter:
+                  default: 720h
+                  description: |-
+                    ExpireAfter is the duration the controller will wait
+                    before terminating a node, measured from when the node is created. This
+                    is useful to implement features like eventually consistent node upgrade,
+                    memory leak protection, and disruption testing.
+                  pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                  type: string
+                nodeClassRef:
+                  description: NodeClassRef is a reference to an object that defines provider specific configuration
+                  properties:
+                    group:
+                      description: API version of the referent
+                      pattern: ^[^/]*$
+                      type: string
+                      x-kubernetes-validations:
+                        - message: group may not be empty
+                          rule: self != ''
+                    kind:
+                      description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                      type: string
+                      x-kubernetes-validations:
+                        - message: kind may not be empty
+                          rule: self != ''
+                    name:
+                      description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                      type: string
+                      x-kubernetes-validations:
+                        - message: name may not be empty
+                          rule: self != ''
+                  required:
+                    - group
+                    - kind
+                    - name
+                  type: object
+                requirements:
+                  description: Requirements are layered with GetLabels and applied to every node.
+                  items:
+                    description: |-
+                      A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                      and minValues that represent the requirement to have at least that many values.
+                    properties:
+                      key:
+                        description: The label key that the selector applies to.
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                        x-kubernetes-validations:
+                          - message: label domain "kubernetes.io" is restricted
+                            rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                          - message: label domain "k8s.io" is restricted
+                            rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                          - message: label domain "karpenter.sh" is restricted
+                            rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                          - message: label "kubernetes.io/hostname" is restricted
+                            rule: self != "kubernetes.io/hostname"
+                          - message: label domain "karpenter.k8s.aws" is restricted
+                            rule: self in ["karpenter.k8s.aws/capacity-reservation-id", "karpenter.k8s.aws/ec2nodeclass", "karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu", "karpenter.k8s.aws/instance-cpu-manufacturer", "karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz", "karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                      minValues:
+                        description: |-
+                          This field is ALPHA and can be dropped or replaced at any time
+                          MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                        maximum: 50
+                        minimum: 1
+                        type: integer
+                      operator:
+                        description: |-
+                          Represents a key's relationship to a set of values.
+                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                        type: string
+                        enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          - Gt
+                          - Lt
+                      values:
+                        description: |-
+                          An array of string values. If the operator is In or NotIn,
+                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                          the values array must be empty. If the operator is Gt or Lt, the values
+                          array must have a single element, which will be interpreted as an integer.
+                          This array is replaced during a strategic merge patch.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                        maxLength: 63
+                        pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                    required:
+                      - key
+                      - operator
+                    type: object
+                  maxItems: 100
+                  type: array
+                  x-kubernetes-validations:
+                    - message: requirements with operator 'In' must have a value defined
+                      rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                    - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                      rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                    - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                      rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                resources:
+                  description: Resources models the resource requirements for the NodeClaim to launch
+                  properties:
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: Requests describes the minimum required resources for the NodeClaim to launch
+                      type: object
+                  type: object
+                startupTaints:
+                  description: |-
+                    StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                    within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                    daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                    purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                taints:
+                  description: Taints will be applied to the NodeClaim's node.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                terminationGracePeriod:
+                  description: |-
+                    TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
+
+                    Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
+
+                    This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
+                    When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
+
+                    Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
+                    If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
+                    that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
+
+                    The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
+                    If left undefined, the controller will wait indefinitely for pods to be drained.
+                  pattern: ^([0-9]+(s|m|h))+$
+                  type: string
+              required:
+                - nodeClassRef
+                - requirements
+              type: object
+              x-kubernetes-validations:
+                - message: spec is immutable
+                  rule: self == oldSelf
+            status:
+              description: NodeClaimStatus defines the observed state of NodeClaim
+              properties:
+                allocatable:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Allocatable is the estimated allocatable capacity of the node
+                  type: object
+                capacity:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Capacity is the estimated full capacity of the node
+                  type: object
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        pattern: ^([A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?|)$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - status
+                      - type
+                    type: object
+                  type: array
+                imageID:
+                  description: ImageID is an identifier for the image that runs on the node
+                  type: string
+                lastPodEventTime:
+                  description: |-
+                    LastPodEventTime is updated with the last time a pod was scheduled
+                    or removed from the node. A pod going terminal or terminating
+                    is also considered as removed.
+                  format: date-time
+                  type: string
+                nodeName:
+                  description: NodeName is the name of the corresponding node object
+                  type: string
+                providerID:
+                  description: ProviderID of the corresponding node object
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/content/projects/karpenter/v1.3.1/karpenter.sh_nodepools.yaml
+++ b/content/projects/karpenter/v1.3.1/karpenter.sh_nodepools.yaml
@@ -1,0 +1,519 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: nodepools.karpenter.sh
+spec:
+  group: karpenter.sh
+  names:
+    categories:
+      - karpenter
+    kind: NodePool
+    listKind: NodePoolList
+    plural: nodepools
+    singular: nodepool
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.template.spec.nodeClassRef.name
+          name: NodeClass
+          type: string
+        - jsonPath: .status.resources.nodes
+          name: Nodes
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.weight
+          name: Weight
+          priority: 1
+          type: integer
+        - jsonPath: .status.resources.cpu
+          name: CPU
+          priority: 1
+          type: string
+        - jsonPath: .status.resources.memory
+          name: Memory
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: NodePool is the Schema for the NodePools API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                NodePoolSpec is the top level nodepool specification. Nodepools
+                launch nodes in response to pods that are unschedulable. A single nodepool
+                is capable of managing a diverse set of nodes. Node properties are determined
+                from a combination of nodepool and pod scheduling constraints.
+              properties:
+                disruption:
+                  default:
+                    consolidateAfter: 0s
+                  description: Disruption contains the parameters that relate to Karpenter's disruption logic
+                  properties:
+                    budgets:
+                      default:
+                        - nodes: 10%
+                      description: |-
+                        Budgets is a list of Budgets.
+                        If there are multiple active budgets, Karpenter uses
+                        the most restrictive value. If left undefined,
+                        this will default to one budget with a value to 10%.
+                      items:
+                        description: |-
+                          Budget defines when Karpenter will restrict the
+                          number of Node Claims that can be terminating simultaneously.
+                        properties:
+                          duration:
+                            description: |-
+                              Duration determines how long a Budget is active since each Schedule hit.
+                              Only minutes and hours are accepted, as cron does not work in seconds.
+                              If omitted, the budget is always active.
+                              This is required if Schedule is set.
+                              This regex has an optional 0s at the end since the duration.String() always adds
+                              a 0s at the end.
+                            pattern: ^((([0-9]+(h|m))|([0-9]+h[0-9]+m))(0s)?)$
+                            type: string
+                          nodes:
+                            default: 10%
+                            description: |-
+                              Nodes dictates the maximum number of NodeClaims owned by this NodePool
+                              that can be terminating at once. This is calculated by counting nodes that
+                              have a deletion timestamp set, or are actively being deleted by Karpenter.
+                              This field is required when specifying a budget.
+                              This cannot be of type intstr.IntOrString since kubebuilder doesn't support pattern
+                              checking for int nodes for IntOrString nodes.
+                              Ref: https://github.com/kubernetes-sigs/controller-tools/blob/55efe4be40394a288216dab63156b0a64fb82929/pkg/crd/markers/validation.go#L379-L388
+                            pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
+                            type: string
+                          reasons:
+                            description: |-
+                              Reasons is a list of disruption methods that this budget applies to. If Reasons is not set, this budget applies to all methods.
+                              Otherwise, this will apply to each reason defined.
+                              allowed reasons are Underutilized, Empty, and Drifted.
+                            items:
+                              description: DisruptionReason defines valid reasons for disruption budgets.
+                              enum:
+                                - Underutilized
+                                - Empty
+                                - Drifted
+                              type: string
+                            type: array
+                          schedule:
+                            description: |-
+                              Schedule specifies when a budget begins being active, following
+                              the upstream cronjob syntax. If omitted, the budget is always active.
+                              Timezones are not supported.
+                              This field is required if Duration is set.
+                            pattern: ^(@(annually|yearly|monthly|weekly|daily|midnight|hourly))|((.+)\s(.+)\s(.+)\s(.+)\s(.+))$
+                            type: string
+                        required:
+                          - nodes
+                        type: object
+                      maxItems: 50
+                      type: array
+                      x-kubernetes-validations:
+                        - message: '''schedule'' must be set with ''duration'''
+                          rule: self.all(x, has(x.schedule) == has(x.duration))
+                    consolidateAfter:
+                      description: |-
+                        ConsolidateAfter is the duration the controller will wait
+                        before attempting to terminate nodes that are underutilized.
+                        Refer to ConsolidationPolicy for how underutilization is considered.
+                      pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                      type: string
+                    consolidationPolicy:
+                      default: WhenEmptyOrUnderutilized
+                      description: |-
+                        ConsolidationPolicy describes which nodes Karpenter can disrupt through its consolidation
+                        algorithm. This policy defaults to "WhenEmptyOrUnderutilized" if not specified
+                      enum:
+                        - WhenEmpty
+                        - WhenEmptyOrUnderutilized
+                      type: string
+                  required:
+                    - consolidateAfter
+                  type: object
+                limits:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Limits define a set of bounds for provisioning capacity.
+                  type: object
+                template:
+                  description: |-
+                    Template contains the template of possibilities for the provisioning logic to launch a NodeClaim with.
+                    NodeClaims launched from this NodePool will often be further constrained than the template specifies.
+                  properties:
+                    metadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Annotations is an unstructured key value map stored with a resource that may be
+                            set by external tools to store and retrieve arbitrary metadata. They are not
+                            queryable and should be preserved when modifying objects.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                            maxLength: 63
+                            pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                          description: |-
+                            Map of string keys and values that can be used to organize and categorize
+                            (scope and select) objects. May match selectors of replication controllers
+                            and services.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
+                          type: object
+                          maxProperties: 100
+                          x-kubernetes-validations:
+                            - message: label domain "kubernetes.io" is restricted
+                              rule: self.all(x, x in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region",  "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || x.find("^([^/]+)").endsWith("node.kubernetes.io") || x.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !x.find("^([^/]+)").endsWith("kubernetes.io"))
+                            - message: label domain "k8s.io" is restricted
+                              rule: self.all(x, x.find("^([^/]+)").endsWith("kops.k8s.io") || !x.find("^([^/]+)").endsWith("k8s.io"))
+                            - message: label domain "karpenter.sh" is restricted
+                              rule: self.all(x, x in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !x.find("^([^/]+)").endsWith("karpenter.sh"))
+                            - message: label "karpenter.sh/nodepool" is restricted
+                              rule: self.all(x, x != "karpenter.sh/nodepool")
+                            - message: label "kubernetes.io/hostname" is restricted
+                              rule: self.all(x, x != "kubernetes.io/hostname")
+                            - message: label domain "karpenter.k8s.aws" is restricted
+                              rule: self.all(x, x in ["karpenter.k8s.aws/capacity-reservation-id", "karpenter.k8s.aws/ec2nodeclass", "karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu", "karpenter.k8s.aws/instance-cpu-manufacturer", "karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz", "karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !x.find("^([^/]+)").endsWith("karpenter.k8s.aws"))
+                      type: object
+                    spec:
+                      description: |-
+                        NodeClaimTemplateSpec describes the desired state of the NodeClaim in the Nodepool
+                        NodeClaimTemplateSpec is used in the NodePool's NodeClaimTemplate, with the resource requests omitted since
+                        users are not able to set resource requests in the NodePool.
+                      properties:
+                        expireAfter:
+                          default: 720h
+                          description: |-
+                            ExpireAfter is the duration the controller will wait
+                            before terminating a node, measured from when the node is created. This
+                            is useful to implement features like eventually consistent node upgrade,
+                            memory leak protection, and disruption testing.
+                          pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                          type: string
+                        nodeClassRef:
+                          description: NodeClassRef is a reference to an object that defines provider specific configuration
+                          properties:
+                            group:
+                              description: API version of the referent
+                              pattern: ^[^/]*$
+                              type: string
+                              x-kubernetes-validations:
+                                - message: group may not be empty
+                                  rule: self != ''
+                            kind:
+                              description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                              type: string
+                              x-kubernetes-validations:
+                                - message: kind may not be empty
+                                  rule: self != ''
+                            name:
+                              description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                              x-kubernetes-validations:
+                                - message: name may not be empty
+                                  rule: self != ''
+                          required:
+                            - group
+                            - kind
+                            - name
+                          type: object
+                          x-kubernetes-validations:
+                            - message: nodeClassRef.group is immutable
+                              rule: self.group == oldSelf.group
+                            - message: nodeClassRef.kind is immutable
+                              rule: self.kind == oldSelf.kind
+                        requirements:
+                          description: Requirements are layered with GetLabels and applied to every node.
+                          items:
+                            description: |-
+                              A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                              and minValues that represent the requirement to have at least that many values.
+                            properties:
+                              key:
+                                description: The label key that the selector applies to.
+                                type: string
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                                x-kubernetes-validations:
+                                  - message: label domain "kubernetes.io" is restricted
+                                    rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                                  - message: label domain "k8s.io" is restricted
+                                    rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                                  - message: label domain "karpenter.sh" is restricted
+                                    rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                                  - message: label "karpenter.sh/nodepool" is restricted
+                                    rule: self != "karpenter.sh/nodepool"
+                                  - message: label "kubernetes.io/hostname" is restricted
+                                    rule: self != "kubernetes.io/hostname"
+                                  - message: label domain "karpenter.k8s.aws" is restricted
+                                    rule: self in ["karpenter.k8s.aws/capacity-reservation-id", "karpenter.k8s.aws/ec2nodeclass", "karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu", "karpenter.k8s.aws/instance-cpu-manufacturer", "karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz", "karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                              minValues:
+                                description: |-
+                                  This field is ALPHA and can be dropped or replaced at any time
+                                  MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                                maximum: 50
+                                minimum: 1
+                                type: integer
+                              operator:
+                                description: |-
+                                  Represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                type: string
+                                enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  - Gt
+                                  - Lt
+                              values:
+                                description: |-
+                                  An array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                  array must have a single element, which will be interpreted as an integer.
+                                  This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          maxItems: 100
+                          type: array
+                          x-kubernetes-validations:
+                            - message: requirements with operator 'In' must have a value defined
+                              rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                            - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                              rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                            - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                              rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                        startupTaints:
+                          description: |-
+                            StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                            within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                            daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                            purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        taints:
+                          description: Taints will be applied to the NodeClaim's node.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        terminationGracePeriod:
+                          description: |-
+                            TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
+
+                            Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
+
+                            This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
+                            When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
+
+                            Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
+                            If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
+                            that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
+
+                            The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
+                            If left undefined, the controller will wait indefinitely for pods to be drained.
+                          pattern: ^([0-9]+(s|m|h))+$
+                          type: string
+                      required:
+                        - nodeClassRef
+                        - requirements
+                      type: object
+                  required:
+                    - spec
+                  type: object
+                weight:
+                  description: |-
+                    Weight is the priority given to the nodepool during scheduling. A higher
+                    numerical weight indicates that this nodepool will be ordered
+                    ahead of other nodepools with lower weights. A nodepool with no weight
+                    will be treated as if it is a nodepool with a weight of 0.
+                  format: int32
+                  maximum: 100
+                  minimum: 1
+                  type: integer
+              required:
+                - template
+              type: object
+            status:
+              description: NodePoolStatus defines the observed state of NodePool
+              properties:
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                resources:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Resources is the list of resources that have been provisioned.
+                  type: object
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/content/projects/karpenter/v1.3.2/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/content/projects/karpenter/v1.3.2/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -1,0 +1,815 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: ec2nodeclasses.karpenter.k8s.aws
+spec:
+  group: karpenter.k8s.aws
+  names:
+    categories:
+      - karpenter
+    kind: EC2NodeClass
+    listKind: EC2NodeClassList
+    plural: ec2nodeclasses
+    shortNames:
+      - ec2nc
+      - ec2ncs
+    singular: ec2nodeclass
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.role
+          name: Role
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: EC2NodeClass is the Schema for the EC2NodeClass API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                EC2NodeClassSpec is the top level specification for the AWS Karpenter Provider.
+                This will contain configuration necessary to launch instances in AWS.
+              properties:
+                amiFamily:
+                  description: |-
+                    AMIFamily dictates the UserData format and default BlockDeviceMappings used when generating launch templates.
+                    This field is optional when using an alias amiSelectorTerm, and the value will be inferred from the alias'
+                    family. When an alias is specified, this field may only be set to its corresponding family or 'Custom'. If no
+                    alias is specified, this field is required.
+                    NOTE: We ignore the AMIFamily for hashing here because we hash the AMIFamily dynamically by using the alias using
+                    the AMIFamily() helper function
+                  enum:
+                    - AL2
+                    - AL2023
+                    - Bottlerocket
+                    - Custom
+                    - Windows2019
+                    - Windows2022
+                  type: string
+                amiSelectorTerms:
+                  description: AMISelectorTerms is a list of or ami selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      AMISelectorTerm defines selection logic for an ami used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      alias:
+                        description: |-
+                          Alias specifies which EKS optimized AMI to select.
+                          Each alias consists of a family and an AMI version, specified as "family@version".
+                          Valid families include: al2, al2023, bottlerocket, windows2019, and windows2022.
+                          The version can either be pinned to a specific AMI release, with that AMIs version format (ex: "al2023@v20240625" or "bottlerocket@v1.10.0").
+                          The version can also be set to "latest" for any family. Setting the version to latest will result in drift when a new AMI is released. This is **not** recommended for production environments.
+                          Note: The Windows families do **not** support version pinning, and only latest may be used.
+                        maxLength: 30
+                        type: string
+                        x-kubernetes-validations:
+                          - message: '''alias'' is improperly formatted, must match the format ''family@version'''
+                            rule: self.matches('^[a-zA-Z0-9]+@.+$')
+                          - message: 'family is not supported, must be one of the following: ''al2'', ''al2023'', ''bottlerocket'', ''windows2019'', ''windows2022'''
+                            rule: self.split('@')[0] in ['al2','al2023','bottlerocket','windows2019','windows2022']
+                          - message: windows families may only specify version 'latest'
+                            rule: 'self.split(''@'')[0] in [''windows2019'',''windows2022''] ? self.split(''@'')[1] == ''latest'' : true'
+                      id:
+                        description: ID is the ami id in EC2
+                        pattern: ami-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the ami name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      owner:
+                        description: |-
+                          Owner is the owner for the ami.
+                          You can specify a combination of AWS account IDs, "self", "amazon", and "aws-marketplace"
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select amis.
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  minItems: 1
+                  type: array
+                  x-kubernetes-validations:
+                    - message: expected at least one, got none, ['tags', 'id', 'name', 'alias']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name) || has(x.alias))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.exists(x, has(x.id) && (has(x.alias) || has(x.tags) || has(x.name) || has(x.owner)))'
+                    - message: '''alias'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.exists(x, has(x.alias) && (has(x.id) || has(x.tags) || has(x.name) || has(x.owner)))'
+                    - message: '''alias'' is mutually exclusive, cannot be set with a combination of other amiSelectorTerms'
+                      rule: '!(self.exists(x, has(x.alias)) && self.size() != 1)'
+                associatePublicIPAddress:
+                  description: AssociatePublicIPAddress controls if public IP addresses are assigned to instances that are launched with the nodeclass.
+                  type: boolean
+                blockDeviceMappings:
+                  description: BlockDeviceMappings to be applied to provisioned nodes.
+                  items:
+                    properties:
+                      deviceName:
+                        description: The device name (for example, /dev/sdh or xvdh).
+                        type: string
+                      ebs:
+                        description: EBS contains parameters used to automatically set up EBS volumes when an instance is launched.
+                        properties:
+                          deleteOnTermination:
+                            description: DeleteOnTermination indicates whether the EBS volume is deleted on instance termination.
+                            type: boolean
+                          encrypted:
+                            description: |-
+                              Encrypted indicates whether the EBS volume is encrypted. Encrypted volumes can only
+                              be attached to instances that support Amazon EBS encryption. If you are creating
+                              a volume from a snapshot, you can't specify an encryption value.
+                            type: boolean
+                          iops:
+                            description: |-
+                              IOPS is the number of I/O operations per second (IOPS). For gp3, io1, and io2 volumes,
+                              this represents the number of IOPS that are provisioned for the volume. For
+                              gp2 volumes, this represents the baseline performance of the volume and the
+                              rate at which the volume accumulates I/O credits for bursting.
+
+                              The following are the supported values for each volume type:
+
+                                 * gp3: 3,000-16,000 IOPS
+
+                                 * io1: 100-64,000 IOPS
+
+                                 * io2: 100-64,000 IOPS
+
+                              For io1 and io2 volumes, we guarantee 64,000 IOPS only for Instances built
+                              on the Nitro System (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances).
+                              Other instance families guarantee performance up to 32,000 IOPS.
+
+                              This parameter is supported for io1, io2, and gp3 volumes only. This parameter
+                              is not supported for gp2, st1, sc1, or standard volumes.
+                            format: int64
+                            type: integer
+                          kmsKeyID:
+                            description: KMSKeyID (ARN) of the symmetric Key Management Service (KMS) CMK used for encryption.
+                            type: string
+                          snapshotID:
+                            description: SnapshotID is the ID of an EBS snapshot
+                            type: string
+                          throughput:
+                            description: |-
+                              Throughput to provision for a gp3 volume, with a maximum of 1,000 MiB/s.
+                              Valid Range: Minimum value of 125. Maximum value of 1000.
+                            format: int64
+                            type: integer
+                          volumeSize:
+                            description: |-
+                              VolumeSize in `Gi`, `G`, `Ti`, or `T`. You must specify either a snapshot ID or
+                              a volume size. The following are the supported volumes sizes for each volume
+                              type:
+
+                                 * gp2 and gp3: 1-16,384
+
+                                 * io1 and io2: 4-16,384
+
+                                 * st1 and sc1: 125-16,384
+
+                                 * standard: 1-1,024
+                            pattern: ^((?:[1-9][0-9]{0,3}|[1-4][0-9]{4}|[5][0-8][0-9]{3}|59000)Gi|(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|[6][0-3][0-9]{3}|64000)G|([1-9]||[1-5][0-7]|58)Ti|([1-9]||[1-5][0-9]|6[0-3]|64)T)$
+                            type: string
+                          volumeType:
+                            description: |-
+                              VolumeType of the block device.
+                              For more information, see Amazon EBS volume types (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html)
+                              in the Amazon Elastic Compute Cloud User Guide.
+                            enum:
+                              - standard
+                              - io1
+                              - io2
+                              - gp2
+                              - sc1
+                              - st1
+                              - gp3
+                            type: string
+                        type: object
+                        x-kubernetes-validations:
+                          - message: snapshotID or volumeSize must be defined
+                            rule: has(self.snapshotID) || has(self.volumeSize)
+                      rootVolume:
+                        description: |-
+                          RootVolume is a flag indicating if this device is mounted as kubelet root dir. You can
+                          configure at most one root volume in BlockDeviceMappings.
+                        type: boolean
+                    type: object
+                  maxItems: 50
+                  type: array
+                  x-kubernetes-validations:
+                    - message: must have only one blockDeviceMappings with rootVolume
+                      rule: self.filter(x, has(x.rootVolume)?x.rootVolume==true:false).size() <= 1
+                capacityReservationSelectorTerms:
+                  description: |-
+                    CapacityReservationSelectorTerms is a list of capacity reservation selector terms. Each term is ORed together to
+                    determine the set of eligible capacity reservations.
+                  items:
+                    properties:
+                      id:
+                        description: ID is the capacity reservation id in EC2
+                        pattern: ^cr-[0-9a-z]+$
+                        type: string
+                      ownerID:
+                        description: Owner is the owner id for the ami.
+                        pattern: ^[0-9]{12}$
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select capacity reservations.
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: expected at least one, got none, ['tags', 'id']
+                      rule: self.all(x, has(x.tags) || has(x.id))
+                    - message: '''id'' is mutually exclusive, cannot be set along with tags in a capacity reservation selector term'
+                      rule: '!self.all(x, has(x.id) && (has(x.tags) || has(x.ownerID)))'
+                context:
+                  description: |-
+                    Context is a Reserved field in EC2 APIs
+                    https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet.html
+                  type: string
+                detailedMonitoring:
+                  description: DetailedMonitoring controls if detailed monitoring is enabled for instances that are launched
+                  type: boolean
+                instanceProfile:
+                  description: |-
+                    InstanceProfile is the AWS entity that instances use.
+                    This field is mutually exclusive from role.
+                    The instance profile should already have a role assigned to it that Karpenter
+                     has PassRole permission on for instance launch using this instanceProfile to succeed.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: instanceProfile cannot be empty
+                      rule: self != ''
+                instanceStorePolicy:
+                  description: InstanceStorePolicy specifies how to handle instance-store disks.
+                  enum:
+                    - RAID0
+                  type: string
+                kubelet:
+                  description: |-
+                    Kubelet defines args to be used when configuring kubelet on provisioned nodes.
+                    They are a subset of the upstream types, recognizing not all options may be supported.
+                    Wherever possible, the types and names should reflect the upstream kubelet types.
+                  properties:
+                    clusterDNS:
+                      description: |-
+                        clusterDNS is a list of IP addresses for the cluster DNS server.
+                        Note that not all providers may use all addresses.
+                      items:
+                        type: string
+                      type: array
+                    cpuCFSQuota:
+                      description: CPUCFSQuota enables CPU CFS quota enforcement for containers that specify CPU limits.
+                      type: boolean
+                    evictionHard:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionHard is the map of signal names to quantities that define hard eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionHard are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionMaxPodGracePeriod:
+                      description: |-
+                        EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in
+                        response to soft eviction thresholds being met.
+                      format: int32
+                      type: integer
+                    evictionSoft:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionSoft is the map of signal names to quantities that define soft eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoft are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionSoftGracePeriod:
+                      additionalProperties:
+                        type: string
+                      description: EvictionSoftGracePeriod is the map of signal names to quantities that define grace periods for each eviction signal
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoftGracePeriod are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    imageGCHighThresholdPercent:
+                      description: |-
+                        ImageGCHighThresholdPercent is the percent of disk usage after which image
+                        garbage collection is always run. The percent is calculated by dividing this
+                        field value by 100, so this field must be between 0 and 100, inclusive.
+                        When specified, the value must be greater than ImageGCLowThresholdPercent.
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    imageGCLowThresholdPercent:
+                      description: |-
+                        ImageGCLowThresholdPercent is the percent of disk usage before which image
+                        garbage collection is never run. Lowest disk usage to garbage collect to.
+                        The percent is calculated by dividing this field value by 100,
+                        so the field value must be between 0 and 100, inclusive.
+                        When specified, the value must be less than imageGCHighThresholdPercent
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    kubeReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: KubeReserved contains resources reserved for Kubernetes system components.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for kubeReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: kubeReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                    maxPods:
+                      description: |-
+                        MaxPods is an override for the maximum number of pods that can run on
+                        a worker node instance.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    podsPerCore:
+                      description: |-
+                        PodsPerCore is an override for the number of pods that can run on a worker node
+                        instance based on the number of cpu cores. This value cannot exceed MaxPods, so, if
+                        MaxPods is a lower value, that value will be used.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    systemReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: SystemReserved contains resources reserved for OS system daemons and kernel memory.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for systemReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: systemReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                  type: object
+                  x-kubernetes-validations:
+                    - message: imageGCHighThresholdPercent must be greater than imageGCLowThresholdPercent
+                      rule: 'has(self.imageGCHighThresholdPercent) && has(self.imageGCLowThresholdPercent) ?  self.imageGCHighThresholdPercent > self.imageGCLowThresholdPercent  : true'
+                    - message: evictionSoft OwnerKey does not have a matching evictionSoftGracePeriod
+                      rule: has(self.evictionSoft) ? self.evictionSoft.all(e, (e in self.evictionSoftGracePeriod)):true
+                    - message: evictionSoftGracePeriod OwnerKey does not have a matching evictionSoft
+                      rule: has(self.evictionSoftGracePeriod) ? self.evictionSoftGracePeriod.all(e, (e in self.evictionSoft)):true
+                metadataOptions:
+                  default:
+                    httpEndpoint: enabled
+                    httpProtocolIPv6: disabled
+                    httpPutResponseHopLimit: 1
+                    httpTokens: required
+                  description: |-
+                    MetadataOptions for the generated launch template of provisioned nodes.
+
+                    This specifies the exposure of the Instance Metadata Service to
+                    provisioned EC2 nodes. For more information,
+                    see Instance Metadata and User Data
+                    (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
+                    in the Amazon Elastic Compute Cloud User Guide.
+
+                    Refer to recommended, security best practices
+                    (https://aws.github.io/aws-eks-best-practices/security/docs/iam/#restrict-access-to-the-instance-profile-assigned-to-the-worker-node)
+                    for limiting exposure of Instance Metadata and User Data to pods.
+                    If omitted, defaults to httpEndpoint enabled, with httpProtocolIPv6
+                    disabled, with httpPutResponseLimit of 1, and with httpTokens
+                    required.
+                  properties:
+                    httpEndpoint:
+                      default: enabled
+                      description: |-
+                        HTTPEndpoint enables or disables the HTTP metadata endpoint on provisioned
+                        nodes. If metadata options is non-nil, but this parameter is not specified,
+                        the default state is "enabled".
+
+                        If you specify a value of "disabled", instance metadata will not be accessible
+                        on the node.
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpProtocolIPv6:
+                      default: disabled
+                      description: |-
+                        HTTPProtocolIPv6 enables or disables the IPv6 endpoint for the instance metadata
+                        service on provisioned nodes. If metadata options is non-nil, but this parameter
+                        is not specified, the default state is "disabled".
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpPutResponseHopLimit:
+                      default: 1
+                      description: |-
+                        HTTPPutResponseHopLimit is the desired HTTP PUT response hop limit for
+                        instance metadata requests. The larger the number, the further instance
+                        metadata requests can travel. Possible values are integers from 1 to 64.
+                        If metadata options is non-nil, but this parameter is not specified, the
+                        default value is 1.
+                      format: int64
+                      maximum: 64
+                      minimum: 1
+                      type: integer
+                    httpTokens:
+                      default: required
+                      description: |-
+                        HTTPTokens determines the state of token usage for instance metadata
+                        requests. If metadata options is non-nil, but this parameter is not
+                        specified, the default state is "required".
+
+                        If the state is optional, one can choose to retrieve instance metadata with
+                        or without a signed token header on the request. If one retrieves the IAM
+                        role credentials without a token, the version 1.0 role credentials are
+                        returned. If one retrieves the IAM role credentials using a valid signed
+                        token, the version 2.0 role credentials are returned.
+
+                        If the state is "required", one must send a signed token header with any
+                        instance metadata retrieval requests. In this state, retrieving the IAM
+                        role credentials always returns the version 2.0 credentials; the version
+                        1.0 credentials are not available.
+                      enum:
+                        - required
+                        - optional
+                      type: string
+                  type: object
+                role:
+                  description: |-
+                    Role is the AWS identity that nodes use. This field is immutable.
+                    This field is mutually exclusive from instanceProfile.
+                    Marking this field as immutable avoids concerns around terminating managed instance profiles from running instances.
+                    This field may be made mutable in the future, assuming the correct garbage collection and drift handling is implemented
+                    for the old instance profiles on an update.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: role cannot be empty
+                      rule: self != ''
+                    - message: immutable field changed
+                      rule: self == oldSelf
+                securityGroupSelectorTerms:
+                  description: SecurityGroupSelectorTerms is a list of security group selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SecurityGroupSelectorTerm defines selection logic for a security group used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the security group id in EC2
+                        pattern: sg-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the security group name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select security groups.
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: securityGroupSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id', 'name']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in a security group selector term'
+                      rule: '!self.all(x, has(x.id) && (has(x.tags) || has(x.name)))'
+                    - message: '''name'' is mutually exclusive, cannot be set with a combination of other fields in a security group selector term'
+                      rule: '!self.all(x, has(x.name) && (has(x.tags) || has(x.id)))'
+                subnetSelectorTerms:
+                  description: SubnetSelectorTerms is a list of subnet selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SubnetSelectorTerm defines selection logic for a subnet used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the subnet id in EC2
+                        pattern: subnet-[0-9a-z]+
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: subnetSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id']
+                      rule: self.all(x, has(x.tags) || has(x.id))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in a subnet selector term'
+                      rule: '!self.all(x, has(x.id) && has(x.tags))'
+                tags:
+                  additionalProperties:
+                    type: string
+                  description: Tags to be applied on ec2 resources like instances and launch templates.
+                  type: object
+                  x-kubernetes-validations:
+                    - message: empty tag keys aren't supported
+                      rule: self.all(k, k != '')
+                    - message: tag contains a restricted tag matching eks:eks-cluster-name
+                      rule: self.all(k, k !='eks:eks-cluster-name')
+                    - message: tag contains a restricted tag matching kubernetes.io/cluster/
+                      rule: self.all(k, !k.startsWith('kubernetes.io/cluster') )
+                    - message: tag contains a restricted tag matching karpenter.sh/nodepool
+                      rule: self.all(k, k != 'karpenter.sh/nodepool')
+                    - message: tag contains a restricted tag matching karpenter.sh/nodeclaim
+                      rule: self.all(k, k !='karpenter.sh/nodeclaim')
+                    - message: tag contains a restricted tag matching karpenter.k8s.aws/ec2nodeclass
+                      rule: self.all(k, k !='karpenter.k8s.aws/ec2nodeclass')
+                userData:
+                  description: |-
+                    UserData to be applied to the provisioned nodes.
+                    It must be in the appropriate format based on the AMIFamily in use. Karpenter will merge certain fields into
+                    this UserData to ensure nodes are being provisioned with the correct configuration.
+                  type: string
+              required:
+                - amiSelectorTerms
+                - securityGroupSelectorTerms
+                - subnetSelectorTerms
+              type: object
+              x-kubernetes-validations:
+                - message: must specify exactly one of ['role', 'instanceProfile']
+                  rule: (has(self.role) && !has(self.instanceProfile)) || (!has(self.role) && has(self.instanceProfile))
+                - message: changing from 'instanceProfile' to 'role' is not supported. You must delete and recreate this node class if you want to change this.
+                  rule: (has(oldSelf.role) && has(self.role)) || (has(oldSelf.instanceProfile) && has(self.instanceProfile))
+                - message: if set, amiFamily must be 'AL2' or 'Custom' when using an AL2 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''al2'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''AL2'') : true)'
+                - message: if set, amiFamily must be 'AL2023' or 'Custom' when using an AL2023 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''al2023'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''AL2023'') : true)'
+                - message: if set, amiFamily must be 'Bottlerocket' or 'Custom' when using a Bottlerocket alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''bottlerocket'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Bottlerocket'') : true)'
+                - message: if set, amiFamily must be 'Windows2019' or 'Custom' when using a Windows2019 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''windows2019'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Windows2019'') : true)'
+                - message: if set, amiFamily must be 'Windows2022' or 'Custom' when using a Windows2022 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''windows2022'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Windows2022'') : true)'
+                - message: must specify amiFamily if amiSelectorTerms does not contain an alias
+                  rule: 'self.amiSelectorTerms.exists(x, has(x.alias)) ? true : has(self.amiFamily)'
+            status:
+              description: EC2NodeClassStatus contains the resolved state of the EC2NodeClass
+              properties:
+                amis:
+                  description: |-
+                    AMI contains the current AMI values that are available to the
+                    cluster under the AMI selectors.
+                  items:
+                    description: AMI contains resolved AMI selector values utilized for node launch
+                    properties:
+                      deprecated:
+                        description: Deprecation status of the AMI
+                        type: boolean
+                      id:
+                        description: ID of the AMI
+                        type: string
+                      name:
+                        description: Name of the AMI
+                        type: string
+                      requirements:
+                        description: Requirements of the AMI to be utilized on an instance type
+                        items:
+                          description: |-
+                            A node selector requirement is a selector that contains values, a key, and an operator
+                            that relates the key and values.
+                          properties:
+                            key:
+                              description: The label key that the selector applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                Represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                              type: string
+                            values:
+                              description: |-
+                                An array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. If the operator is Gt or Lt, the values
+                                array must have a single element, which will be interpreted as an integer.
+                                This array is replaced during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                            - key
+                            - operator
+                          type: object
+                        type: array
+                    required:
+                      - id
+                      - requirements
+                    type: object
+                  type: array
+                capacityReservations:
+                  description: |-
+                    CapacityReservations contains the current capacity reservation values that are available to this NodeClass under the
+                    CapacityReservation selectors.
+                  items:
+                    properties:
+                      availabilityZone:
+                        description: The availability zone the capacity reservation is available in.
+                        type: string
+                      endTime:
+                        description: |-
+                          The time at which the capacity reservation expires. Once expired, the reserved capacity is released and Karpenter
+                          will no longer be able to launch instances into that reservation.
+                        format: date-time
+                        type: string
+                      id:
+                        description: The id for the capacity reservation.
+                        pattern: ^cr-[0-9a-z]+$
+                        type: string
+                      instanceMatchCriteria:
+                        description: Indicates the type of instance launches the capacity reservation accepts.
+                        enum:
+                          - open
+                          - targeted
+                        type: string
+                      instanceType:
+                        description: The instance type for the capacity reservation.
+                        type: string
+                      ownerID:
+                        description: The ID of the AWS account that owns the capacity reservation.
+                        pattern: ^[0-9]{12}$
+                        type: string
+                    required:
+                      - availabilityZone
+                      - id
+                      - instanceMatchCriteria
+                      - instanceType
+                      - ownerID
+                    type: object
+                  type: array
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                instanceProfile:
+                  description: InstanceProfile contains the resolved instance profile for the role
+                  type: string
+                securityGroups:
+                  description: |-
+                    SecurityGroups contains the current security group values that are available to the
+                    cluster under the SecurityGroups selectors.
+                  items:
+                    description: SecurityGroup contains resolved SecurityGroup selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the security group
+                        type: string
+                      name:
+                        description: Name of the security group
+                        type: string
+                    required:
+                      - id
+                    type: object
+                  type: array
+                subnets:
+                  description: |-
+                    Subnets contains the current subnet values that are available to the
+                    cluster under the subnet selectors.
+                  items:
+                    description: Subnet contains resolved Subnet selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the subnet
+                        type: string
+                      zone:
+                        description: The associated availability zone
+                        type: string
+                      zoneID:
+                        description: The associated availability zone ID
+                        type: string
+                    required:
+                      - id
+                      - zone
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/content/projects/karpenter/v1.3.2/karpenter.sh_nodeclaims.yaml
+++ b/content/projects/karpenter/v1.3.2/karpenter.sh_nodeclaims.yaml
@@ -1,0 +1,395 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: nodeclaims.karpenter.sh
+spec:
+  group: karpenter.sh
+  names:
+    categories:
+      - karpenter
+    kind: NodeClaim
+    listKind: NodeClaimList
+    plural: nodeclaims
+    singular: nodeclaim
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.labels.node\.kubernetes\.io/instance-type
+          name: Type
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/capacity-type
+          name: Capacity
+          type: string
+        - jsonPath: .metadata.labels.topology\.kubernetes\.io/zone
+          name: Zone
+          type: string
+        - jsonPath: .status.nodeName
+          name: Node
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .status.imageID
+          name: ImageID
+          priority: 1
+          type: string
+        - jsonPath: .status.providerID
+          name: ID
+          priority: 1
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/nodepool
+          name: NodePool
+          priority: 1
+          type: string
+        - jsonPath: .spec.nodeClassRef.name
+          name: NodeClass
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: NodeClaim is the Schema for the NodeClaims API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: NodeClaimSpec describes the desired state of the NodeClaim
+              properties:
+                expireAfter:
+                  default: 720h
+                  description: |-
+                    ExpireAfter is the duration the controller will wait
+                    before terminating a node, measured from when the node is created. This
+                    is useful to implement features like eventually consistent node upgrade,
+                    memory leak protection, and disruption testing.
+                  pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                  type: string
+                nodeClassRef:
+                  description: NodeClassRef is a reference to an object that defines provider specific configuration
+                  properties:
+                    group:
+                      description: API version of the referent
+                      pattern: ^[^/]*$
+                      type: string
+                      x-kubernetes-validations:
+                        - message: group may not be empty
+                          rule: self != ''
+                    kind:
+                      description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                      type: string
+                      x-kubernetes-validations:
+                        - message: kind may not be empty
+                          rule: self != ''
+                    name:
+                      description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                      type: string
+                      x-kubernetes-validations:
+                        - message: name may not be empty
+                          rule: self != ''
+                  required:
+                    - group
+                    - kind
+                    - name
+                  type: object
+                requirements:
+                  description: Requirements are layered with GetLabels and applied to every node.
+                  items:
+                    description: |-
+                      A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                      and minValues that represent the requirement to have at least that many values.
+                    properties:
+                      key:
+                        description: The label key that the selector applies to.
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                        x-kubernetes-validations:
+                          - message: label domain "kubernetes.io" is restricted
+                            rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                          - message: label domain "k8s.io" is restricted
+                            rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                          - message: label domain "karpenter.sh" is restricted
+                            rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                          - message: label "kubernetes.io/hostname" is restricted
+                            rule: self != "kubernetes.io/hostname"
+                          - message: label domain "karpenter.k8s.aws" is restricted
+                            rule: self in ["karpenter.k8s.aws/capacity-reservation-id", "karpenter.k8s.aws/ec2nodeclass", "karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu", "karpenter.k8s.aws/instance-cpu-manufacturer", "karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz", "karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                      minValues:
+                        description: |-
+                          This field is ALPHA and can be dropped or replaced at any time
+                          MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                        maximum: 50
+                        minimum: 1
+                        type: integer
+                      operator:
+                        description: |-
+                          Represents a key's relationship to a set of values.
+                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                        type: string
+                        enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          - Gt
+                          - Lt
+                      values:
+                        description: |-
+                          An array of string values. If the operator is In or NotIn,
+                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                          the values array must be empty. If the operator is Gt or Lt, the values
+                          array must have a single element, which will be interpreted as an integer.
+                          This array is replaced during a strategic merge patch.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                        maxLength: 63
+                        pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                    required:
+                      - key
+                      - operator
+                    type: object
+                  maxItems: 100
+                  type: array
+                  x-kubernetes-validations:
+                    - message: requirements with operator 'In' must have a value defined
+                      rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                    - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                      rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                    - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                      rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                resources:
+                  description: Resources models the resource requirements for the NodeClaim to launch
+                  properties:
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: Requests describes the minimum required resources for the NodeClaim to launch
+                      type: object
+                  type: object
+                startupTaints:
+                  description: |-
+                    StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                    within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                    daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                    purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                taints:
+                  description: Taints will be applied to the NodeClaim's node.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                terminationGracePeriod:
+                  description: |-
+                    TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
+
+                    Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
+
+                    This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
+                    When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
+
+                    Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
+                    If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
+                    that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
+
+                    The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
+                    If left undefined, the controller will wait indefinitely for pods to be drained.
+                  pattern: ^([0-9]+(s|m|h))+$
+                  type: string
+              required:
+                - nodeClassRef
+                - requirements
+              type: object
+              x-kubernetes-validations:
+                - message: spec is immutable
+                  rule: self == oldSelf
+            status:
+              description: NodeClaimStatus defines the observed state of NodeClaim
+              properties:
+                allocatable:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Allocatable is the estimated allocatable capacity of the node
+                  type: object
+                capacity:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Capacity is the estimated full capacity of the node
+                  type: object
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        pattern: ^([A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?|)$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - status
+                      - type
+                    type: object
+                  type: array
+                imageID:
+                  description: ImageID is an identifier for the image that runs on the node
+                  type: string
+                lastPodEventTime:
+                  description: |-
+                    LastPodEventTime is updated with the last time a pod was scheduled
+                    or removed from the node. A pod going terminal or terminating
+                    is also considered as removed.
+                  format: date-time
+                  type: string
+                nodeName:
+                  description: NodeName is the name of the corresponding node object
+                  type: string
+                providerID:
+                  description: ProviderID of the corresponding node object
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/content/projects/karpenter/v1.3.2/karpenter.sh_nodepools.yaml
+++ b/content/projects/karpenter/v1.3.2/karpenter.sh_nodepools.yaml
@@ -1,0 +1,519 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: nodepools.karpenter.sh
+spec:
+  group: karpenter.sh
+  names:
+    categories:
+      - karpenter
+    kind: NodePool
+    listKind: NodePoolList
+    plural: nodepools
+    singular: nodepool
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.template.spec.nodeClassRef.name
+          name: NodeClass
+          type: string
+        - jsonPath: .status.resources.nodes
+          name: Nodes
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.weight
+          name: Weight
+          priority: 1
+          type: integer
+        - jsonPath: .status.resources.cpu
+          name: CPU
+          priority: 1
+          type: string
+        - jsonPath: .status.resources.memory
+          name: Memory
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: NodePool is the Schema for the NodePools API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                NodePoolSpec is the top level nodepool specification. Nodepools
+                launch nodes in response to pods that are unschedulable. A single nodepool
+                is capable of managing a diverse set of nodes. Node properties are determined
+                from a combination of nodepool and pod scheduling constraints.
+              properties:
+                disruption:
+                  default:
+                    consolidateAfter: 0s
+                  description: Disruption contains the parameters that relate to Karpenter's disruption logic
+                  properties:
+                    budgets:
+                      default:
+                        - nodes: 10%
+                      description: |-
+                        Budgets is a list of Budgets.
+                        If there are multiple active budgets, Karpenter uses
+                        the most restrictive value. If left undefined,
+                        this will default to one budget with a value to 10%.
+                      items:
+                        description: |-
+                          Budget defines when Karpenter will restrict the
+                          number of Node Claims that can be terminating simultaneously.
+                        properties:
+                          duration:
+                            description: |-
+                              Duration determines how long a Budget is active since each Schedule hit.
+                              Only minutes and hours are accepted, as cron does not work in seconds.
+                              If omitted, the budget is always active.
+                              This is required if Schedule is set.
+                              This regex has an optional 0s at the end since the duration.String() always adds
+                              a 0s at the end.
+                            pattern: ^((([0-9]+(h|m))|([0-9]+h[0-9]+m))(0s)?)$
+                            type: string
+                          nodes:
+                            default: 10%
+                            description: |-
+                              Nodes dictates the maximum number of NodeClaims owned by this NodePool
+                              that can be terminating at once. This is calculated by counting nodes that
+                              have a deletion timestamp set, or are actively being deleted by Karpenter.
+                              This field is required when specifying a budget.
+                              This cannot be of type intstr.IntOrString since kubebuilder doesn't support pattern
+                              checking for int nodes for IntOrString nodes.
+                              Ref: https://github.com/kubernetes-sigs/controller-tools/blob/55efe4be40394a288216dab63156b0a64fb82929/pkg/crd/markers/validation.go#L379-L388
+                            pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
+                            type: string
+                          reasons:
+                            description: |-
+                              Reasons is a list of disruption methods that this budget applies to. If Reasons is not set, this budget applies to all methods.
+                              Otherwise, this will apply to each reason defined.
+                              allowed reasons are Underutilized, Empty, and Drifted.
+                            items:
+                              description: DisruptionReason defines valid reasons for disruption budgets.
+                              enum:
+                                - Underutilized
+                                - Empty
+                                - Drifted
+                              type: string
+                            type: array
+                          schedule:
+                            description: |-
+                              Schedule specifies when a budget begins being active, following
+                              the upstream cronjob syntax. If omitted, the budget is always active.
+                              Timezones are not supported.
+                              This field is required if Duration is set.
+                            pattern: ^(@(annually|yearly|monthly|weekly|daily|midnight|hourly))|((.+)\s(.+)\s(.+)\s(.+)\s(.+))$
+                            type: string
+                        required:
+                          - nodes
+                        type: object
+                      maxItems: 50
+                      type: array
+                      x-kubernetes-validations:
+                        - message: '''schedule'' must be set with ''duration'''
+                          rule: self.all(x, has(x.schedule) == has(x.duration))
+                    consolidateAfter:
+                      description: |-
+                        ConsolidateAfter is the duration the controller will wait
+                        before attempting to terminate nodes that are underutilized.
+                        Refer to ConsolidationPolicy for how underutilization is considered.
+                      pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                      type: string
+                    consolidationPolicy:
+                      default: WhenEmptyOrUnderutilized
+                      description: |-
+                        ConsolidationPolicy describes which nodes Karpenter can disrupt through its consolidation
+                        algorithm. This policy defaults to "WhenEmptyOrUnderutilized" if not specified
+                      enum:
+                        - WhenEmpty
+                        - WhenEmptyOrUnderutilized
+                      type: string
+                  required:
+                    - consolidateAfter
+                  type: object
+                limits:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Limits define a set of bounds for provisioning capacity.
+                  type: object
+                template:
+                  description: |-
+                    Template contains the template of possibilities for the provisioning logic to launch a NodeClaim with.
+                    NodeClaims launched from this NodePool will often be further constrained than the template specifies.
+                  properties:
+                    metadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Annotations is an unstructured key value map stored with a resource that may be
+                            set by external tools to store and retrieve arbitrary metadata. They are not
+                            queryable and should be preserved when modifying objects.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                            maxLength: 63
+                            pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                          description: |-
+                            Map of string keys and values that can be used to organize and categorize
+                            (scope and select) objects. May match selectors of replication controllers
+                            and services.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
+                          type: object
+                          maxProperties: 100
+                          x-kubernetes-validations:
+                            - message: label domain "kubernetes.io" is restricted
+                              rule: self.all(x, x in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region",  "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || x.find("^([^/]+)").endsWith("node.kubernetes.io") || x.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !x.find("^([^/]+)").endsWith("kubernetes.io"))
+                            - message: label domain "k8s.io" is restricted
+                              rule: self.all(x, x.find("^([^/]+)").endsWith("kops.k8s.io") || !x.find("^([^/]+)").endsWith("k8s.io"))
+                            - message: label domain "karpenter.sh" is restricted
+                              rule: self.all(x, x in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !x.find("^([^/]+)").endsWith("karpenter.sh"))
+                            - message: label "karpenter.sh/nodepool" is restricted
+                              rule: self.all(x, x != "karpenter.sh/nodepool")
+                            - message: label "kubernetes.io/hostname" is restricted
+                              rule: self.all(x, x != "kubernetes.io/hostname")
+                            - message: label domain "karpenter.k8s.aws" is restricted
+                              rule: self.all(x, x in ["karpenter.k8s.aws/capacity-reservation-id", "karpenter.k8s.aws/ec2nodeclass", "karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu", "karpenter.k8s.aws/instance-cpu-manufacturer", "karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz", "karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !x.find("^([^/]+)").endsWith("karpenter.k8s.aws"))
+                      type: object
+                    spec:
+                      description: |-
+                        NodeClaimTemplateSpec describes the desired state of the NodeClaim in the Nodepool
+                        NodeClaimTemplateSpec is used in the NodePool's NodeClaimTemplate, with the resource requests omitted since
+                        users are not able to set resource requests in the NodePool.
+                      properties:
+                        expireAfter:
+                          default: 720h
+                          description: |-
+                            ExpireAfter is the duration the controller will wait
+                            before terminating a node, measured from when the node is created. This
+                            is useful to implement features like eventually consistent node upgrade,
+                            memory leak protection, and disruption testing.
+                          pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                          type: string
+                        nodeClassRef:
+                          description: NodeClassRef is a reference to an object that defines provider specific configuration
+                          properties:
+                            group:
+                              description: API version of the referent
+                              pattern: ^[^/]*$
+                              type: string
+                              x-kubernetes-validations:
+                                - message: group may not be empty
+                                  rule: self != ''
+                            kind:
+                              description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                              type: string
+                              x-kubernetes-validations:
+                                - message: kind may not be empty
+                                  rule: self != ''
+                            name:
+                              description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                              x-kubernetes-validations:
+                                - message: name may not be empty
+                                  rule: self != ''
+                          required:
+                            - group
+                            - kind
+                            - name
+                          type: object
+                          x-kubernetes-validations:
+                            - message: nodeClassRef.group is immutable
+                              rule: self.group == oldSelf.group
+                            - message: nodeClassRef.kind is immutable
+                              rule: self.kind == oldSelf.kind
+                        requirements:
+                          description: Requirements are layered with GetLabels and applied to every node.
+                          items:
+                            description: |-
+                              A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                              and minValues that represent the requirement to have at least that many values.
+                            properties:
+                              key:
+                                description: The label key that the selector applies to.
+                                type: string
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                                x-kubernetes-validations:
+                                  - message: label domain "kubernetes.io" is restricted
+                                    rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                                  - message: label domain "k8s.io" is restricted
+                                    rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                                  - message: label domain "karpenter.sh" is restricted
+                                    rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                                  - message: label "karpenter.sh/nodepool" is restricted
+                                    rule: self != "karpenter.sh/nodepool"
+                                  - message: label "kubernetes.io/hostname" is restricted
+                                    rule: self != "kubernetes.io/hostname"
+                                  - message: label domain "karpenter.k8s.aws" is restricted
+                                    rule: self in ["karpenter.k8s.aws/capacity-reservation-id", "karpenter.k8s.aws/ec2nodeclass", "karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu", "karpenter.k8s.aws/instance-cpu-manufacturer", "karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz", "karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                              minValues:
+                                description: |-
+                                  This field is ALPHA and can be dropped or replaced at any time
+                                  MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                                maximum: 50
+                                minimum: 1
+                                type: integer
+                              operator:
+                                description: |-
+                                  Represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                type: string
+                                enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  - Gt
+                                  - Lt
+                              values:
+                                description: |-
+                                  An array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                  array must have a single element, which will be interpreted as an integer.
+                                  This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          maxItems: 100
+                          type: array
+                          x-kubernetes-validations:
+                            - message: requirements with operator 'In' must have a value defined
+                              rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                            - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                              rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                            - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                              rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                        startupTaints:
+                          description: |-
+                            StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                            within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                            daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                            purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        taints:
+                          description: Taints will be applied to the NodeClaim's node.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        terminationGracePeriod:
+                          description: |-
+                            TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
+
+                            Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
+
+                            This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
+                            When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
+
+                            Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
+                            If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
+                            that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
+
+                            The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
+                            If left undefined, the controller will wait indefinitely for pods to be drained.
+                          pattern: ^([0-9]+(s|m|h))+$
+                          type: string
+                      required:
+                        - nodeClassRef
+                        - requirements
+                      type: object
+                  required:
+                    - spec
+                  type: object
+                weight:
+                  description: |-
+                    Weight is the priority given to the nodepool during scheduling. A higher
+                    numerical weight indicates that this nodepool will be ordered
+                    ahead of other nodepools with lower weights. A nodepool with no weight
+                    will be treated as if it is a nodepool with a weight of 0.
+                  format: int32
+                  maximum: 100
+                  minimum: 1
+                  type: integer
+              required:
+                - template
+              type: object
+            status:
+              description: NodePoolStatus defines the observed state of NodePool
+              properties:
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                resources:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Resources is the list of resources that have been provisioned.
+                  type: object
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/content/projects/karpenter/v1.3.3/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/content/projects/karpenter/v1.3.3/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -1,0 +1,815 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: ec2nodeclasses.karpenter.k8s.aws
+spec:
+  group: karpenter.k8s.aws
+  names:
+    categories:
+      - karpenter
+    kind: EC2NodeClass
+    listKind: EC2NodeClassList
+    plural: ec2nodeclasses
+    shortNames:
+      - ec2nc
+      - ec2ncs
+    singular: ec2nodeclass
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.role
+          name: Role
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: EC2NodeClass is the Schema for the EC2NodeClass API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                EC2NodeClassSpec is the top level specification for the AWS Karpenter Provider.
+                This will contain configuration necessary to launch instances in AWS.
+              properties:
+                amiFamily:
+                  description: |-
+                    AMIFamily dictates the UserData format and default BlockDeviceMappings used when generating launch templates.
+                    This field is optional when using an alias amiSelectorTerm, and the value will be inferred from the alias'
+                    family. When an alias is specified, this field may only be set to its corresponding family or 'Custom'. If no
+                    alias is specified, this field is required.
+                    NOTE: We ignore the AMIFamily for hashing here because we hash the AMIFamily dynamically by using the alias using
+                    the AMIFamily() helper function
+                  enum:
+                    - AL2
+                    - AL2023
+                    - Bottlerocket
+                    - Custom
+                    - Windows2019
+                    - Windows2022
+                  type: string
+                amiSelectorTerms:
+                  description: AMISelectorTerms is a list of or ami selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      AMISelectorTerm defines selection logic for an ami used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      alias:
+                        description: |-
+                          Alias specifies which EKS optimized AMI to select.
+                          Each alias consists of a family and an AMI version, specified as "family@version".
+                          Valid families include: al2, al2023, bottlerocket, windows2019, and windows2022.
+                          The version can either be pinned to a specific AMI release, with that AMIs version format (ex: "al2023@v20240625" or "bottlerocket@v1.10.0").
+                          The version can also be set to "latest" for any family. Setting the version to latest will result in drift when a new AMI is released. This is **not** recommended for production environments.
+                          Note: The Windows families do **not** support version pinning, and only latest may be used.
+                        maxLength: 30
+                        type: string
+                        x-kubernetes-validations:
+                          - message: '''alias'' is improperly formatted, must match the format ''family@version'''
+                            rule: self.matches('^[a-zA-Z0-9]+@.+$')
+                          - message: 'family is not supported, must be one of the following: ''al2'', ''al2023'', ''bottlerocket'', ''windows2019'', ''windows2022'''
+                            rule: self.split('@')[0] in ['al2','al2023','bottlerocket','windows2019','windows2022']
+                          - message: windows families may only specify version 'latest'
+                            rule: 'self.split(''@'')[0] in [''windows2019'',''windows2022''] ? self.split(''@'')[1] == ''latest'' : true'
+                      id:
+                        description: ID is the ami id in EC2
+                        pattern: ami-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the ami name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      owner:
+                        description: |-
+                          Owner is the owner for the ami.
+                          You can specify a combination of AWS account IDs, "self", "amazon", and "aws-marketplace"
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select amis.
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  minItems: 1
+                  type: array
+                  x-kubernetes-validations:
+                    - message: expected at least one, got none, ['tags', 'id', 'name', 'alias']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name) || has(x.alias))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.exists(x, has(x.id) && (has(x.alias) || has(x.tags) || has(x.name) || has(x.owner)))'
+                    - message: '''alias'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
+                      rule: '!self.exists(x, has(x.alias) && (has(x.id) || has(x.tags) || has(x.name) || has(x.owner)))'
+                    - message: '''alias'' is mutually exclusive, cannot be set with a combination of other amiSelectorTerms'
+                      rule: '!(self.exists(x, has(x.alias)) && self.size() != 1)'
+                associatePublicIPAddress:
+                  description: AssociatePublicIPAddress controls if public IP addresses are assigned to instances that are launched with the nodeclass.
+                  type: boolean
+                blockDeviceMappings:
+                  description: BlockDeviceMappings to be applied to provisioned nodes.
+                  items:
+                    properties:
+                      deviceName:
+                        description: The device name (for example, /dev/sdh or xvdh).
+                        type: string
+                      ebs:
+                        description: EBS contains parameters used to automatically set up EBS volumes when an instance is launched.
+                        properties:
+                          deleteOnTermination:
+                            description: DeleteOnTermination indicates whether the EBS volume is deleted on instance termination.
+                            type: boolean
+                          encrypted:
+                            description: |-
+                              Encrypted indicates whether the EBS volume is encrypted. Encrypted volumes can only
+                              be attached to instances that support Amazon EBS encryption. If you are creating
+                              a volume from a snapshot, you can't specify an encryption value.
+                            type: boolean
+                          iops:
+                            description: |-
+                              IOPS is the number of I/O operations per second (IOPS). For gp3, io1, and io2 volumes,
+                              this represents the number of IOPS that are provisioned for the volume. For
+                              gp2 volumes, this represents the baseline performance of the volume and the
+                              rate at which the volume accumulates I/O credits for bursting.
+
+                              The following are the supported values for each volume type:
+
+                                 * gp3: 3,000-16,000 IOPS
+
+                                 * io1: 100-64,000 IOPS
+
+                                 * io2: 100-64,000 IOPS
+
+                              For io1 and io2 volumes, we guarantee 64,000 IOPS only for Instances built
+                              on the Nitro System (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances).
+                              Other instance families guarantee performance up to 32,000 IOPS.
+
+                              This parameter is supported for io1, io2, and gp3 volumes only. This parameter
+                              is not supported for gp2, st1, sc1, or standard volumes.
+                            format: int64
+                            type: integer
+                          kmsKeyID:
+                            description: KMSKeyID (ARN) of the symmetric Key Management Service (KMS) CMK used for encryption.
+                            type: string
+                          snapshotID:
+                            description: SnapshotID is the ID of an EBS snapshot
+                            type: string
+                          throughput:
+                            description: |-
+                              Throughput to provision for a gp3 volume, with a maximum of 1,000 MiB/s.
+                              Valid Range: Minimum value of 125. Maximum value of 1000.
+                            format: int64
+                            type: integer
+                          volumeSize:
+                            description: |-
+                              VolumeSize in `Gi`, `G`, `Ti`, or `T`. You must specify either a snapshot ID or
+                              a volume size. The following are the supported volumes sizes for each volume
+                              type:
+
+                                 * gp2 and gp3: 1-16,384
+
+                                 * io1 and io2: 4-16,384
+
+                                 * st1 and sc1: 125-16,384
+
+                                 * standard: 1-1,024
+                            pattern: ^((?:[1-9][0-9]{0,3}|[1-4][0-9]{4}|[5][0-8][0-9]{3}|59000)Gi|(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|[6][0-3][0-9]{3}|64000)G|([1-9]||[1-5][0-7]|58)Ti|([1-9]||[1-5][0-9]|6[0-3]|64)T)$
+                            type: string
+                          volumeType:
+                            description: |-
+                              VolumeType of the block device.
+                              For more information, see Amazon EBS volume types (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html)
+                              in the Amazon Elastic Compute Cloud User Guide.
+                            enum:
+                              - standard
+                              - io1
+                              - io2
+                              - gp2
+                              - sc1
+                              - st1
+                              - gp3
+                            type: string
+                        type: object
+                        x-kubernetes-validations:
+                          - message: snapshotID or volumeSize must be defined
+                            rule: has(self.snapshotID) || has(self.volumeSize)
+                      rootVolume:
+                        description: |-
+                          RootVolume is a flag indicating if this device is mounted as kubelet root dir. You can
+                          configure at most one root volume in BlockDeviceMappings.
+                        type: boolean
+                    type: object
+                  maxItems: 50
+                  type: array
+                  x-kubernetes-validations:
+                    - message: must have only one blockDeviceMappings with rootVolume
+                      rule: self.filter(x, has(x.rootVolume)?x.rootVolume==true:false).size() <= 1
+                capacityReservationSelectorTerms:
+                  description: |-
+                    CapacityReservationSelectorTerms is a list of capacity reservation selector terms. Each term is ORed together to
+                    determine the set of eligible capacity reservations.
+                  items:
+                    properties:
+                      id:
+                        description: ID is the capacity reservation id in EC2
+                        pattern: ^cr-[0-9a-z]+$
+                        type: string
+                      ownerID:
+                        description: Owner is the owner id for the ami.
+                        pattern: ^[0-9]{12}$
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select capacity reservations.
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: expected at least one, got none, ['tags', 'id']
+                      rule: self.all(x, has(x.tags) || has(x.id))
+                    - message: '''id'' is mutually exclusive, cannot be set along with tags in a capacity reservation selector term'
+                      rule: '!self.all(x, has(x.id) && (has(x.tags) || has(x.ownerID)))'
+                context:
+                  description: |-
+                    Context is a Reserved field in EC2 APIs
+                    https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet.html
+                  type: string
+                detailedMonitoring:
+                  description: DetailedMonitoring controls if detailed monitoring is enabled for instances that are launched
+                  type: boolean
+                instanceProfile:
+                  description: |-
+                    InstanceProfile is the AWS entity that instances use.
+                    This field is mutually exclusive from role.
+                    The instance profile should already have a role assigned to it that Karpenter
+                     has PassRole permission on for instance launch using this instanceProfile to succeed.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: instanceProfile cannot be empty
+                      rule: self != ''
+                instanceStorePolicy:
+                  description: InstanceStorePolicy specifies how to handle instance-store disks.
+                  enum:
+                    - RAID0
+                  type: string
+                kubelet:
+                  description: |-
+                    Kubelet defines args to be used when configuring kubelet on provisioned nodes.
+                    They are a subset of the upstream types, recognizing not all options may be supported.
+                    Wherever possible, the types and names should reflect the upstream kubelet types.
+                  properties:
+                    clusterDNS:
+                      description: |-
+                        clusterDNS is a list of IP addresses for the cluster DNS server.
+                        Note that not all providers may use all addresses.
+                      items:
+                        type: string
+                      type: array
+                    cpuCFSQuota:
+                      description: CPUCFSQuota enables CPU CFS quota enforcement for containers that specify CPU limits.
+                      type: boolean
+                    evictionHard:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionHard is the map of signal names to quantities that define hard eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionHard are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionMaxPodGracePeriod:
+                      description: |-
+                        EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in
+                        response to soft eviction thresholds being met.
+                      format: int32
+                      type: integer
+                    evictionSoft:
+                      additionalProperties:
+                        type: string
+                        pattern: ^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
+                      description: EvictionSoft is the map of signal names to quantities that define soft eviction thresholds
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoft are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    evictionSoftGracePeriod:
+                      additionalProperties:
+                        type: string
+                      description: EvictionSoftGracePeriod is the map of signal names to quantities that define grace periods for each eviction signal
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for evictionSoftGracePeriod are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                          rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    imageGCHighThresholdPercent:
+                      description: |-
+                        ImageGCHighThresholdPercent is the percent of disk usage after which image
+                        garbage collection is always run. The percent is calculated by dividing this
+                        field value by 100, so this field must be between 0 and 100, inclusive.
+                        When specified, the value must be greater than ImageGCLowThresholdPercent.
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    imageGCLowThresholdPercent:
+                      description: |-
+                        ImageGCLowThresholdPercent is the percent of disk usage before which image
+                        garbage collection is never run. Lowest disk usage to garbage collect to.
+                        The percent is calculated by dividing this field value by 100,
+                        so the field value must be between 0 and 100, inclusive.
+                        When specified, the value must be less than imageGCHighThresholdPercent
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                    kubeReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: KubeReserved contains resources reserved for Kubernetes system components.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for kubeReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: kubeReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                    maxPods:
+                      description: |-
+                        MaxPods is an override for the maximum number of pods that can run on
+                        a worker node instance.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    podsPerCore:
+                      description: |-
+                        PodsPerCore is an override for the number of pods that can run on a worker node
+                        instance based on the number of cpu cores. This value cannot exceed MaxPods, so, if
+                        MaxPods is a lower value, that value will be used.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    systemReserved:
+                      additionalProperties:
+                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      description: SystemReserved contains resources reserved for OS system daemons and kernel memory.
+                      type: object
+                      x-kubernetes-validations:
+                        - message: valid keys for systemReserved are ['cpu','memory','ephemeral-storage','pid']
+                          rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')
+                        - message: systemReserved value cannot be a negative resource quantity
+                          rule: self.all(x, !self[x].startsWith('-'))
+                  type: object
+                  x-kubernetes-validations:
+                    - message: imageGCHighThresholdPercent must be greater than imageGCLowThresholdPercent
+                      rule: 'has(self.imageGCHighThresholdPercent) && has(self.imageGCLowThresholdPercent) ?  self.imageGCHighThresholdPercent > self.imageGCLowThresholdPercent  : true'
+                    - message: evictionSoft OwnerKey does not have a matching evictionSoftGracePeriod
+                      rule: has(self.evictionSoft) ? self.evictionSoft.all(e, (e in self.evictionSoftGracePeriod)):true
+                    - message: evictionSoftGracePeriod OwnerKey does not have a matching evictionSoft
+                      rule: has(self.evictionSoftGracePeriod) ? self.evictionSoftGracePeriod.all(e, (e in self.evictionSoft)):true
+                metadataOptions:
+                  default:
+                    httpEndpoint: enabled
+                    httpProtocolIPv6: disabled
+                    httpPutResponseHopLimit: 1
+                    httpTokens: required
+                  description: |-
+                    MetadataOptions for the generated launch template of provisioned nodes.
+
+                    This specifies the exposure of the Instance Metadata Service to
+                    provisioned EC2 nodes. For more information,
+                    see Instance Metadata and User Data
+                    (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
+                    in the Amazon Elastic Compute Cloud User Guide.
+
+                    Refer to recommended, security best practices
+                    (https://aws.github.io/aws-eks-best-practices/security/docs/iam/#restrict-access-to-the-instance-profile-assigned-to-the-worker-node)
+                    for limiting exposure of Instance Metadata and User Data to pods.
+                    If omitted, defaults to httpEndpoint enabled, with httpProtocolIPv6
+                    disabled, with httpPutResponseLimit of 1, and with httpTokens
+                    required.
+                  properties:
+                    httpEndpoint:
+                      default: enabled
+                      description: |-
+                        HTTPEndpoint enables or disables the HTTP metadata endpoint on provisioned
+                        nodes. If metadata options is non-nil, but this parameter is not specified,
+                        the default state is "enabled".
+
+                        If you specify a value of "disabled", instance metadata will not be accessible
+                        on the node.
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpProtocolIPv6:
+                      default: disabled
+                      description: |-
+                        HTTPProtocolIPv6 enables or disables the IPv6 endpoint for the instance metadata
+                        service on provisioned nodes. If metadata options is non-nil, but this parameter
+                        is not specified, the default state is "disabled".
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpPutResponseHopLimit:
+                      default: 1
+                      description: |-
+                        HTTPPutResponseHopLimit is the desired HTTP PUT response hop limit for
+                        instance metadata requests. The larger the number, the further instance
+                        metadata requests can travel. Possible values are integers from 1 to 64.
+                        If metadata options is non-nil, but this parameter is not specified, the
+                        default value is 1.
+                      format: int64
+                      maximum: 64
+                      minimum: 1
+                      type: integer
+                    httpTokens:
+                      default: required
+                      description: |-
+                        HTTPTokens determines the state of token usage for instance metadata
+                        requests. If metadata options is non-nil, but this parameter is not
+                        specified, the default state is "required".
+
+                        If the state is optional, one can choose to retrieve instance metadata with
+                        or without a signed token header on the request. If one retrieves the IAM
+                        role credentials without a token, the version 1.0 role credentials are
+                        returned. If one retrieves the IAM role credentials using a valid signed
+                        token, the version 2.0 role credentials are returned.
+
+                        If the state is "required", one must send a signed token header with any
+                        instance metadata retrieval requests. In this state, retrieving the IAM
+                        role credentials always returns the version 2.0 credentials; the version
+                        1.0 credentials are not available.
+                      enum:
+                        - required
+                        - optional
+                      type: string
+                  type: object
+                role:
+                  description: |-
+                    Role is the AWS identity that nodes use. This field is immutable.
+                    This field is mutually exclusive from instanceProfile.
+                    Marking this field as immutable avoids concerns around terminating managed instance profiles from running instances.
+                    This field may be made mutable in the future, assuming the correct garbage collection and drift handling is implemented
+                    for the old instance profiles on an update.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: role cannot be empty
+                      rule: self != ''
+                    - message: immutable field changed
+                      rule: self == oldSelf
+                securityGroupSelectorTerms:
+                  description: SecurityGroupSelectorTerms is a list of security group selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SecurityGroupSelectorTerm defines selection logic for a security group used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the security group id in EC2
+                        pattern: sg-[0-9a-z]+
+                        type: string
+                      name:
+                        description: |-
+                          Name is the security group name in EC2.
+                          This value is the name field, which is different from the name tag.
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select security groups.
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: securityGroupSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id', 'name']
+                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in a security group selector term'
+                      rule: '!self.all(x, has(x.id) && (has(x.tags) || has(x.name)))'
+                    - message: '''name'' is mutually exclusive, cannot be set with a combination of other fields in a security group selector term'
+                      rule: '!self.all(x, has(x.name) && (has(x.tags) || has(x.id)))'
+                subnetSelectorTerms:
+                  description: SubnetSelectorTerms is a list of subnet selector terms. The terms are ORed.
+                  items:
+                    description: |-
+                      SubnetSelectorTerm defines selection logic for a subnet used by Karpenter to launch nodes.
+                      If multiple fields are used for selection, the requirements are ANDed.
+                    properties:
+                      id:
+                        description: ID is the subnet id in EC2
+                        pattern: subnet-[0-9a-z]+
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags is a map of key/value tags used to select subnets
+                          Specifying '*' for a value selects all values for a given tag key.
+                        maxProperties: 20
+                        type: object
+                        x-kubernetes-validations:
+                          - message: empty tag keys or values aren't supported
+                            rule: self.all(k, k != '' && self[k] != '')
+                    type: object
+                  maxItems: 30
+                  type: array
+                  x-kubernetes-validations:
+                    - message: subnetSelectorTerms cannot be empty
+                      rule: self.size() != 0
+                    - message: expected at least one, got none, ['tags', 'id']
+                      rule: self.all(x, has(x.tags) || has(x.id))
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in a subnet selector term'
+                      rule: '!self.all(x, has(x.id) && has(x.tags))'
+                tags:
+                  additionalProperties:
+                    type: string
+                  description: Tags to be applied on ec2 resources like instances and launch templates.
+                  type: object
+                  x-kubernetes-validations:
+                    - message: empty tag keys aren't supported
+                      rule: self.all(k, k != '')
+                    - message: tag contains a restricted tag matching eks:eks-cluster-name
+                      rule: self.all(k, k !='eks:eks-cluster-name')
+                    - message: tag contains a restricted tag matching kubernetes.io/cluster/
+                      rule: self.all(k, !k.startsWith('kubernetes.io/cluster') )
+                    - message: tag contains a restricted tag matching karpenter.sh/nodepool
+                      rule: self.all(k, k != 'karpenter.sh/nodepool')
+                    - message: tag contains a restricted tag matching karpenter.sh/nodeclaim
+                      rule: self.all(k, k !='karpenter.sh/nodeclaim')
+                    - message: tag contains a restricted tag matching karpenter.k8s.aws/ec2nodeclass
+                      rule: self.all(k, k !='karpenter.k8s.aws/ec2nodeclass')
+                userData:
+                  description: |-
+                    UserData to be applied to the provisioned nodes.
+                    It must be in the appropriate format based on the AMIFamily in use. Karpenter will merge certain fields into
+                    this UserData to ensure nodes are being provisioned with the correct configuration.
+                  type: string
+              required:
+                - amiSelectorTerms
+                - securityGroupSelectorTerms
+                - subnetSelectorTerms
+              type: object
+              x-kubernetes-validations:
+                - message: must specify exactly one of ['role', 'instanceProfile']
+                  rule: (has(self.role) && !has(self.instanceProfile)) || (!has(self.role) && has(self.instanceProfile))
+                - message: changing from 'instanceProfile' to 'role' is not supported. You must delete and recreate this node class if you want to change this.
+                  rule: (has(oldSelf.role) && has(self.role)) || (has(oldSelf.instanceProfile) && has(self.instanceProfile))
+                - message: if set, amiFamily must be 'AL2' or 'Custom' when using an AL2 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''al2'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''AL2'') : true)'
+                - message: if set, amiFamily must be 'AL2023' or 'Custom' when using an AL2023 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''al2023'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''AL2023'') : true)'
+                - message: if set, amiFamily must be 'Bottlerocket' or 'Custom' when using a Bottlerocket alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''bottlerocket'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Bottlerocket'') : true)'
+                - message: if set, amiFamily must be 'Windows2019' or 'Custom' when using a Windows2019 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''windows2019'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Windows2019'') : true)'
+                - message: if set, amiFamily must be 'Windows2022' or 'Custom' when using a Windows2022 alias
+                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''windows2022'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Windows2022'') : true)'
+                - message: must specify amiFamily if amiSelectorTerms does not contain an alias
+                  rule: 'self.amiSelectorTerms.exists(x, has(x.alias)) ? true : has(self.amiFamily)'
+            status:
+              description: EC2NodeClassStatus contains the resolved state of the EC2NodeClass
+              properties:
+                amis:
+                  description: |-
+                    AMI contains the current AMI values that are available to the
+                    cluster under the AMI selectors.
+                  items:
+                    description: AMI contains resolved AMI selector values utilized for node launch
+                    properties:
+                      deprecated:
+                        description: Deprecation status of the AMI
+                        type: boolean
+                      id:
+                        description: ID of the AMI
+                        type: string
+                      name:
+                        description: Name of the AMI
+                        type: string
+                      requirements:
+                        description: Requirements of the AMI to be utilized on an instance type
+                        items:
+                          description: |-
+                            A node selector requirement is a selector that contains values, a key, and an operator
+                            that relates the key and values.
+                          properties:
+                            key:
+                              description: The label key that the selector applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                Represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                              type: string
+                            values:
+                              description: |-
+                                An array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. If the operator is Gt or Lt, the values
+                                array must have a single element, which will be interpreted as an integer.
+                                This array is replaced during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                            - key
+                            - operator
+                          type: object
+                        type: array
+                    required:
+                      - id
+                      - requirements
+                    type: object
+                  type: array
+                capacityReservations:
+                  description: |-
+                    CapacityReservations contains the current capacity reservation values that are available to this NodeClass under the
+                    CapacityReservation selectors.
+                  items:
+                    properties:
+                      availabilityZone:
+                        description: The availability zone the capacity reservation is available in.
+                        type: string
+                      endTime:
+                        description: |-
+                          The time at which the capacity reservation expires. Once expired, the reserved capacity is released and Karpenter
+                          will no longer be able to launch instances into that reservation.
+                        format: date-time
+                        type: string
+                      id:
+                        description: The id for the capacity reservation.
+                        pattern: ^cr-[0-9a-z]+$
+                        type: string
+                      instanceMatchCriteria:
+                        description: Indicates the type of instance launches the capacity reservation accepts.
+                        enum:
+                          - open
+                          - targeted
+                        type: string
+                      instanceType:
+                        description: The instance type for the capacity reservation.
+                        type: string
+                      ownerID:
+                        description: The ID of the AWS account that owns the capacity reservation.
+                        pattern: ^[0-9]{12}$
+                        type: string
+                    required:
+                      - availabilityZone
+                      - id
+                      - instanceMatchCriteria
+                      - instanceType
+                      - ownerID
+                    type: object
+                  type: array
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                instanceProfile:
+                  description: InstanceProfile contains the resolved instance profile for the role
+                  type: string
+                securityGroups:
+                  description: |-
+                    SecurityGroups contains the current security group values that are available to the
+                    cluster under the SecurityGroups selectors.
+                  items:
+                    description: SecurityGroup contains resolved SecurityGroup selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the security group
+                        type: string
+                      name:
+                        description: Name of the security group
+                        type: string
+                    required:
+                      - id
+                    type: object
+                  type: array
+                subnets:
+                  description: |-
+                    Subnets contains the current subnet values that are available to the
+                    cluster under the subnet selectors.
+                  items:
+                    description: Subnet contains resolved Subnet selector values utilized for node launch
+                    properties:
+                      id:
+                        description: ID of the subnet
+                        type: string
+                      zone:
+                        description: The associated availability zone
+                        type: string
+                      zoneID:
+                        description: The associated availability zone ID
+                        type: string
+                    required:
+                      - id
+                      - zone
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/content/projects/karpenter/v1.3.3/karpenter.sh_nodeclaims.yaml
+++ b/content/projects/karpenter/v1.3.3/karpenter.sh_nodeclaims.yaml
@@ -1,0 +1,395 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: nodeclaims.karpenter.sh
+spec:
+  group: karpenter.sh
+  names:
+    categories:
+      - karpenter
+    kind: NodeClaim
+    listKind: NodeClaimList
+    plural: nodeclaims
+    singular: nodeclaim
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.labels.node\.kubernetes\.io/instance-type
+          name: Type
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/capacity-type
+          name: Capacity
+          type: string
+        - jsonPath: .metadata.labels.topology\.kubernetes\.io/zone
+          name: Zone
+          type: string
+        - jsonPath: .status.nodeName
+          name: Node
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .status.imageID
+          name: ImageID
+          priority: 1
+          type: string
+        - jsonPath: .status.providerID
+          name: ID
+          priority: 1
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/nodepool
+          name: NodePool
+          priority: 1
+          type: string
+        - jsonPath: .spec.nodeClassRef.name
+          name: NodeClass
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: NodeClaim is the Schema for the NodeClaims API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: NodeClaimSpec describes the desired state of the NodeClaim
+              properties:
+                expireAfter:
+                  default: 720h
+                  description: |-
+                    ExpireAfter is the duration the controller will wait
+                    before terminating a node, measured from when the node is created. This
+                    is useful to implement features like eventually consistent node upgrade,
+                    memory leak protection, and disruption testing.
+                  pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                  type: string
+                nodeClassRef:
+                  description: NodeClassRef is a reference to an object that defines provider specific configuration
+                  properties:
+                    group:
+                      description: API version of the referent
+                      pattern: ^[^/]*$
+                      type: string
+                      x-kubernetes-validations:
+                        - message: group may not be empty
+                          rule: self != ''
+                    kind:
+                      description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                      type: string
+                      x-kubernetes-validations:
+                        - message: kind may not be empty
+                          rule: self != ''
+                    name:
+                      description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                      type: string
+                      x-kubernetes-validations:
+                        - message: name may not be empty
+                          rule: self != ''
+                  required:
+                    - group
+                    - kind
+                    - name
+                  type: object
+                requirements:
+                  description: Requirements are layered with GetLabels and applied to every node.
+                  items:
+                    description: |-
+                      A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                      and minValues that represent the requirement to have at least that many values.
+                    properties:
+                      key:
+                        description: The label key that the selector applies to.
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                        x-kubernetes-validations:
+                          - message: label domain "kubernetes.io" is restricted
+                            rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                          - message: label domain "k8s.io" is restricted
+                            rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                          - message: label domain "karpenter.sh" is restricted
+                            rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                          - message: label "kubernetes.io/hostname" is restricted
+                            rule: self != "kubernetes.io/hostname"
+                          - message: label domain "karpenter.k8s.aws" is restricted
+                            rule: self in ["karpenter.k8s.aws/capacity-reservation-id", "karpenter.k8s.aws/ec2nodeclass", "karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu", "karpenter.k8s.aws/instance-cpu-manufacturer", "karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz", "karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                      minValues:
+                        description: |-
+                          This field is ALPHA and can be dropped or replaced at any time
+                          MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                        maximum: 50
+                        minimum: 1
+                        type: integer
+                      operator:
+                        description: |-
+                          Represents a key's relationship to a set of values.
+                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                        type: string
+                        enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          - Gt
+                          - Lt
+                      values:
+                        description: |-
+                          An array of string values. If the operator is In or NotIn,
+                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                          the values array must be empty. If the operator is Gt or Lt, the values
+                          array must have a single element, which will be interpreted as an integer.
+                          This array is replaced during a strategic merge patch.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                        maxLength: 63
+                        pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                    required:
+                      - key
+                      - operator
+                    type: object
+                  maxItems: 100
+                  type: array
+                  x-kubernetes-validations:
+                    - message: requirements with operator 'In' must have a value defined
+                      rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                    - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                      rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                    - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                      rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                resources:
+                  description: Resources models the resource requirements for the NodeClaim to launch
+                  properties:
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: Requests describes the minimum required resources for the NodeClaim to launch
+                      type: object
+                  type: object
+                startupTaints:
+                  description: |-
+                    StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                    within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                    daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                    purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                taints:
+                  description: Taints will be applied to the NodeClaim's node.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: |-
+                          TimeAdded represents the time at which the taint was added.
+                          It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                terminationGracePeriod:
+                  description: |-
+                    TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
+
+                    Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
+
+                    This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
+                    When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
+
+                    Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
+                    If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
+                    that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
+
+                    The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
+                    If left undefined, the controller will wait indefinitely for pods to be drained.
+                  pattern: ^([0-9]+(s|m|h))+$
+                  type: string
+              required:
+                - nodeClassRef
+                - requirements
+              type: object
+              x-kubernetes-validations:
+                - message: spec is immutable
+                  rule: self == oldSelf
+            status:
+              description: NodeClaimStatus defines the observed state of NodeClaim
+              properties:
+                allocatable:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Allocatable is the estimated allocatable capacity of the node
+                  type: object
+                capacity:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Capacity is the estimated full capacity of the node
+                  type: object
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        pattern: ^([A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?|)$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - status
+                      - type
+                    type: object
+                  type: array
+                imageID:
+                  description: ImageID is an identifier for the image that runs on the node
+                  type: string
+                lastPodEventTime:
+                  description: |-
+                    LastPodEventTime is updated with the last time a pod was scheduled
+                    or removed from the node. A pod going terminal or terminating
+                    is also considered as removed.
+                  format: date-time
+                  type: string
+                nodeName:
+                  description: NodeName is the name of the corresponding node object
+                  type: string
+                providerID:
+                  description: ProviderID of the corresponding node object
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/content/projects/karpenter/v1.3.3/karpenter.sh_nodepools.yaml
+++ b/content/projects/karpenter/v1.3.3/karpenter.sh_nodepools.yaml
@@ -1,0 +1,519 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: nodepools.karpenter.sh
+spec:
+  group: karpenter.sh
+  names:
+    categories:
+      - karpenter
+    kind: NodePool
+    listKind: NodePoolList
+    plural: nodepools
+    singular: nodepool
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.template.spec.nodeClassRef.name
+          name: NodeClass
+          type: string
+        - jsonPath: .status.resources.nodes
+          name: Nodes
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.weight
+          name: Weight
+          priority: 1
+          type: integer
+        - jsonPath: .status.resources.cpu
+          name: CPU
+          priority: 1
+          type: string
+        - jsonPath: .status.resources.memory
+          name: Memory
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: NodePool is the Schema for the NodePools API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                NodePoolSpec is the top level nodepool specification. Nodepools
+                launch nodes in response to pods that are unschedulable. A single nodepool
+                is capable of managing a diverse set of nodes. Node properties are determined
+                from a combination of nodepool and pod scheduling constraints.
+              properties:
+                disruption:
+                  default:
+                    consolidateAfter: 0s
+                  description: Disruption contains the parameters that relate to Karpenter's disruption logic
+                  properties:
+                    budgets:
+                      default:
+                        - nodes: 10%
+                      description: |-
+                        Budgets is a list of Budgets.
+                        If there are multiple active budgets, Karpenter uses
+                        the most restrictive value. If left undefined,
+                        this will default to one budget with a value to 10%.
+                      items:
+                        description: |-
+                          Budget defines when Karpenter will restrict the
+                          number of Node Claims that can be terminating simultaneously.
+                        properties:
+                          duration:
+                            description: |-
+                              Duration determines how long a Budget is active since each Schedule hit.
+                              Only minutes and hours are accepted, as cron does not work in seconds.
+                              If omitted, the budget is always active.
+                              This is required if Schedule is set.
+                              This regex has an optional 0s at the end since the duration.String() always adds
+                              a 0s at the end.
+                            pattern: ^((([0-9]+(h|m))|([0-9]+h[0-9]+m))(0s)?)$
+                            type: string
+                          nodes:
+                            default: 10%
+                            description: |-
+                              Nodes dictates the maximum number of NodeClaims owned by this NodePool
+                              that can be terminating at once. This is calculated by counting nodes that
+                              have a deletion timestamp set, or are actively being deleted by Karpenter.
+                              This field is required when specifying a budget.
+                              This cannot be of type intstr.IntOrString since kubebuilder doesn't support pattern
+                              checking for int nodes for IntOrString nodes.
+                              Ref: https://github.com/kubernetes-sigs/controller-tools/blob/55efe4be40394a288216dab63156b0a64fb82929/pkg/crd/markers/validation.go#L379-L388
+                            pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
+                            type: string
+                          reasons:
+                            description: |-
+                              Reasons is a list of disruption methods that this budget applies to. If Reasons is not set, this budget applies to all methods.
+                              Otherwise, this will apply to each reason defined.
+                              allowed reasons are Underutilized, Empty, and Drifted.
+                            items:
+                              description: DisruptionReason defines valid reasons for disruption budgets.
+                              enum:
+                                - Underutilized
+                                - Empty
+                                - Drifted
+                              type: string
+                            type: array
+                          schedule:
+                            description: |-
+                              Schedule specifies when a budget begins being active, following
+                              the upstream cronjob syntax. If omitted, the budget is always active.
+                              Timezones are not supported.
+                              This field is required if Duration is set.
+                            pattern: ^(@(annually|yearly|monthly|weekly|daily|midnight|hourly))|((.+)\s(.+)\s(.+)\s(.+)\s(.+))$
+                            type: string
+                        required:
+                          - nodes
+                        type: object
+                      maxItems: 50
+                      type: array
+                      x-kubernetes-validations:
+                        - message: '''schedule'' must be set with ''duration'''
+                          rule: self.all(x, has(x.schedule) == has(x.duration))
+                    consolidateAfter:
+                      description: |-
+                        ConsolidateAfter is the duration the controller will wait
+                        before attempting to terminate nodes that are underutilized.
+                        Refer to ConsolidationPolicy for how underutilization is considered.
+                      pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                      type: string
+                    consolidationPolicy:
+                      default: WhenEmptyOrUnderutilized
+                      description: |-
+                        ConsolidationPolicy describes which nodes Karpenter can disrupt through its consolidation
+                        algorithm. This policy defaults to "WhenEmptyOrUnderutilized" if not specified
+                      enum:
+                        - WhenEmpty
+                        - WhenEmptyOrUnderutilized
+                      type: string
+                  required:
+                    - consolidateAfter
+                  type: object
+                limits:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Limits define a set of bounds for provisioning capacity.
+                  type: object
+                template:
+                  description: |-
+                    Template contains the template of possibilities for the provisioning logic to launch a NodeClaim with.
+                    NodeClaims launched from this NodePool will often be further constrained than the template specifies.
+                  properties:
+                    metadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Annotations is an unstructured key value map stored with a resource that may be
+                            set by external tools to store and retrieve arbitrary metadata. They are not
+                            queryable and should be preserved when modifying objects.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                            maxLength: 63
+                            pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                          description: |-
+                            Map of string keys and values that can be used to organize and categorize
+                            (scope and select) objects. May match selectors of replication controllers
+                            and services.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
+                          type: object
+                          maxProperties: 100
+                          x-kubernetes-validations:
+                            - message: label domain "kubernetes.io" is restricted
+                              rule: self.all(x, x in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region",  "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || x.find("^([^/]+)").endsWith("node.kubernetes.io") || x.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !x.find("^([^/]+)").endsWith("kubernetes.io"))
+                            - message: label domain "k8s.io" is restricted
+                              rule: self.all(x, x.find("^([^/]+)").endsWith("kops.k8s.io") || !x.find("^([^/]+)").endsWith("k8s.io"))
+                            - message: label domain "karpenter.sh" is restricted
+                              rule: self.all(x, x in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !x.find("^([^/]+)").endsWith("karpenter.sh"))
+                            - message: label "karpenter.sh/nodepool" is restricted
+                              rule: self.all(x, x != "karpenter.sh/nodepool")
+                            - message: label "kubernetes.io/hostname" is restricted
+                              rule: self.all(x, x != "kubernetes.io/hostname")
+                            - message: label domain "karpenter.k8s.aws" is restricted
+                              rule: self.all(x, x in ["karpenter.k8s.aws/capacity-reservation-id", "karpenter.k8s.aws/ec2nodeclass", "karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu", "karpenter.k8s.aws/instance-cpu-manufacturer", "karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz", "karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !x.find("^([^/]+)").endsWith("karpenter.k8s.aws"))
+                      type: object
+                    spec:
+                      description: |-
+                        NodeClaimTemplateSpec describes the desired state of the NodeClaim in the Nodepool
+                        NodeClaimTemplateSpec is used in the NodePool's NodeClaimTemplate, with the resource requests omitted since
+                        users are not able to set resource requests in the NodePool.
+                      properties:
+                        expireAfter:
+                          default: 720h
+                          description: |-
+                            ExpireAfter is the duration the controller will wait
+                            before terminating a node, measured from when the node is created. This
+                            is useful to implement features like eventually consistent node upgrade,
+                            memory leak protection, and disruption testing.
+                          pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                          type: string
+                        nodeClassRef:
+                          description: NodeClassRef is a reference to an object that defines provider specific configuration
+                          properties:
+                            group:
+                              description: API version of the referent
+                              pattern: ^[^/]*$
+                              type: string
+                              x-kubernetes-validations:
+                                - message: group may not be empty
+                                  rule: self != ''
+                            kind:
+                              description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                              type: string
+                              x-kubernetes-validations:
+                                - message: kind may not be empty
+                                  rule: self != ''
+                            name:
+                              description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                              x-kubernetes-validations:
+                                - message: name may not be empty
+                                  rule: self != ''
+                          required:
+                            - group
+                            - kind
+                            - name
+                          type: object
+                          x-kubernetes-validations:
+                            - message: nodeClassRef.group is immutable
+                              rule: self.group == oldSelf.group
+                            - message: nodeClassRef.kind is immutable
+                              rule: self.kind == oldSelf.kind
+                        requirements:
+                          description: Requirements are layered with GetLabels and applied to every node.
+                          items:
+                            description: |-
+                              A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                              and minValues that represent the requirement to have at least that many values.
+                            properties:
+                              key:
+                                description: The label key that the selector applies to.
+                                type: string
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                                x-kubernetes-validations:
+                                  - message: label domain "kubernetes.io" is restricted
+                                    rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                                  - message: label domain "k8s.io" is restricted
+                                    rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                                  - message: label domain "karpenter.sh" is restricted
+                                    rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                                  - message: label "karpenter.sh/nodepool" is restricted
+                                    rule: self != "karpenter.sh/nodepool"
+                                  - message: label "kubernetes.io/hostname" is restricted
+                                    rule: self != "kubernetes.io/hostname"
+                                  - message: label domain "karpenter.k8s.aws" is restricted
+                                    rule: self in ["karpenter.k8s.aws/capacity-reservation-id", "karpenter.k8s.aws/ec2nodeclass", "karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu", "karpenter.k8s.aws/instance-cpu-manufacturer", "karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz", "karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                              minValues:
+                                description: |-
+                                  This field is ALPHA and can be dropped or replaced at any time
+                                  MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                                maximum: 50
+                                minimum: 1
+                                type: integer
+                              operator:
+                                description: |-
+                                  Represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                type: string
+                                enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  - Gt
+                                  - Lt
+                              values:
+                                description: |-
+                                  An array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                  array must have a single element, which will be interpreted as an integer.
+                                  This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          maxItems: 100
+                          type: array
+                          x-kubernetes-validations:
+                            - message: requirements with operator 'In' must have a value defined
+                              rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                            - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                              rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                            - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                              rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                        startupTaints:
+                          description: |-
+                            StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                            within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                            daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                            purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        taints:
+                          description: Taints will be applied to the NodeClaim's node.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: |-
+                                  TimeAdded represents the time at which the taint was added.
+                                  It is only written for NoExecute taints.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        terminationGracePeriod:
+                          description: |-
+                            TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
+
+                            Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
+
+                            This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
+                            When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
+
+                            Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
+                            If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
+                            that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
+
+                            The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
+                            If left undefined, the controller will wait indefinitely for pods to be drained.
+                          pattern: ^([0-9]+(s|m|h))+$
+                          type: string
+                      required:
+                        - nodeClassRef
+                        - requirements
+                      type: object
+                  required:
+                    - spec
+                  type: object
+                weight:
+                  description: |-
+                    Weight is the priority given to the nodepool during scheduling. A higher
+                    numerical weight indicates that this nodepool will be ordered
+                    ahead of other nodepools with lower weights. A nodepool with no weight
+                    will be treated as if it is a nodepool with a weight of 0.
+                  format: int32
+                  maximum: 100
+                  minimum: 1
+                  type: integer
+              required:
+                - template
+              type: object
+            status:
+              description: NodePoolStatus defines the observed state of NodePool
+              properties:
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                resources:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Resources is the list of resources that have been provisioned.
+                  type: object
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/src/lib/kube/projects.ts
+++ b/src/lib/kube/projects.ts
@@ -91,4 +91,12 @@ export default [
     // For some reason, the cilium repo has duplicate tags like "v1.10.0" and "1.10.0"
     filterTag: (tag: string) => !tag.startsWith("v"),
   },
+  {
+    name: "Karpenter",
+    slug: "karpenter",
+    logo: "https://avatars.githubusercontent.com/u/2232217?s=200&v=4",
+    repo: "aws/karpenter-provider-aws",
+    pathToManifests: ["pkg/apis/crds"],
+    filterTag: (tag: string) => !tag.startsWith("v0."),
+  },
 ];


### PR DESCRIPTION
For issue #27.

This PR adds Karpenter CRDs from the `aws/karpenter-provider-aws` repository. It only adds CRDs for versions >=1.0. It also adds some examples and documentation links for the 3 resource types.

This PR does not solve for how to integrate multiple cloud provider implementations of the `*NodeClass` custom resource spread across different GitHub repositories ([ref](https://github.com/kubernetes-sigs/karpenter?tab=readme-ov-file#karpenter-implementations)). For now, it only includes the AWS `EC2NodeClass` reference.



