### PR TITLE
fix: Tag picker to allow the selection of the latest tags

### DIFF
--- a/src/components/TagPicker.tsx
+++ b/src/components/TagPicker.tsx
@@ -9,10 +9,18 @@ type Props = {
 
 export function TagPicker(props: Props) {
   const onChanged = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const path = props.gvkRef
-      ? `/${props.project}/${e.target.value}/${props.gvkRef}`
-      : `/${props.project}/${e.target.value}`;
+    const selectedValue = e.target.value;
+    const pathSegments = [props.project];
 
+    if (selectedValue !== props.latestTag) {
+      pathSegments.push(selectedValue);
+    }
+
+    if (props.gvkRef) {
+      pathSegments.push(props.gvkRef);
+    }
+
+    const path = `/${pathSegments.join("/")}`;
     window.location.href = path;
   };
 


### PR DESCRIPTION
Hello again 😁

Some context:

When we are on the spec explorer (i.e. https://kubespec.dev/cert-manager) if we select from the tag picker the version `v1.17.0` it works, but when selecting the latest tag `v1.17.1` it gives us a 404.

This PR fixes that bug.