### PR TITLE
feat: add the optional possibility to run download only for one specific project

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Contributions are welcome!
 - run `npm run download -- --project-slug="<slug>"` to download the defined CRD spec's for that project
 - create a pull request
 
-### Update all project or a specific project
+### Update all projects or one specific project
 
 - run either of the following
   - `npm run download` to update all projects

--- a/README.md
+++ b/README.md
@@ -18,6 +18,19 @@ Contributions are welcome!
 - run `npm install`
 - run `npm run dev`
 
+### Adding a new project (source of CRD specs)
+
+- add a new entry at the end of the list of projects in `src/lib/kube/projects.ts`
+- run `npm run download -- --project-slug="<slug>"` to download the defined CRD spec's for that project
+- create a pull request
+
+### Update all project or a specific project
+
+- run either of the following
+  - `npm run download` to update all projects
+  - `npm run download -- --project-slug="<slug>"` to update a specific project
+- create a pull request
+
 ## 📃 License
 
 MIT

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "astro-expressive-code": "^0.41.3",
         "cal-sans": "1.0.1",
         "diff": "8.0.2",
+        "minimist": "1.2.8",
         "pluralize": "8.0.0",
         "react": "19.1.0",
         "react-dom": "19.1.0",
@@ -34,6 +35,9 @@
         "tsx": "4.20.3",
         "typescript": "5.8.3",
         "yaml": "2.8.0"
+      },
+      "devDependencies": {
+        "@types/minimist": "1.2.5"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -2901,6 +2905,13 @@
       "dependencies": {
         "@types/unist": "*"
       }
+    },
+    "node_modules/@types/minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",
@@ -6224,6 +6235,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/minipass": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
@@ -6672,23 +6692,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/prettier": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
-      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prismjs": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "astro-expressive-code": "^0.41.3",
     "cal-sans": "1.0.1",
     "diff": "8.0.2",
+    "minimist": "1.2.8",
     "pluralize": "8.0.0",
     "react": "19.1.0",
     "react-dom": "19.1.0",
@@ -40,5 +41,8 @@
   },
   "engines": {
     "node": ">=22.0.0"
+  },
+  "devDependencies": {
+    "@types/minimist": "1.2.5"
   }
 }

--- a/scripts/download.ts
+++ b/scripts/download.ts
@@ -1,5 +1,6 @@
 import { writeFile, mkdir, access, constants } from "node:fs/promises";
 import { default as ALL_PROJECTS, type ProjectDef } from "@lib/kube/projects";
+import minimist from "minimist";
 
 const tagsToIgnore = [
   "rc",
@@ -107,12 +108,15 @@ async function downloadManifestFromRelease(
   console.log(`- Downloaded ${project.slug}@${tag} (1 file)`);
 }
 
-// Main
-if (!process.env.GH_TOKEN) {
-  throw new Error("GH_TOKEN environment variable is required");
+function findProjectBySlug(projectSlug: string): ProjectDef {
+  const project : ProjectDef | undefined = ALL_PROJECTS.find(p => p.slug === projectSlug);
+  if (!project) {
+    throw new Error(`Project with slug '${projectSlug}' not found`);
+  }
+  return project;
 }
 
-for (const project of ALL_PROJECTS) {
+async function processProject(project: ProjectDef) {
   console.log(`Processing ${project.slug}...`);
 
   const tags = await findTags(project);
@@ -129,5 +133,25 @@ for (const project of ALL_PROJECTS) {
     } else {
       await downloadManifestsFromGit(project, tag, outDir);
     }
+  }
+}
+
+// Main
+if (!process.env.GH_TOKEN) {
+  throw new Error("GH_TOKEN environment variable is required");
+}
+
+// args can be passed to the npm run command 'npm run <command> -- <args>'
+// optional: --project-slug="<slug>"
+// e.g.: 'npm run download -- --project-slug="<slug>"'
+const args = minimist(process.argv.slice(2));
+const argProjectSlug = args["project-slug"] || null;
+
+if (argProjectSlug !== null) {
+  const project = findProjectBySlug(argProjectSlug);
+  await processProject(project);
+} else {
+  for (const project of ALL_PROJECTS) {
+    await processProject(project);
   }
 }


### PR DESCRIPTION
Hey again :)
was wondering if something like this feature would be wanted.

The feature would remove the need to comment out projects when someone only wants to update one specific project.
It adds an optional arg to pass to the `npm run download`.
Example:
`npm run download -- --project-slug=enovy-gateway`

Command `npm run download` still downloads all.

Was not sure what the preferred implementation / dependency would be. I'll gladly change to whats preferred.