### PR TITLE
feat(kubernetes): include CustomResourceDefinition in built-in resources

### DIFF
--- a/content/metadata/kubernetes/apiextensions.k8s.io/v1/customresourcedefinition/1-customresourcedefinition.md
+++ b/content/metadata/kubernetes/apiextensions.k8s.io/v1/customresourcedefinition/1-customresourcedefinition.md
@@ -1,0 +1,47 @@
+---
+title: Extend the Kubernetes API with CustomResourceDefinitions
+description: Defines a custom resource (CronTab) with a schema specifying cronSpec, image, and replicas properties.
+---
+
+```yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: crontabs.stable.example.com
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: stable.example.com
+  # list of versions supported by this CustomResourceDefinition
+  versions:
+    - name: v1
+      # Each version can be enabled/disabled by Served flag.
+      served: true
+      # One and only one version must be marked as the storage version.
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                cronSpec:
+                  type: string
+                image:
+                  type: string
+                replicas:
+                  type: integer
+  # either Namespaced or Cluster
+  scope: Namespaced
+  names:
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: crontabs
+    # singular name to be used as an alias on the CLI and for display
+    singular: crontab
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: CronTab
+    # shortNames allow shorter string to match your resource on the CLI
+    shortNames:
+    - ct
+```

--- a/content/metadata/kubernetes/apiextensions.k8s.io/v1/customresourcedefinition/2-customresourcedefinition-versions.md
+++ b/content/metadata/kubernetes/apiextensions.k8s.io/v1/customresourcedefinition/2-customresourcedefinition-versions.md
@@ -1,0 +1,60 @@
+---
+title: Versions in CustomResourceDefinitions
+description: Demonstrates a CRD with multiple versions (v1beta1 and v1), each with its own schema, and a None conversion strategy.
+---
+
+```yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: crontabs.example.com
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: example.com
+  # list of versions supported by this CustomResourceDefinition
+  versions:
+  - name: v1beta1
+    # Each version can be enabled/disabled by Served flag.
+    served: true
+    # One and only one version must be marked as the storage version.
+    storage: true
+    # A schema is required
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          host:
+            type: string
+          port:
+            type: string
+  - name: v1
+    served: true
+    storage: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          host:
+            type: string
+          port:
+            type: string
+  # The conversion section is introduced in Kubernetes 1.13+ with a default value of
+  # None conversion (strategy sub-field set to None).
+  conversion:
+    # None conversion assumes the same schema for all versions and only sets the apiVersion
+    # field of custom resources to the proper value
+    strategy: None
+  # either Namespaced or Cluster
+  scope: Namespaced
+  names:
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: crontabs
+    # singular name to be used as an alias on the CLI and for display
+    singular: crontab
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: CronTab
+    # shortNames allow shorter string to match your resource on the CLI
+    shortNames:
+    - ct
+```

--- a/content/metadata/kubernetes/apiextensions.k8s.io/v1/customresourcedefinition/customresourcedefinition.json
+++ b/content/metadata/kubernetes/apiextensions.k8s.io/v1/customresourcedefinition/customresourcedefinition.json
@@ -1,0 +1,12 @@
+{
+  "links": [
+    {
+      "name": "Extend the Kubernetes API with CustomResourceDefinitions",
+      "href": "https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/"
+    },
+    {
+      "name": "Versions in CustomResourceDefinitions",
+      "href": "https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/"
+    }
+  ]
+}

--- a/src/lib/kube/kubernetes.ts
+++ b/src/lib/kube/kubernetes.ts
@@ -75,8 +75,7 @@ function getAllGVK(spec: SwaggerDocument): GVK[] {
   const gvk = Object.values(spec.paths)
     .flatMap((p) => Object.values(p))
     .filter((a) => a["x-kubernetes-action"] === "list")
-    .map((a) => a["x-kubernetes-group-version-kind"])
-    .filter((a) => a.kind !== "CustomResourceDefinition");
+    .map((a) => a["x-kubernetes-group-version-kind"]);
 
   const deduped = Object.values(
     gvk.reduce(
@@ -188,6 +187,7 @@ const kindToCategory: Record<string, string> = {
   ValidatingWebhookConfiguration: "Administration",
   ValidatingAdmissionPolicy: "Administration",
   ValidatingAdmissionPolicyBinding: "Administration",
+  CustomResourceDefinition: "Administration",
   RuntimeClass: "Administration",
   PriorityClass: "Administration",
   ResourceClass: "Administration",

--- a/src/lib/kube/kubernetes.ts
+++ b/src/lib/kube/kubernetes.ts
@@ -95,12 +95,15 @@ function getAllGVK(spec: SwaggerDocument): GVK[] {
 
 function getDefinitionByKey(
   swagger: SwaggerDocument,
-  key: string
+  key: string,
+  visited: Set<string> = new Set()
 ): ResourceDefinition {
   const root = swagger.definitions[key];
   if (!root) {
     throw new Error(`No definition found for ${key}`);
   }
+
+  visited.add(key);
 
   const definition: ResourceDefinition = {
     description: root.description ?? "",
@@ -130,15 +133,17 @@ function getDefinitionByKey(
         ? `${refType}[]`
         : refType;
 
-      if (refType !== "Time") {
+      if (refType !== "Time" && !visited.has(refKey)) {
         definition.properties[name].definition = getDefinitionByKey(
           swagger,
-          refKey
+          refKey,
+          visited
         );
       }
     }
   }
 
+  visited.delete(key);
   return definition;
 }
 


### PR DESCRIPTION
## Summary

This PR includes `CustomResourceDefinition` (from `apiextensions.k8s.io/v1`) in the list of built-in Kubernetes resources displayed on kubespec.dev.

Previously, it was explicitly filtered out in the `getAllGVK` function. The underlying schema data is already present in the swagger.json files — this just stops removing it from the output.

Changes:
- Removed the `.filter()` that excluded `CustomResourceDefinition` from `getAllGVK()`
- Added `CustomResourceDefinition` to the **Administration** category in `kindToCategory`